### PR TITLE
API 스펙 맞추기

### DIFF
--- a/BE/src/config/config/validation-decorator.ts
+++ b/BE/src/config/config/validation-decorator.ts
@@ -1,0 +1,18 @@
+import { registerDecorator, ValidationOptions } from 'class-validator';
+
+export const IsNotEmptyString = (validationOptions?: ValidationOptions) => {
+  return function (object: object, propertyKey: string) {
+    registerDecorator({
+      name: 'isNonEmptyString',
+      target: object.constructor,
+      propertyName: propertyKey,
+      constraints: [],
+      options: validationOptions,
+      validator: {
+        validate(value: any) {
+          return value !== undefined && typeof value === 'string';
+        },
+      },
+    });
+  };
+};

--- a/BE/src/config/validation/index.ts
+++ b/BE/src/config/validation/index.ts
@@ -1,15 +1,30 @@
 import { ValidationError, ValidationPipeOptions } from '@nestjs/common';
 import { MotimateException } from '../../common/exception/motimate.excpetion';
 
+export interface ValidationErrorMessage {
+  [key: string]: string[] | string;
+}
+
 export const validationPipeOptions: ValidationPipeOptions = {
   whitelist: true,
   forbidNonWhitelisted: true,
   transform: true,
   exceptionFactory: (errors: ValidationError[]) => {
-    const validated = errors.reduce((prev, error: ValidationError) => {
-      prev[error.property] = Object.values(error.constraints || {});
-      return prev;
-    }, {});
+    const defaultErrorMessage: ValidationErrorMessage = {
+      error: '잘못된 입력입니다.',
+    };
+
+    const validated: ValidationErrorMessage =
+      errors?.reduce((prev: ValidationErrorMessage, error: ValidationError) => {
+        prev[error.property] = Object.values(error.constraints || {});
+        return prev;
+      }, {}) || defaultErrorMessage;
+
+    for (const key in validated) {
+      if (validated[key].length <= 1) {
+        validated[key] = validated[key][0];
+      }
+    }
 
     return new MotimateException({ statusCode: 400, message: validated });
   },

--- a/BE/src/config/validation/validation-pipe-options.spec.ts
+++ b/BE/src/config/validation/validation-pipe-options.spec.ts
@@ -1,0 +1,100 @@
+import { ValidationError } from '@nestjs/common';
+import { validationPipeOptions } from './index';
+import { MotimateException } from '../../common/exception/motimate.excpetion';
+
+describe('ValidationPipeOption test', () => {
+  it('exceptionFactory는 errors가 null일 때도 예외를 발생시키지 않는다', () => {
+    // given
+    const emptyErrors: ValidationError[] = null;
+
+    // when
+    const exception = validationPipeOptions.exceptionFactory(emptyErrors);
+
+    // then
+    expect(exception).toBeDefined();
+    expect(exception).toBeInstanceOf(MotimateException);
+    expect(exception.status).toBe(400);
+    expect(exception.getResponse()).toStrictEqual({
+      error: '잘못된 입력입니다.',
+    });
+  });
+
+  it('exceptionFactory는 errors가 undefined일 때도 예외를 발생시키지 않는다', () => {
+    // given
+    const emptyErrors: ValidationError[] = undefined;
+
+    // when
+    const exception = validationPipeOptions.exceptionFactory(emptyErrors);
+
+    // then
+    expect(exception).toBeDefined();
+    expect(exception).toBeInstanceOf(MotimateException);
+    expect(exception.status).toBe(400);
+    expect(exception.getResponse()).toStrictEqual({
+      error: '잘못된 입력입니다.',
+    });
+  });
+
+  it('ValidationError의 적절한 constraints가 없어도 동작이 멈추지 않는다.', () => {
+    //given
+    const validationErrors: ValidationError[] = [
+      { property: 'test1' },
+      { property: 'test2' },
+    ];
+
+    // when
+    const exception = validationPipeOptions.exceptionFactory(validationErrors);
+
+    // then
+    expect(exception).toBeDefined();
+    expect(exception).toBeInstanceOf(MotimateException);
+    expect(exception.status).toBe(400);
+    expect(exception.getResponse()).toStrictEqual({
+      test1: undefined,
+      test2: undefined,
+    });
+  });
+
+  it('errors의 동일한 키의 property가 없을 땐 에러 메시지가 단일 메시지 형태로 전달된다.', () => {
+    //given
+    const validationErrors: ValidationError[] = [
+      { property: 'test1', constraints: { test: 'test-error1' } },
+      { property: 'test2', constraints: { test: 'test-error2' } },
+    ];
+
+    // when
+    const exception = validationPipeOptions.exceptionFactory(validationErrors);
+
+    // then
+    expect(exception).toBeDefined();
+    expect(exception).toBeInstanceOf(MotimateException);
+    expect(exception.status).toBe(400);
+    expect(exception.getResponse()).toStrictEqual({
+      test1: 'test-error1',
+      test2: 'test-error2',
+    });
+  });
+
+  it('errors의 동일 키의 property가 있을 땐 배열의 형태로 묶인다.', () => {
+    //given
+    const validationErrors: ValidationError[] = [
+      {
+        property: 'test1',
+        constraints: { error1: 'test1-error1', error2: 'test1-error2' },
+      },
+      { property: 'test2', constraints: { error1: 'test2-error1' } },
+    ];
+
+    // when
+    const exception = validationPipeOptions.exceptionFactory(validationErrors);
+
+    // then
+    expect(exception).toBeDefined();
+    expect(exception).toBeInstanceOf(MotimateException);
+    expect(exception.status).toBe(400);
+    expect(exception.getResponse()).toStrictEqual({
+      test1: ['test1-error1', 'test1-error2'],
+      test2: 'test2-error1',
+    });
+  });
+});

--- a/BE/src/operate/controller/operate.controller.ts
+++ b/BE/src/operate/controller/operate.controller.ts
@@ -5,7 +5,7 @@ import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { MotiPolicyCreate } from '../dto/moti-policy-create';
 import { ApiData } from '../../common/api/api-data';
 
-@Controller('operate')
+@Controller('/api/v1/operate')
 @ApiTags('운영 API')
 export class OperateController {
   constructor(private readonly operateService: OperateService) {}

--- a/BE/src/operate/dto/moti-policy-create.ts
+++ b/BE/src/operate/dto/moti-policy-create.ts
@@ -1,20 +1,17 @@
-import { IsNotEmpty, IsString } from 'class-validator';
+import { IsNotEmptyString } from '../../config/config/validation-decorator';
 import { MotiPolicy } from '../domain/moti-policy.domain';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class MotiPolicyCreate {
-  @IsNotEmpty()
-  @IsString()
+  @IsNotEmptyString({ message: '잘못된 최신 버전입니다.' })
   @ApiProperty({ description: '최신 버전' })
   latest: string;
 
-  @IsNotEmpty()
-  @IsString()
+  @IsNotEmptyString({ message: '잘못된 최소 버전입니다.' })
   @ApiProperty({ description: '최소 버전' })
   required: string;
 
-  @IsNotEmpty()
-  @IsString()
+  @IsNotEmptyString({ message: '잘못된 보안 규약입니다.' })
   @ApiProperty({ description: '보안 규약' })
   privacyPolicy: string;
 


### PR DESCRIPTION
## PR 요약
* api prefix - /api/v1
* 에러 메시지 형식 변경

#### 변경 사항

* api prefix
* validationPipe에서 에러 빌등하는 로직 수정
* validationPipe에서 에러 빌등하는 로직 테스트

##### 스크린샷

![image](https://github.com/boostcampwm2023/iOS02-moti/assets/75921696/9b3f3742-a821-4fde-a004-cabc858bc50f)

* /api/v1/operate/policy 이 형태의 api prefix를 적용했습니다.
* ios분들이 요구하신 대로 최대한 하나의 프로퍼티에 하나의 Message가 매칭되도록 수정했습니다.


#### Linked Issue
close #79 
