### PR TITLE
sqlite를 고려한 엔티티 코드 변경

### DIFF
--- a/BE/src/users/entities/role.entity.ts
+++ b/BE/src/users/entities/role.entity.ts
@@ -2,7 +2,7 @@ import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
 
 @Entity({ name: 'role' })
 export class RoleEntity {
-  @PrimaryGeneratedColumn({ type: 'int' })
+  @PrimaryGeneratedColumn('increment', { type: 'int' })
   id: number;
 
   @Column({ type: 'varchar', length: 20, nullable: false })

--- a/BE/src/users/entities/role.entity.ts
+++ b/BE/src/users/entities/role.entity.ts
@@ -2,7 +2,7 @@ import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
 
 @Entity({ name: 'role' })
 export class RoleEntity {
-  @PrimaryGeneratedColumn('increment', { type: 'int' })
+  @PrimaryGeneratedColumn({ type: 'int' })
   id: number;
 
   @Column({ type: 'varchar', length: 20, nullable: false })

--- a/BE/src/users/entities/users.entity.ts
+++ b/BE/src/users/entities/users.entity.ts
@@ -3,7 +3,7 @@ import { BaseTimeEntity } from '../../common/entities/base.entity';
 
 @Entity({ name: 'users' })
 export class UsersEntity extends BaseTimeEntity {
-  @PrimaryGeneratedColumn('increment', { type: 'bigint' })
+  @PrimaryGeneratedColumn()
   id: number;
 
   @Column({ type: 'varchar', length: 320, nullable: false })

--- a/BE/src/users/entities/users.entity.ts
+++ b/BE/src/users/entities/users.entity.ts
@@ -3,7 +3,7 @@ import { BaseTimeEntity } from '../../common/entities/base.entity';
 
 @Entity({ name: 'users' })
 export class UsersEntity extends BaseTimeEntity {
-  @PrimaryGeneratedColumn({ type: 'bigint' })
+  @PrimaryGeneratedColumn('increment', { type: 'bigint' })
   id: number;
 
   @Column({ type: 'varchar', length: 320, nullable: false })


### PR DESCRIPTION
#### 변경 사항

mysql 기준 식별자에 bigint를 사용해야하는 경우 typeorm의 `PrimaryGeneratedColumn` 으로 사용하도록 변경

```ts
@Entity({ name: 'users' })
export class UsersEntity extends BaseTimeEntity {
  @PrimaryGeneratedColumn()
  id: number;

  @Column({ type: 'varchar', length: 320, nullable: false })
  email: string;
  @Column({ type: 'varchar', length: 100, nullable: true })
  avatar: string;
  @Column({ type: 'varchar', length: 100, nullable: false })
  userCode: string;
}
```

##### 스크린샷
![image](https://github.com/boostcampwm2023/iOS02-moti/assets/75921696/b65f9d83-837c-43e2-884e-182465fd66b6)

sqlite를 사용하는 테스트에서도 잘 동작하네요!


#### Linked Issue
close #42
