### PR TITLE
달성 기록 리스트 API를 작성한다.

### DIFF
--- a/BE/src/achievement/achievement.module.ts
+++ b/BE/src/achievement/achievement.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { AchievementController } from './controller/achievement.controller';
+import { AchievementService } from './application/achievement.service';
+import { CustomTypeOrmModule } from '../config/typeorm/custom-typeorm.module';
+import { AchievementRepository } from './entities/achievement.repository';
+
+@Module({
+  imports: [CustomTypeOrmModule.forCustomRepository([AchievementRepository])],
+  controllers: [AchievementController],
+  providers: [AchievementService],
+})
+export class AchievementModule {}

--- a/BE/src/achievement/application/achievement.service.spec.ts
+++ b/BE/src/achievement/application/achievement.service.spec.ts
@@ -59,7 +59,7 @@ describe('AchievementService Test', () => {
     const nextRequest = new PaginateAchievementRequest(
       category.id,
       4,
-      firstResponse.next.where__id__less_than,
+      firstResponse.next.whereIdLessThan,
     );
     const nextResponse = await achievementService.getAchievements(
       user.id,
@@ -69,7 +69,7 @@ describe('AchievementService Test', () => {
     const lastRequest = new PaginateAchievementRequest(
       category.id,
       4,
-      nextResponse.next.where__id__less_than,
+      nextResponse.next.whereIdLessThan,
     );
     const lastResponse = await achievementService.getAchievements(
       user.id,
@@ -78,15 +78,14 @@ describe('AchievementService Test', () => {
 
     expect(firstResponse.count).toEqual(4);
     expect(firstResponse.data.length).toEqual(4);
-    expect(firstResponse.next.where__id__less_than).toEqual(7);
+    expect(firstResponse.next.whereIdLessThan).toEqual(7);
 
     expect(nextResponse.count).toEqual(4);
     expect(nextResponse.data.length).toEqual(4);
-    expect(nextResponse.next.where__id__less_than).toEqual(3);
+    expect(nextResponse.next.whereIdLessThan).toEqual(3);
 
     expect(lastResponse.count).toEqual(2);
     expect(lastResponse.data.length).toEqual(2);
     expect(lastResponse.next).toEqual(null);
-    console.log(lastResponse);
   });
 });

--- a/BE/src/achievement/application/achievement.service.spec.ts
+++ b/BE/src/achievement/application/achievement.service.spec.ts
@@ -1,0 +1,92 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AchievementService } from './achievement.service';
+import { CustomTypeOrmModule } from '../../config/typeorm/custom-typeorm.module';
+import { AchievementRepository } from '../entities/achievement.repository';
+import { ConfigModule } from '@nestjs/config';
+import { configServiceModuleOptions } from '../../config/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { typeOrmModuleOptions } from '../../config/typeorm';
+import { UsersTestModule } from '../../../test/user/users-test.module';
+import { UsersFixture } from '../../../test/user/users-fixture';
+import { CategoryFixture } from '../../../test/category/category-fixture';
+import { AchievementFixture } from '../../../test/achievement/achievement-fixture';
+import { CategoryTestModule } from '../../../test/category/category-test.module';
+import { AchievementTestModule } from '../../../test/achievement/achievement-test.module';
+import { PaginateAchievementRequest } from '../dto/paginate-achievement-request';
+
+describe('AchievementService Test', () => {
+  let achievementService: AchievementService;
+  let usersFixture: UsersFixture;
+  let categoryFixture: CategoryFixture;
+  let achievementFixture: AchievementFixture;
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot(configServiceModuleOptions),
+        TypeOrmModule.forRootAsync(typeOrmModuleOptions),
+        CustomTypeOrmModule.forCustomRepository([AchievementRepository]),
+        UsersTestModule,
+        CategoryTestModule,
+        AchievementTestModule,
+      ],
+      providers: [AchievementService],
+    }).compile();
+
+    achievementService = module.get<AchievementService>(AchievementService);
+    usersFixture = module.get<UsersFixture>(UsersFixture);
+    categoryFixture = module.get<CategoryFixture>(CategoryFixture);
+    achievementFixture = module.get<AchievementFixture>(AchievementFixture);
+  });
+
+  test('개인 달성 기록 리스트에 대한 페이지네이션 조회를 할 수 있다.', async () => {
+    // given
+    const user = await usersFixture.getUser('ABC');
+    const category = await categoryFixture.getCategory(user, 'ABC');
+    const achievements = [];
+    for (let i = 0; i < 10; i++) {
+      achievements.push(
+        await achievementFixture.getAchievement(user, category),
+      );
+    }
+
+    // when
+    const firstRequest = new PaginateAchievementRequest(category.id, 4);
+    const firstResponse = await achievementService.getAchievements(
+      user.id,
+      firstRequest,
+    );
+
+    const nextRequest = new PaginateAchievementRequest(
+      category.id,
+      4,
+      firstResponse.next.where__id__less_than,
+    );
+    const nextResponse = await achievementService.getAchievements(
+      user.id,
+      nextRequest,
+    );
+
+    const lastRequest = new PaginateAchievementRequest(
+      category.id,
+      4,
+      nextResponse.next.where__id__less_than,
+    );
+    const lastResponse = await achievementService.getAchievements(
+      user.id,
+      lastRequest,
+    );
+
+    expect(firstResponse.count).toEqual(4);
+    expect(firstResponse.data.length).toEqual(4);
+    expect(firstResponse.next.where__id__less_than).toEqual(7);
+
+    expect(nextResponse.count).toEqual(4);
+    expect(nextResponse.data.length).toEqual(4);
+    expect(nextResponse.next.where__id__less_than).toEqual(3);
+
+    expect(lastResponse.count).toEqual(2);
+    expect(lastResponse.data.length).toEqual(2);
+    expect(lastResponse.next).toEqual(null);
+    console.log(lastResponse);
+  });
+});

--- a/BE/src/achievement/application/achievement.service.ts
+++ b/BE/src/achievement/application/achievement.service.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@nestjs/common';
+import { AchievementRepository } from '../entities/achievement.repository';
+import { AchievementResponse } from '../dto/achievement-response';
+import { PaginateAchievementRequest } from '../dto/paginate-achievement-request';
+import { PaginateAchievementResponse } from '../dto/paginate-achievement-response';
+
+@Injectable()
+export class AchievementService {
+  constructor(private readonly achievementRepository: AchievementRepository) {}
+  async getAchievements(
+    userId: number,
+    paginateAchievementRequest: PaginateAchievementRequest,
+  ) {
+    const achievements = await this.achievementRepository.findAll(
+      userId,
+      paginateAchievementRequest,
+    );
+    return new PaginateAchievementResponse(
+      paginateAchievementRequest,
+      achievements.map((achievement) => AchievementResponse.from(achievement)),
+    );
+  }
+}

--- a/BE/src/achievement/controller/achievement.controller.ts
+++ b/BE/src/achievement/controller/achievement.controller.ts
@@ -5,13 +5,24 @@ import { AuthenticatedUser } from '../../auth/decorator/athenticated-user.decora
 import { User } from '../../users/domain/user.domain';
 import { ApiData } from '../../common/api/api-data';
 import { PaginateAchievementRequest } from '../dto/paginate-achievement-request';
+import { ApiCreatedResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { PaginateAchievementResponse } from '../dto/paginate-achievement-response';
 
 @Controller('/api/v1/achievements')
+@ApiTags('achievement API')
 export class AchievementController {
   constructor(private readonly achievementService: AchievementService) {}
 
   @Get()
   @UseGuards(AccessTokenGuard)
+  @ApiOperation({
+    summary: '달성기록 리스트 API',
+    description: '달성기록 리스트를 커서 페이지네이션 기반으로 조회한다.',
+  })
+  @ApiCreatedResponse({
+    description: '달성기록 리스트',
+    type: PaginateAchievementResponse,
+  })
   async getAchievements(
     @AuthenticatedUser() user: User,
     @Query() paginateAchievementRequest: PaginateAchievementRequest,

--- a/BE/src/achievement/controller/achievement.controller.ts
+++ b/BE/src/achievement/controller/achievement.controller.ts
@@ -1,0 +1,25 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { AchievementService } from '../application/achievement.service';
+import { AccessTokenGuard } from '../../auth/guard/access-token.guard';
+import { AuthenticatedUser } from '../../auth/decorator/athenticated-user.decorator';
+import { User } from '../../users/domain/user.domain';
+import { ApiData } from '../../common/api/api-data';
+import { PaginateAchievementRequest } from '../dto/paginate-achievement-request';
+
+@Controller('/api/v1/achievements')
+export class AchievementController {
+  constructor(private readonly achievementService: AchievementService) {}
+
+  @Get()
+  @UseGuards(AccessTokenGuard)
+  async getAchievements(
+    @AuthenticatedUser() user: User,
+    @Query() paginateAchievementRequest: PaginateAchievementRequest,
+  ) {
+    const response = await this.achievementService.getAchievements(
+      user.id,
+      paginateAchievementRequest,
+    );
+    return ApiData.success(response);
+  }
+}

--- a/BE/src/achievement/controller/achievement.controller.ts
+++ b/BE/src/achievement/controller/achievement.controller.ts
@@ -9,7 +9,7 @@ import { ApiCreatedResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { PaginateAchievementResponse } from '../dto/paginate-achievement-response';
 
 @Controller('/api/v1/achievements')
-@ApiTags('achievement API')
+@ApiTags('달성기록 API')
 export class AchievementController {
   constructor(private readonly achievementService: AchievementService) {}
 

--- a/BE/src/achievement/domain/achievement.domain.ts
+++ b/BE/src/achievement/domain/achievement.domain.ts
@@ -1,0 +1,42 @@
+import { User } from '../../users/domain/user.domain';
+import { Category } from '../../category/domain/category.domain';
+
+export class Achievement {
+  id: number;
+
+  user: User;
+
+  category: Category;
+
+  title: string;
+
+  content: string;
+
+  imageUrl: string;
+
+  thumbnailUrl: string;
+
+  constructor(
+    user: User,
+    category: Category,
+    title: string,
+    content: string,
+    imageUrl: string,
+    thumbnailUrl: string,
+  ) {
+    this.user = user;
+    this.category = category;
+    this.title = title;
+    this.content = content;
+    this.imageUrl = imageUrl;
+    this.thumbnailUrl = thumbnailUrl;
+  }
+
+  assignUser(user: User) {
+    this.user = user;
+  }
+
+  assignCategory(category: Category) {
+    this.category = category;
+  }
+}

--- a/BE/src/achievement/dto/achievement-detail-response.ts
+++ b/BE/src/achievement/dto/achievement-detail-response.ts
@@ -1,0 +1,9 @@
+export class AchievementDetailResponse {
+  id: number;
+  imageUrl: string;
+  title: string;
+  content: string;
+  categoryName: string;
+  categoryRoundCnt: string;
+  createdAt: string;
+}

--- a/BE/src/achievement/dto/achievement-response.ts
+++ b/BE/src/achievement/dto/achievement-response.ts
@@ -1,0 +1,21 @@
+import { Achievement } from '../domain/achievement.domain';
+
+export class AchievementResponse {
+  id: number;
+  thumbnailUrl: string;
+  title: string;
+
+  constructor(id: number, thumbnailUrl: string, title: string) {
+    this.id = id;
+    this.thumbnailUrl = thumbnailUrl;
+    this.title = title;
+  }
+
+  static from(achievement: Achievement) {
+    return new AchievementResponse(
+      achievement.id,
+      achievement.thumbnailUrl,
+      achievement.title,
+    );
+  }
+}

--- a/BE/src/achievement/dto/achievement-response.ts
+++ b/BE/src/achievement/dto/achievement-response.ts
@@ -1,8 +1,12 @@
 import { Achievement } from '../domain/achievement.domain';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class AchievementResponse {
+  @ApiProperty({ description: 'id' })
   id: number;
+  @ApiProperty({ description: 'string' })
   thumbnailUrl: string;
+  @ApiProperty({ description: 'string' })
   title: string;
 
   constructor(id: number, thumbnailUrl: string, title: string) {

--- a/BE/src/achievement/dto/paginate-achievement-request.ts
+++ b/BE/src/achievement/dto/paginate-achievement-request.ts
@@ -1,0 +1,25 @@
+import { IsNumber, IsOptional } from 'class-validator';
+
+export class PaginateAchievementRequest {
+  @IsNumber()
+  @IsOptional()
+  where__id__less_than?: number;
+
+  @IsNumber()
+  @IsOptional()
+  take: number = 12;
+
+  @IsNumber()
+  @IsOptional()
+  categoryId: number;
+
+  constructor(
+    categoryId?: number,
+    take?: number,
+    where__id__less_than?: number,
+  ) {
+    this.categoryId = categoryId;
+    this.take = take;
+    this.where__id__less_than = where__id__less_than;
+  }
+}

--- a/BE/src/achievement/dto/paginate-achievement-request.ts
+++ b/BE/src/achievement/dto/paginate-achievement-request.ts
@@ -5,7 +5,7 @@ export class PaginateAchievementRequest {
   @IsNumber()
   @IsOptional()
   @ApiProperty({ description: 'next cursor id' })
-  where__id__less_than?: number;
+  whereIdLessThan?: number;
 
   @IsNumber()
   @IsOptional()
@@ -17,13 +17,9 @@ export class PaginateAchievementRequest {
   @ApiProperty({ description: 'categoryId' })
   categoryId: number;
 
-  constructor(
-    categoryId?: number,
-    take?: number,
-    where__id__less_than?: number,
-  ) {
+  constructor(categoryId?: number, take?: number, whereIdLessThan?: number) {
     this.categoryId = categoryId;
     this.take = take;
-    this.where__id__less_than = where__id__less_than;
+    this.whereIdLessThan = whereIdLessThan;
   }
 }

--- a/BE/src/achievement/dto/paginate-achievement-request.ts
+++ b/BE/src/achievement/dto/paginate-achievement-request.ts
@@ -1,16 +1,20 @@
 import { IsNumber, IsOptional } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class PaginateAchievementRequest {
   @IsNumber()
   @IsOptional()
+  @ApiProperty({ description: 'next cursor id' })
   where__id__less_than?: number;
 
   @IsNumber()
   @IsOptional()
+  @ApiProperty({ description: 'take' })
   take: number = 12;
 
   @IsNumber()
   @IsOptional()
+  @ApiProperty({ description: 'categoryId' })
   categoryId: number;
 
   constructor(

--- a/BE/src/achievement/dto/paginate-achievement-response.spec.ts
+++ b/BE/src/achievement/dto/paginate-achievement-response.spec.ts
@@ -18,9 +18,7 @@ describe('PaginateAchievementResponse test', () => {
       paginateAchievementRequest,
       achievementResponses.slice(0, paginateAchievementRequest.take),
     );
-    expect(response.next).toEqual(
-      '/api/v1/achievements?&take=12&where__id__less_than=88',
-    );
+    expect(response.next).toEqual({ take: 12, where__id__less_than: 88 });
   });
   test('next url을 생성한다. - categoryId 필터링 추가', () => {
     const paginateAchievementRequest = new PaginateAchievementRequest();
@@ -30,8 +28,10 @@ describe('PaginateAchievementResponse test', () => {
       paginateAchievementRequest,
       achievementResponses.slice(0, paginateAchievementRequest.take),
     );
-    expect(response.next).toEqual(
-      '/api/v1/achievements?&take=12&categoryId=1&where__id__less_than=88',
-    );
+    expect(response.next).toEqual({
+      categoryId: 1,
+      take: 12,
+      where__id__less_than: 88,
+    });
   });
 });

--- a/BE/src/achievement/dto/paginate-achievement-response.spec.ts
+++ b/BE/src/achievement/dto/paginate-achievement-response.spec.ts
@@ -11,7 +11,7 @@ describe('PaginateAchievementResponse test', () => {
     );
   }
 
-  test('next url을 생성한다.', () => {
+  test('다음 페이지 네이션 요청을 위한 정보를 가지고 있는 next을 생성한다.', () => {
     const paginateAchievementRequest = new PaginateAchievementRequest();
     paginateAchievementRequest.take = 12;
     const response = new PaginateAchievementResponse(
@@ -20,7 +20,7 @@ describe('PaginateAchievementResponse test', () => {
     );
     expect(response.next).toEqual({ take: 12, where__id__less_than: 88 });
   });
-  test('next url을 생성한다. - categoryId 필터링 추가', () => {
+  test('다음 페이지 네이션 요청을 위한 정보를 가지고 있는 next을 생성한다. - categoryId 필터링 추가', () => {
     const paginateAchievementRequest = new PaginateAchievementRequest();
     paginateAchievementRequest.take = 12;
     paginateAchievementRequest.categoryId = 1;

--- a/BE/src/achievement/dto/paginate-achievement-response.spec.ts
+++ b/BE/src/achievement/dto/paginate-achievement-response.spec.ts
@@ -18,7 +18,7 @@ describe('PaginateAchievementResponse test', () => {
       paginateAchievementRequest,
       achievementResponses.slice(0, paginateAchievementRequest.take),
     );
-    expect(response.next).toEqual({ take: 12, where__id__less_than: 88 });
+    expect(response.next).toEqual({ take: 12, whereIdLessThan: 88 });
   });
   test('다음 페이지 네이션 요청을 위한 정보를 가지고 있는 next을 생성한다. - categoryId 필터링 추가', () => {
     const paginateAchievementRequest = new PaginateAchievementRequest();
@@ -31,7 +31,7 @@ describe('PaginateAchievementResponse test', () => {
     expect(response.next).toEqual({
       categoryId: 1,
       take: 12,
-      where__id__less_than: 88,
+      whereIdLessThan: 88,
     });
   });
 });

--- a/BE/src/achievement/dto/paginate-achievement-response.spec.ts
+++ b/BE/src/achievement/dto/paginate-achievement-response.spec.ts
@@ -1,0 +1,37 @@
+import { PaginateAchievementResponse } from './paginate-achievement-response';
+import { AchievementResponse } from './achievement-response';
+import { PaginateAchievementRequest } from './paginate-achievement-request';
+
+describe('PaginateAchievementResponse test', () => {
+  const achievementResponses: AchievementResponse[] = [];
+
+  for (let i = 99; i >= 0; i--) {
+    achievementResponses.push(
+      new AchievementResponse(i, `thumbnail${i}`, `title${i}`),
+    );
+  }
+
+  test('next url을 생성한다.', () => {
+    const paginateAchievementRequest = new PaginateAchievementRequest();
+    paginateAchievementRequest.take = 12;
+    const response = new PaginateAchievementResponse(
+      paginateAchievementRequest,
+      achievementResponses.slice(0, paginateAchievementRequest.take),
+    );
+    expect(response.next).toEqual(
+      '/api/v1/achievements?&take=12&where__id__less_than=88',
+    );
+  });
+  test('next url을 생성한다. - categoryId 필터링 추가', () => {
+    const paginateAchievementRequest = new PaginateAchievementRequest();
+    paginateAchievementRequest.take = 12;
+    paginateAchievementRequest.categoryId = 1;
+    const response = new PaginateAchievementResponse(
+      paginateAchievementRequest,
+      achievementResponses.slice(0, paginateAchievementRequest.take),
+    );
+    expect(response.next).toEqual(
+      '/api/v1/achievements?&take=12&categoryId=1&where__id__less_than=88',
+    );
+  });
+});

--- a/BE/src/achievement/dto/paginate-achievement-response.ts
+++ b/BE/src/achievement/dto/paginate-achievement-response.ts
@@ -1,10 +1,14 @@
 import { AchievementResponse } from './achievement-response';
 import { PaginateAchievementRequest } from './paginate-achievement-request';
 import { Next } from '../index';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class PaginateAchievementResponse {
+  @ApiProperty({ type: [AchievementResponse], description: 'data' })
   data: AchievementResponse[];
+  @ApiProperty({ description: 'count' })
   count: number;
+  @ApiProperty({ description: 'next' })
   next: Next | null;
 
   constructor(

--- a/BE/src/achievement/dto/paginate-achievement-response.ts
+++ b/BE/src/achievement/dto/paginate-achievement-response.ts
@@ -1,14 +1,11 @@
 import { AchievementResponse } from './achievement-response';
 import { PaginateAchievementRequest } from './paginate-achievement-request';
+import { Next } from '../index';
 
 export class PaginateAchievementResponse {
-  private basePath = '/api/v1/achievements?';
   data: AchievementResponse[];
-  cursor: {
-    after: number;
-  };
   count: number;
-  next: string;
+  next: Next | null;
 
   constructor(
     paginateAchievementRequest: PaginateAchievementRequest,
@@ -22,32 +19,28 @@ export class PaginateAchievementResponse {
         ? achievements[achievements.length - 1]
         : null;
 
-    this.cursor = {
-      after: last?.id ?? null,
-    };
-
     this.count = achievements.length;
-    this.next = this.makeNextUrl(paginateAchievementRequest, last);
+    this.next = this.makeNext(paginateAchievementRequest, last);
   }
 
-  private makeNextUrl(
+  private makeNext(
     paginateAchievementRequest: PaginateAchievementRequest,
     last: AchievementResponse,
   ) {
-    const nextUrl = last && [this.basePath];
+    const next: Next | null = last && {};
 
-    if (nextUrl) {
+    if (next) {
       for (const key of Object.keys(paginateAchievementRequest)) {
         if (!paginateAchievementRequest[key]) {
           continue;
         }
         if (key !== 'where__id__less_than') {
-          nextUrl.push(`${key}=${paginateAchievementRequest[key]}`);
+          next[key] = paginateAchievementRequest[key];
         }
       }
-      nextUrl.push(`where__id__less_than=${last.id.toString()}`);
+      next.where__id__less_than = parseInt(last.id.toString());
     }
 
-    return nextUrl?.join('&').toString() ?? null;
+    return next ?? null;
   }
 }

--- a/BE/src/achievement/dto/paginate-achievement-response.ts
+++ b/BE/src/achievement/dto/paginate-achievement-response.ts
@@ -1,0 +1,53 @@
+import { AchievementResponse } from './achievement-response';
+import { PaginateAchievementRequest } from './paginate-achievement-request';
+
+export class PaginateAchievementResponse {
+  private basePath = '/api/v1/achievements?';
+  data: AchievementResponse[];
+  cursor: {
+    after: number;
+  };
+  count: number;
+  next: string;
+
+  constructor(
+    paginateAchievementRequest: PaginateAchievementRequest,
+    achievements: AchievementResponse[],
+  ) {
+    this.data = achievements;
+
+    const last =
+      achievements.length > 0 &&
+      achievements.length === paginateAchievementRequest.take
+        ? achievements[achievements.length - 1]
+        : null;
+
+    this.cursor = {
+      after: last?.id ?? null,
+    };
+
+    this.count = achievements.length;
+    this.next = this.makeNextUrl(paginateAchievementRequest, last);
+  }
+
+  private makeNextUrl(
+    paginateAchievementRequest: PaginateAchievementRequest,
+    last: AchievementResponse,
+  ) {
+    const nextUrl = last && [this.basePath];
+
+    if (nextUrl) {
+      for (const key of Object.keys(paginateAchievementRequest)) {
+        if (!paginateAchievementRequest[key]) {
+          continue;
+        }
+        if (key !== 'where__id__less_than') {
+          nextUrl.push(`${key}=${paginateAchievementRequest[key]}`);
+        }
+      }
+      nextUrl.push(`where__id__less_than=${last.id.toString()}`);
+    }
+
+    return nextUrl?.join('&').toString() ?? null;
+  }
+}

--- a/BE/src/achievement/dto/paginate-achievement-response.ts
+++ b/BE/src/achievement/dto/paginate-achievement-response.ts
@@ -38,11 +38,11 @@ export class PaginateAchievementResponse {
         if (!paginateAchievementRequest[key]) {
           continue;
         }
-        if (key !== 'where__id__less_than') {
+        if (key !== 'whereIdLessThan') {
           next[key] = paginateAchievementRequest[key];
         }
       }
-      next.where__id__less_than = parseInt(last.id.toString());
+      next.whereIdLessThan = parseInt(last.id.toString());
     }
 
     return next ?? null;

--- a/BE/src/achievement/entities/achievement.entity.ts
+++ b/BE/src/achievement/entities/achievement.entity.ts
@@ -37,8 +37,8 @@ export class AchievementEntity extends BaseTimeEntity {
 
   toModel() {
     const achievement = new Achievement(
-      this.user.toModel(),
-      this.category.toModel(),
+      this.user?.toModel(),
+      this.category?.toModel(),
       this.title,
       this.content,
       this.imageUrl,

--- a/BE/src/achievement/entities/achievement.entity.ts
+++ b/BE/src/achievement/entities/achievement.entity.ts
@@ -8,9 +8,10 @@ import {
 } from 'typeorm';
 import { UserEntity } from '../../users/entities/user.entity';
 import { CategoryEntity } from '../../category/entities/category.entity';
+import { Achievement } from '../domain/achievement.domain';
 
-@Entity({ name: 'user_achievement' })
-export class UserAchievementEntity extends BaseTimeEntity {
+@Entity({ name: 'achievement' })
+export class AchievementEntity extends BaseTimeEntity {
   @PrimaryGeneratedColumn()
   id: number;
 
@@ -22,9 +23,40 @@ export class UserAchievementEntity extends BaseTimeEntity {
   @JoinColumn({ name: 'category_id' })
   category: CategoryEntity;
 
+  @Column({ type: 'varchar', length: 20 })
+  title: string;
+
   @Column({ type: 'text' })
   content: string;
 
   @Column({ type: 'varchar', length: 100 })
   imageUrl: string;
+
+  @Column({ type: 'varchar', length: 100 })
+  thumbnailUrl: string;
+
+  toModel() {
+    const achievement = new Achievement(
+      this.user.toModel(),
+      this.category.toModel(),
+      this.title,
+      this.content,
+      this.imageUrl,
+      this.thumbnailUrl,
+    );
+    achievement.id = this.id;
+    return achievement;
+  }
+
+  static from(achievement: Achievement) {
+    const achievementEntity = new AchievementEntity();
+    achievementEntity.id = achievement.id;
+    achievementEntity.user = UserEntity.from(achievement.user);
+    achievementEntity.category = CategoryEntity.from(achievement.category);
+    achievementEntity.title = achievement.title;
+    achievementEntity.content = achievement.content;
+    achievementEntity.imageUrl = achievement.imageUrl;
+    achievementEntity.thumbnailUrl = achievement.thumbnailUrl;
+    return achievementEntity;
+  }
 }

--- a/BE/src/achievement/entities/achievement.repository.spec.ts
+++ b/BE/src/achievement/entities/achievement.repository.spec.ts
@@ -1,0 +1,108 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CustomTypeOrmModule } from '../../config/typeorm/custom-typeorm.module';
+import { ConfigModule } from '@nestjs/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { typeOrmModuleOptions } from '../../config/typeorm';
+import { configServiceModuleOptions } from '../../config/config';
+import { DataSource } from 'typeorm';
+import { transactionTest } from '../../../test/common/transaction-test';
+import {
+  AchievementPaginationOption,
+  AchievementRepository,
+} from './achievement.repository';
+import { UsersFixture } from '../../../test/user/users-fixture';
+import { UsersTestModule } from '../../../test/user/users-test.module';
+import { CategoryRepository } from '../../category/entities/category.repository';
+import { CategoryFixture } from '../../../test/category/category-fixture';
+import { AchievementTestModule } from '../../../test/achievement/achievement-test.module';
+import { AchievementFixture } from '../../../test/achievement/achievement-fixture';
+import { CategoryTestModule } from '../../../test/category/category-test.module';
+import { Achievement } from '../domain/achievement.domain';
+
+describe('AchievementRepository test', () => {
+  let achievementRepository: AchievementRepository;
+  let dataSource: DataSource;
+  let usersFixture: UsersFixture;
+  let categoryFixture: CategoryFixture;
+  let achievementFixture: AchievementFixture;
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot(configServiceModuleOptions),
+        TypeOrmModule.forRootAsync(typeOrmModuleOptions),
+        CustomTypeOrmModule.forCustomRepository([
+          AchievementRepository,
+          CategoryRepository,
+        ]),
+        UsersTestModule,
+        CategoryTestModule,
+        AchievementTestModule,
+      ],
+    }).compile();
+
+    usersFixture = module.get<UsersFixture>(UsersFixture);
+    categoryFixture = module.get<CategoryFixture>(CategoryFixture);
+    achievementFixture = module.get<AchievementFixture>(AchievementFixture);
+    achievementRepository = module.get<AchievementRepository>(
+      AchievementRepository,
+    );
+    dataSource = module.get<DataSource>(DataSource);
+  });
+
+  afterAll(async () => {
+    await dataSource.destroy();
+  });
+
+  test('달성 기록을 저장할 수 있다.', async () => {
+    await transactionTest(dataSource, async () => {
+      // given
+      const user = await usersFixture.getUser('ABC');
+      const category = await categoryFixture.getCategory(user, '카테고리1');
+      const achievement = new Achievement(
+        user,
+        category,
+        '다이어트 1회차',
+        '오늘의 닭가슴살',
+        'imageUrl',
+        'thumbnailUrl',
+      );
+
+      // when
+      const expected = await achievementRepository.saveAchievement(achievement);
+
+      // then
+      expect(expected.title).toEqual('다이어트 1회차');
+      expect(expected.content).toEqual('오늘의 닭가슴살');
+      expect(expected.imageUrl).toEqual('imageUrl');
+      expect(expected.thumbnailUrl).toEqual('thumbnailUrl');
+    });
+  });
+
+  test('달성 기록을 조회한다.', async () => {
+    await transactionTest(dataSource, async () => {
+      // given
+      const user = await usersFixture.getUser('ABC');
+      const category = await categoryFixture.getCategory(user, 'ABC');
+      const achievements = [];
+      for (let i = 0; i < 10; i++) {
+        achievements.push(
+          await achievementFixture.getAchievement(user, category),
+        );
+      }
+
+      // when
+      const achievementPaginationOption: AchievementPaginationOption = {
+        categoryId: category.id,
+        take: 12,
+      };
+      const findAll = await achievementRepository.findAll(
+        user.id,
+        achievementPaginationOption,
+      );
+
+      // then
+      expect(findAll.length).toEqual(10);
+    });
+  });
+});

--- a/BE/src/achievement/entities/achievement.repository.spec.ts
+++ b/BE/src/achievement/entities/achievement.repository.spec.ts
@@ -6,10 +6,7 @@ import { typeOrmModuleOptions } from '../../config/typeorm';
 import { configServiceModuleOptions } from '../../config/config';
 import { DataSource } from 'typeorm';
 import { transactionTest } from '../../../test/common/transaction-test';
-import {
-  AchievementPaginationOption,
-  AchievementRepository,
-} from './achievement.repository';
+import { AchievementRepository } from './achievement.repository';
 import { UsersFixture } from '../../../test/user/users-fixture';
 import { UsersTestModule } from '../../../test/user/users-test.module';
 import { CategoryRepository } from '../../category/entities/category.repository';
@@ -18,6 +15,7 @@ import { AchievementTestModule } from '../../../test/achievement/achievement-tes
 import { AchievementFixture } from '../../../test/achievement/achievement-fixture';
 import { CategoryTestModule } from '../../../test/category/category-test.module';
 import { Achievement } from '../domain/achievement.domain';
+import { Next } from '../index';
 
 describe('AchievementRepository test', () => {
   let achievementRepository: AchievementRepository;
@@ -92,7 +90,7 @@ describe('AchievementRepository test', () => {
       }
 
       // when
-      const achievementPaginationOption: AchievementPaginationOption = {
+      const achievementPaginationOption: Next = {
         categoryId: category.id,
         take: 12,
       };

--- a/BE/src/achievement/entities/achievement.repository.ts
+++ b/BE/src/achievement/entities/achievement.repository.ts
@@ -3,24 +3,20 @@ import { TransactionalRepository } from '../../config/transaction-manager/transa
 import { AchievementEntity } from './achievement.entity';
 import { Achievement } from '../domain/achievement.domain';
 import { FindOptionsWhere, LessThan } from 'typeorm';
+import { Next } from '../index';
 
-export interface AchievementPaginationOption {
-  categoryId: number;
-  where__id__less_than?: number;
-  take: number;
-}
 @CustomRepository(AchievementEntity)
 export class AchievementRepository extends TransactionalRepository<AchievementEntity> {
   async findAll(
     userId: number,
-    achievementPaginationOption: AchievementPaginationOption,
+    achievementPaginationOption: Next,
   ): Promise<Achievement[]> {
     const where: FindOptionsWhere<AchievementEntity> = {
       user: { id: userId },
       category: { id: achievementPaginationOption.categoryId },
     };
-    if (achievementPaginationOption.where__id__less_than) {
-      where.id = LessThan(achievementPaginationOption.where__id__less_than);
+    if (achievementPaginationOption.whereIdLessThan) {
+      where.id = LessThan(achievementPaginationOption.whereIdLessThan);
     }
     const achievementEntities = await this.repository.find({
       where,

--- a/BE/src/achievement/entities/achievement.repository.ts
+++ b/BE/src/achievement/entities/achievement.repository.ts
@@ -1,0 +1,40 @@
+import { CustomRepository } from '../../config/typeorm/custom-repository.decorator';
+import { TransactionalRepository } from '../../config/transaction-manager/transactional-repository';
+import { AchievementEntity } from './achievement.entity';
+import { Achievement } from '../domain/achievement.domain';
+import { FindOptionsWhere, LessThan } from 'typeorm';
+
+export interface AchievementPaginationOption {
+  categoryId: number;
+  where__id__less_than?: number;
+  take: number;
+}
+@CustomRepository(AchievementEntity)
+export class AchievementRepository extends TransactionalRepository<AchievementEntity> {
+  async findAll(
+    userId: number,
+    achievementPaginationOption: AchievementPaginationOption,
+  ): Promise<Achievement[]> {
+    const where: FindOptionsWhere<AchievementEntity> = {
+      user: { id: userId },
+      category: { id: achievementPaginationOption.categoryId },
+    };
+    if (achievementPaginationOption.where__id__less_than) {
+      where.id = LessThan(achievementPaginationOption.where__id__less_than);
+    }
+    const achievementEntities = await this.repository.find({
+      where,
+      order: { createdAt: 'DESC' },
+      take: achievementPaginationOption.take,
+    });
+    return achievementEntities.map((achievementEntity) =>
+      achievementEntity.toModel(),
+    );
+  }
+
+  async saveAchievement(achievement: Achievement): Promise<Achievement> {
+    const achievementEntity = AchievementEntity.from(achievement);
+    const saved = await this.repository.save(achievementEntity);
+    return saved.toModel();
+  }
+}

--- a/BE/src/achievement/index.ts
+++ b/BE/src/achievement/index.ts
@@ -1,0 +1,5 @@
+export interface Next {
+  where__id__less_than?: number;
+  take?: number;
+  categoryId?: number;
+}

--- a/BE/src/achievement/index.ts
+++ b/BE/src/achievement/index.ts
@@ -1,5 +1,5 @@
 export interface Next {
-  where__id__less_than?: number;
+  whereIdLessThan?: number;
   take?: number;
   categoryId?: number;
 }

--- a/BE/src/app.module.ts
+++ b/BE/src/app.module.ts
@@ -10,6 +10,7 @@ import { TransactionModule } from './config/transaction-manager/transaction.modu
 import { OperateModule } from './operate/operate.module';
 import { UsersModule } from './users/users.module';
 import { CategoryModule } from './category/category.module';
+import { AchievementModule } from './achievement/achievement.module';
 
 @Module({
   imports: [
@@ -20,6 +21,7 @@ import { CategoryModule } from './category/category.module';
     TransactionModule,
     OperateModule,
     CategoryModule,
+    AchievementModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/BE/src/config/validation/index.ts
+++ b/BE/src/config/validation/index.ts
@@ -9,6 +9,9 @@ export const validationPipeOptions: ValidationPipeOptions = {
   whitelist: true,
   forbidNonWhitelisted: true,
   transform: true,
+  transformOptions: {
+    enableImplicitConversion: true,
+  },
   exceptionFactory: (errors: ValidationError[]) => {
     const defaultErrorMessage: ValidationErrorMessage = {
       error: '잘못된 입력입니다.',

--- a/BE/test/achievement/achievement-fixture.ts
+++ b/BE/test/achievement/achievement-fixture.ts
@@ -1,0 +1,28 @@
+import { User } from '../../src/users/domain/user.domain';
+import { Injectable } from '@nestjs/common';
+import { AchievementRepository } from '../../src/achievement/entities/achievement.repository';
+import { Achievement } from '../../src/achievement/domain/achievement.domain';
+import { Category } from '../../src/category/domain/category.domain';
+
+@Injectable()
+export class AchievementFixture {
+  static id = 0;
+
+  constructor(private readonly achievementRepository: AchievementRepository) {}
+
+  async getAchievement(user: User, category: Category): Promise<Achievement> {
+    const achievement = AchievementFixture.achievement(user, category);
+    return await this.achievementRepository.saveAchievement(achievement);
+  }
+
+  static achievement(user: User, category: Category) {
+    return new Achievement(
+      user,
+      category,
+      `다이어트 ${this.id}회차`,
+      '오늘의 닭가슴살',
+      `imageUrl${this.id}`,
+      `thumbnailUrl${this.id}`,
+    );
+  }
+}

--- a/BE/test/achievement/achievement-fixture.ts
+++ b/BE/test/achievement/achievement-fixture.ts
@@ -19,7 +19,7 @@ export class AchievementFixture {
     return new Achievement(
       user,
       category,
-      `다이어트 ${this.id}회차`,
+      `다이어트 ${++this.id}회차`,
       '오늘의 닭가슴살',
       `imageUrl${this.id}`,
       `thumbnailUrl${this.id}`,

--- a/BE/test/achievement/achievement-test.module.ts
+++ b/BE/test/achievement/achievement-test.module.ts
@@ -1,0 +1,14 @@
+import { CustomTypeOrmModule } from '../../src/config/typeorm/custom-typeorm.module';
+import { Module } from '@nestjs/common';
+import { AchievementRepository } from '../../src/achievement/entities/achievement.repository';
+import { AchievementModule } from '../../src/achievement/achievement.module';
+import { AchievementFixture } from './achievement-fixture';
+
+@Module({
+  imports: [
+    CustomTypeOrmModule.forCustomRepository([AchievementRepository]),
+    AchievementModule,
+  ],
+  providers: [AchievementFixture],
+})
+export class AchievementTestModule {}

--- a/BE/test/category/category-fixture.ts
+++ b/BE/test/category/category-fixture.ts
@@ -1,0 +1,18 @@
+import { User } from '../../src/users/domain/user.domain';
+import { Injectable } from '@nestjs/common';
+import { Category } from '../../src/category/domain/category.domain';
+import { CategoryRepository } from '../../src/category/entities/category.repository';
+
+@Injectable()
+export class CategoryFixture {
+  constructor(private readonly categoryRepository: CategoryRepository) {}
+
+  async getCategory(user: User, name: string): Promise<Category> {
+    const category = CategoryFixture.category(user, name);
+    return await this.categoryRepository.saveCategory(category);
+  }
+
+  static category(user: User, name: string) {
+    return new Category(user, name);
+  }
+}

--- a/BE/test/category/category-test.module.ts
+++ b/BE/test/category/category-test.module.ts
@@ -1,0 +1,14 @@
+import { CustomTypeOrmModule } from '../../src/config/typeorm/custom-typeorm.module';
+import { Module } from '@nestjs/common';
+import { CategoryRepository } from '../../src/category/entities/category.repository';
+import { CategoryModule } from '../../src/category/category.module';
+import { CategoryFixture } from './category-fixture';
+
+@Module({
+  imports: [
+    CustomTypeOrmModule.forCustomRepository([CategoryRepository]),
+    CategoryModule,
+  ],
+  providers: [CategoryFixture],
+})
+export class CategoryTestModule {}


### PR DESCRIPTION
## PR 요약
- 달성 기록 리스트 API를 작성한다.
- 커서 기반 페이지네이션 적용
- 카테고리로 필터링 가능 
- swagger 추가
  
##### 스크린샷
- 최초/중간 요청
<img width="644" alt="image" src="https://github.com/boostcampwm2023/iOS02-moti/assets/34297340/375edaa3-0fa6-4551-9caa-6f06caa547ec">

- 마지막 요청
<img width="655" alt="image" src="https://github.com/boostcampwm2023/iOS02-moti/assets/34297340/d5697dba-ac88-4387-bec6-36bac4f95a03">

<img width="1595" alt="image" src="https://github.com/boostcampwm2023/iOS02-moti/assets/34297340/625f114b-c2b8-48c1-aae5-70ea56e45735">


#### Linked Issue
close #125 
close #126 
close #148 
