### PR TITLE
git action CI를 적용한다.

### DIFF
--- a/.github/workflows/be.ci.yml
+++ b/.github/workflows/be.ci.yml
@@ -1,0 +1,33 @@
+name: Motimate BE CI
+
+on:
+  push:
+    branches: [ "develop", "main" ]
+  pull_request:
+    branches: [ "develop", "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.x, 18.x]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+          cache-dependency-path: BE/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+        working-directory: ./BE
+      - name: Build
+        run: npm run build --if-present
+        working-directory: ./BE
+      - name: Run tests
+        run: npm test
+        working-directory: ./BE

--- a/BE/package.json
+++ b/BE/package.json
@@ -13,9 +13,9 @@
     "start:debug": "nest start --debug --watch",
     "start:prod": "NODE_ENV=production node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
-    "test": "jest",
-    "test:watch": "jest --watch",
-    "test:cov": "jest --coverage",
+    "test": "NODE_ENV=test jest",
+    "test:watch": "NODE_ENV=test jest --watch",
+    "test:cov": "NOE_ENV=test jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },


### PR DESCRIPTION
## PR 요약
- node version 16과 18에서 이중으로 CI한다.
- npm test로 테스트 코드를 자동으로 실행하도록 한다.
- `main`과 `develop` 브랜치에 PR, merge 되었을 때 실행하도록 한다.

#### 변경 사항
```yml
name: Motimate BE CI

on:
  push:
    branches: [ "develop", "main" ]
  pull_request:
    branches: [ "develop", "main" ]

jobs:
  build:
    runs-on: ubuntu-latest

    strategy:
      matrix:
        node-version: [16.x, 18.x]

    steps:
      - uses: actions/checkout@v3
      - name: Use Node.js ${{ matrix.node-version }}
        uses: actions/setup-node@v3
        with:
          node-version: ${{ matrix.node-version }}
          cache: 'npm'
          cache-dependency-path: BE/package-lock.json
      - name: Install dependencies
        run: npm ci
        working-directory: ./BE
      - name: Build
        run: npm run build --if-present
        working-directory: ./BE
      - name: Run tests
        run: npm test
        working-directory: ./BE

```

##### 스크린샷

![image](https://github.com/boostcampwm2023/iOS02-moti/assets/75921696/c5dcdc95-b656-4c13-bf0c-d335d7c1b0bc)


#### Linked Issue
close #17
