### PR TITLE
TransactionalRepository 타입 안정성 개선

### DIFF
--- a/BE/src/config/transaction-manager/transactional-repository.ts
+++ b/BE/src/config/transaction-manager/transactional-repository.ts
@@ -5,7 +5,7 @@ import { retrieveQueryRunner } from './index';
 export class TransactionalRepository<
   Entity extends ObjectLiteral,
 > extends Repository<Entity> {
-  get repository() {
+  get repository(): Repository<Entity> {
     return retrieveQueryRunner()?.manager.getRepository(this.target) || this;
   }
 }


### PR DESCRIPTION
## PR 요약
TransactionalRepository 타입 추론되도록 수정

#### 변경 사항

```ts
export class TransactionalRepository<
  Entity extends ObjectLiteral,
> extends Repository<Entity> {
  get repository(): Repository<Entity> {
    return retrieveQueryRunner()?.manager.getRepository(this.target) || this;
  }
}
```

* `TransactionalRepository`의 `repository`의 반환타입 명시

##### 스크린샷

![image](https://github.com/boostcampwm2023/iOS02-moti/assets/75921696/a589014e-7430-4187-bcd3-4f658ff2830e)


#### Linked Issue
close #109
