### PR TITLE
NODE_ENV에 따른 typeorm 설정 변경

### DIFF
--- a/BE/src/config/typeorm/index.ts
+++ b/BE/src/config/typeorm/index.ts
@@ -13,7 +13,8 @@ export const typeOrmModuleOptions = {
       password: configService.get('DB_PASSWORD'),
       database: configService.get('DB_DATABASE'),
       entities: [configService.get('DB_ENTITIES')],
-      logging: configService.get('DB_LOGGING'),
+      logging: configService.get('NODE_ENV') === 'development',
+      dropSchema: configService.get('NODE_ENV') === 'test',
       synchronize: true,
       namingStrategy: new CamelSnakeNameStrategy(),
     };


### PR DESCRIPTION
## PR 요약
Github action에서 Mysql과 TypeORM 설정이 충돌되는 이슈 resolve

#### 변경 사항

- logging: configService.get('NODE_ENV') === 'development'
- dropSchema: configService.get('NODE_ENV') === 'test',


#### Linked Issue
close #76 