### PR TITLE
요청 검증기 응답 wrapper 적용

### DIFF
--- a/BE/src/common/exception/motimate.excpetion.ts
+++ b/BE/src/common/exception/motimate.excpetion.ts
@@ -2,7 +2,7 @@ import { HttpException } from '@nestjs/common';
 
 export interface ErrorCode {
   statusCode: number;
-  message: string;
+  message: string | object;
 }
 
 export class MotimateException extends HttpException {

--- a/BE/src/config/validation/index.ts
+++ b/BE/src/config/validation/index.ts
@@ -1,0 +1,16 @@
+import { ValidationError, ValidationPipeOptions } from '@nestjs/common';
+import { MotimateException } from '../../common/exception/motimate.excpetion';
+
+export const validationPipeOptions: ValidationPipeOptions = {
+  whitelist: true,
+  forbidNonWhitelisted: true,
+  transform: true,
+  exceptionFactory: (errors: ValidationError[]) => {
+    const validated = errors.reduce((prev, error: ValidationError) => {
+      prev[error.property] = Object.values(error.constraints || {});
+      return prev;
+    }, {});
+
+    return new MotimateException({ statusCode: 400, message: validated });
+  },
+};

--- a/BE/src/main.ts
+++ b/BE/src/main.ts
@@ -4,10 +4,11 @@ import { swaggerConfig } from './config/swagger';
 import { MotimateExceptionFilter } from './common/filter/exception.filter';
 import { UnexpectedExceptionFilter } from './common/filter/unexpected-exception.filter';
 import { ValidationPipe } from '@nestjs/common';
+import { validationPipeOptions } from './config/validation';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  app.useGlobalPipes(new ValidationPipe({ transform: true }));
+  app.useGlobalPipes(new ValidationPipe(validationPipeOptions));
   app.useGlobalFilters(
     new UnexpectedExceptionFilter(),
     new MotimateExceptionFilter(),


### PR DESCRIPTION
## PR 요약
- exceptionFactory을 적용해서 서비스에 맞는 API response 포맷에 맞춤



#### 변경 사항

* message를 커스텀
* 메시지 또한 어떤 프로퍼티의 메시지인지 알 수 있도록 명시

##### 스크린샷

![image](https://github.com/boostcampwm2023/iOS02-moti/assets/75921696/8411ba9a-7a4c-4fab-91ab-3b2047b110a6)

#### Linked Issue
close #34
