### PR TITLE
촬영 버튼을 재사용할 수 있도록 객체 분리한다.

### DIFF
--- a/iOS/moti/moti/Design/Sources/Design/CaptureButton.swift
+++ b/iOS/moti/moti/Design/Sources/Design/CaptureButton.swift
@@ -45,8 +45,6 @@ public final class CaptureButton: UIButton {
     
     // MARK: - Setup
     private func setupUI() {
-        translatesAutoresizingMaskIntoConstraints = false
-
         backgroundColor = .motiBackground
         layer.borderColor = UIColor.primaryBlue.cgColor
         layer.borderWidth = 6

--- a/iOS/moti/moti/Design/Sources/Design/CaptureButton.swift
+++ b/iOS/moti/moti/Design/Sources/Design/CaptureButton.swift
@@ -1,0 +1,100 @@
+//
+//  CaptureButton.swift
+//  
+//
+//  Created by 유정주 on 11/16/23.
+//
+
+import UIKit
+
+/// 동그란 촬영 버튼.
+/// 기본 크기를 원한다면 defaultSize를 사용하세요.
+public final class CaptureButton: UIButton {
+    public static let defaultSize: CGFloat = 75
+    
+    // MARK: - Views
+    private let circleView = UIView()
+    
+    // MARK: - Properties
+    private let animationDuration = 0.2
+    
+    // MARK: - Init
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setupUI()
+        addTarget()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    private func addTarget() {
+        addTarget(self, action: #selector(captureButtonTouchDown), for: .touchDown)
+        addTarget(self, action: #selector(captureButtonTouchUpInside), for: .touchUpInside)
+        addTarget(self, action: #selector(captureButtonTouchUpOutside), for: .touchUpOutside)
+    }
+    
+    public override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        let size = min(frame.width, frame.height)
+        applyCorenrRadius(size: size)
+    }
+    
+    // MARK: - Setup
+    private func setupUI() {
+        translatesAutoresizingMaskIntoConstraints = false
+
+        backgroundColor = .motiBackground
+        layer.borderColor = UIColor.primaryBlue.cgColor
+        layer.borderWidth = 6
+        
+        setupCircleView()
+    }
+    
+    private func setupCircleView() {
+        circleView.translatesAutoresizingMaskIntoConstraints = false
+        circleView.isUserInteractionEnabled = false
+        
+        circleView.backgroundColor = .primaryBlue
+        
+        addSubview(circleView)
+        // 중앙 정렬
+        NSLayoutConstraint.activate([
+            circleView.centerXAnchor.constraint(equalTo: centerXAnchor),
+            circleView.centerYAnchor.constraint(equalTo: centerYAnchor)
+        ])
+    }
+    
+    // 원으로 만드는 메서드
+    private func applyCorenrRadius(size: CGFloat) {
+        layer.cornerRadius = size / 2
+        circleView.layer.cornerRadius = (size * 0.78) / 2
+        NSLayoutConstraint.activate([
+            circleView.widthAnchor.constraint(equalToConstant: (size * 0.78)),
+            circleView.heightAnchor.constraint(equalToConstant: (size * 0.78))
+        ])
+    }
+
+    // MARK: - Actions
+    @objc private func captureButtonTouchDown() {
+        UIView.animate(withDuration: animationDuration) {
+            let scale = CGAffineTransform(scaleX: 0.9, y: 0.9)
+            self.circleView.transform = scale
+        }
+    }
+    
+    @objc private func captureButtonTouchUpInside() {
+        UIView.animate(withDuration: animationDuration) {
+            self.circleView.transform = .identity
+        }
+    }
+    
+    @objc private func captureButtonTouchUpOutside() {
+        UIView.animate(withDuration: animationDuration) {
+            self.circleView.transform = .identity
+        }
+    }
+}

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeView.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeView.swift
@@ -27,6 +27,8 @@ final class HomeView: UIView {
     // 카테고리 리스트 컬렉션 뷰
     private(set) lazy var categoryCollectionView: UICollectionView = {
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: makeCategoryCollectionView())
+        // 세로로 스크롤이 안 되도록 설정
+        collectionView.alwaysBounceVertical = false
         collectionView.backgroundColor = .motiBackground
         collectionView.register(with: CategoryCollectionViewCell.self)
         return collectionView

--- a/iOS/moti/moti/Presentation/Sources/Presentation/TabBar/TabBarViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/TabBar/TabBarViewController.swift
@@ -15,8 +15,7 @@ protocol TabBarViewControllerDelegate: AnyObject {
 final class TabBarViewController: UITabBarController {
     
     // MARK: - Views
-    private let captureButton = UIButton()
-    private let circleView = UIView()
+    private let captureButton = CaptureButton()
     
     // MARK: - Properties
     weak var tabBarDelegate: TabBarViewControllerDelegate?
@@ -34,30 +33,11 @@ final class TabBarViewController: UITabBarController {
     
     // MARK: - Actions
     private func addTarget() {
-        captureButton.addTarget(self, action: #selector(captureButtonTouchDown), for: .touchDown)
         captureButton.addTarget(self, action: #selector(captureButtonTouchUpInside), for: .touchUpInside)
-        captureButton.addTarget(self, action: #selector(captureButtonTouchUpOutside), for: .touchUpOutside)
-    }
-    
-    @objc private func captureButtonTouchDown() {
-        UIView.animate(withDuration: 0.2) {
-            let scale = CGAffineTransform(scaleX: 0.9, y: 0.9)
-            self.circleView.transform = scale
-        }
     }
     
     @objc private func captureButtonTouchUpInside() {
         tabBarDelegate?.captureButtonDidClicked()
-        
-        UIView.animate(withDuration: 0.2) {
-            self.circleView.transform = .identity
-        }
-    }
-    
-    @objc private func captureButtonTouchUpOutside() {
-        UIView.animate(withDuration: 0.2) {
-            self.circleView.transform = .identity
-        }
     }
 }
 
@@ -71,7 +51,6 @@ private extension TabBarViewController {
         
         setupBorderView()
         setupCaptureTabItem()
-        setupCircleView()
     }
     
     func setupBorderView() {
@@ -92,30 +71,10 @@ private extension TabBarViewController {
     }
     
     func setupCaptureTabItem() {
-        let buttonSize: CGFloat = 75
-
-        captureButton.backgroundColor = .motiBackground
-        captureButton.layer.borderColor = UIColor.primaryBlue.cgColor
-        captureButton.layer.borderWidth = 6
-        captureButton.layer.cornerRadius = buttonSize / 2
-        
         view.addSubview(captureButton)
         captureButton.atl
-            .size(width: buttonSize, height: buttonSize)
+            .size(width: CaptureButton.defaultSize, height: CaptureButton.defaultSize)
             .centerX(equalTo: view.centerXAnchor)
             .bottom(equalTo: view.bottomAnchor, constant: -36)
-    }
-    
-    func setupCircleView() {
-        circleView.isUserInteractionEnabled = false
-        
-        let circleSize: CGFloat = 59
-        circleView.backgroundColor = .primaryBlue
-        circleView.layer.cornerRadius = circleSize / 2
-        
-        view.addSubview(circleView)
-        circleView.atl
-            .size(width: circleSize, height: circleSize)
-            .center(of: captureButton)
     }
 }


### PR DESCRIPTION
## PR 요약
- 캡처 버튼 객체 분리
    - 탭바, 촬영 화면에서 같은 객체 사용

#### 변경 사항
- 촬영 버튼이 필요하다면 Design의 CaptureButton을 사용하세요.
- 기본 크기는 CaptureButton.defaultSize를 적용하세요.

#### Linked Issue
close #124
