### PR TITLE
Exception Handler 수정

### DIFF
--- a/BE/src/common/exception/motimate.excpetion.ts
+++ b/BE/src/common/exception/motimate.excpetion.ts
@@ -1,12 +1,12 @@
+import { HttpException } from "@nestjs/common";
+
 export interface ErrorCode {
   statusCode: number;
   message: string;
 }
 
-export class MotimateException extends Error {
-  public readonly statusCode: number;
+export class MotimateException extends HttpException{
   constructor(errorCode: ErrorCode) {
-    super(errorCode.message);
-    this.statusCode = errorCode.statusCode;
+    super(errorCode.message, errorCode.statusCode);
   }
 }

--- a/BE/src/common/exception/motimate.excpetion.ts
+++ b/BE/src/common/exception/motimate.excpetion.ts
@@ -1,11 +1,11 @@
-import { HttpException } from "@nestjs/common";
+import { HttpException } from '@nestjs/common';
 
 export interface ErrorCode {
   statusCode: number;
   message: string;
 }
 
-export class MotimateException extends HttpException{
+export class MotimateException extends HttpException {
   constructor(errorCode: ErrorCode) {
     super(errorCode.message, errorCode.statusCode);
   }

--- a/BE/src/common/filter/exception.filter.ts
+++ b/BE/src/common/filter/exception.filter.ts
@@ -1,16 +1,15 @@
-import { ArgumentsHost, Catch, ExceptionFilter } from '@nestjs/common';
-import { MotimateException } from '../exception/motimate.excpetion';
+import { ArgumentsHost, Catch, ExceptionFilter, HttpException } from "@nestjs/common";
 import { Request, Response } from 'express';
 
-@Catch(MotimateException)
+@Catch(HttpException)
 export class MotimateExceptionFilter
-  implements ExceptionFilter<MotimateException>
+  implements ExceptionFilter<HttpException>
 {
-  catch(exception: MotimateException, host: ArgumentsHost): any {
+  catch(exception: HttpException, host: ArgumentsHost): any {
     const ctx = host.switchToHttp();
     const response = ctx.getResponse<Response>();
     const request = ctx.getRequest<Request>();
-    const status = exception.statusCode;
+    const status = exception.getStatus();
 
     response.status(status).json({
       statusCode: status,

--- a/BE/src/common/filter/exception.filter.ts
+++ b/BE/src/common/filter/exception.filter.ts
@@ -1,10 +1,13 @@
-import { ArgumentsHost, Catch, ExceptionFilter, HttpException } from "@nestjs/common";
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpException,
+} from '@nestjs/common';
 import { Request, Response } from 'express';
 
 @Catch(HttpException)
-export class MotimateExceptionFilter
-  implements ExceptionFilter<HttpException>
-{
+export class MotimateExceptionFilter implements ExceptionFilter<HttpException> {
   catch(exception: HttpException, host: ArgumentsHost): any {
     const ctx = host.switchToHttp();
     const response = ctx.getResponse<Response>();

--- a/BE/src/common/filter/unexpected-exception.filter.ts
+++ b/BE/src/common/filter/unexpected-exception.filter.ts
@@ -1,9 +1,9 @@
 import { ArgumentsHost, Catch, ExceptionFilter } from '@nestjs/common';
 import { Request, Response } from 'express';
 
-@Catch(Error)
-export class UnexpectedExceptionFilter implements ExceptionFilter<Error> {
-  catch(exception: Error, host: ArgumentsHost): any {
+@Catch()
+export class UnexpectedExceptionFilter implements ExceptionFilter {
+  catch(exception: unknown, host: ArgumentsHost): any {
     const ctx = host.switchToHttp();
     const response = ctx.getResponse<Response>();
     const request = ctx.getRequest<Request>();

--- a/BE/src/main.ts
+++ b/BE/src/main.ts
@@ -2,11 +2,14 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { swaggerConfig } from './config/swagger';
 import { MotimateExceptionFilter } from './common/filter/exception.filter';
-import { UnexpectedExceptionFilter } from "./common/filter/unexpected-exception.filter";
+import { UnexpectedExceptionFilter } from './common/filter/unexpected-exception.filter';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  app.useGlobalFilters(new UnexpectedExceptionFilter(), new MotimateExceptionFilter());
+  app.useGlobalFilters(
+    new UnexpectedExceptionFilter(),
+    new MotimateExceptionFilter(),
+  );
 
   swaggerConfig(app);
   await app.listen(3000);

--- a/BE/src/main.ts
+++ b/BE/src/main.ts
@@ -2,12 +2,11 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { swaggerConfig } from './config/swagger';
 import { MotimateExceptionFilter } from './common/filter/exception.filter';
-import { UnexpectedExceptionFilter } from './common/filter/unexpected-exception.filter';
+import { UnexpectedExceptionFilter } from "./common/filter/unexpected-exception.filter";
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  app.useGlobalFilters(new MotimateExceptionFilter());
-  app.useGlobalFilters(new UnexpectedExceptionFilter());
+  app.useGlobalFilters(new UnexpectedExceptionFilter(), new MotimateExceptionFilter());
 
   swaggerConfig(app);
   await app.listen(3000);


### PR DESCRIPTION
## PR 요약
* Exception Handler으로 동작하는 필터의 순서가 잘못된 문제를 해결
* `MotimateException`을 `HttpException`의 서브타입으로 변경
* `HttpException` 핸들러로 수정

#### 변경 사항

```ts
async function bootstrap() {
  const app = await NestFactory.create(AppModule);
  app.useGlobalFilters(new UnexpectedExceptionFilter(), new MotimateExceptionFilter());

  swaggerConfig(app);
  await app.listen(3000);
}
bootstrap();
```

##### 스크린샷
![image](https://github.com/boostcampwm2023/iOS02-moti/assets/75921696/4cc23166-c1f2-484e-af82-a6ed90eac996)

#### Linked Issue
close #27
