### PR TITLE
categoryId가 0일때 전체 달성기록이 조회되도록 한다.

### DIFF
--- a/BE/src/achievement/dto/paginate-achievement-request.ts
+++ b/BE/src/achievement/dto/paginate-achievement-request.ts
@@ -10,14 +10,18 @@ export class PaginateAchievementRequest {
   @IsNumber()
   @IsOptional()
   @ApiProperty({ description: 'take' })
-  take: number = 12;
+  take: number;
 
   @IsNumber()
   @IsOptional()
   @ApiProperty({ description: 'categoryId' })
   categoryId: number;
 
-  constructor(categoryId?: number, take?: number, whereIdLessThan?: number) {
+  constructor(
+    categoryId?: number,
+    take: number = 12,
+    whereIdLessThan?: number,
+  ) {
     this.categoryId = categoryId;
     this.take = take;
     this.whereIdLessThan = whereIdLessThan;

--- a/BE/src/achievement/entities/achievement.repository.spec.ts
+++ b/BE/src/achievement/entities/achievement.repository.spec.ts
@@ -15,7 +15,7 @@ import { AchievementTestModule } from '../../../test/achievement/achievement-tes
 import { AchievementFixture } from '../../../test/achievement/achievement-fixture';
 import { CategoryTestModule } from '../../../test/category/category-test.module';
 import { Achievement } from '../domain/achievement.domain';
-import { Next } from '../index';
+import { PaginateAchievementRequest } from '../dto/paginate-achievement-request';
 
 describe('AchievementRepository test', () => {
   let achievementRepository: AchievementRepository;
@@ -90,7 +90,7 @@ describe('AchievementRepository test', () => {
       }
 
       // when
-      const achievementPaginationOption: Next = {
+      const achievementPaginationOption: PaginateAchievementRequest = {
         categoryId: category.id,
         take: 12,
       };
@@ -101,6 +101,40 @@ describe('AchievementRepository test', () => {
 
       // then
       expect(findAll.length).toEqual(10);
+    });
+  });
+
+  test('카테고리 ID가 0인 경우에는 모든 달성 기록을 조회한다.', async () => {
+    await transactionTest(dataSource, async () => {
+      // given
+      const user = await usersFixture.getUser('ABC');
+      const category_1 = await categoryFixture.getCategory(user, 'ABC');
+      const category_2 = await categoryFixture.getCategory(user, 'DEF');
+
+      const achievements = [];
+      for (let i = 0; i < 10; i++) {
+        achievements.push(
+          await achievementFixture.getAchievement(user, category_1),
+        );
+      }
+      for (let i = 0; i < 10; i++) {
+        achievements.push(
+          await achievementFixture.getAchievement(user, category_2),
+        );
+      }
+
+      // when
+      const achievementPaginationOption: PaginateAchievementRequest = {
+        categoryId: 0,
+        take: 12,
+      };
+      const findAll = await achievementRepository.findAll(
+        user.id,
+        achievementPaginationOption,
+      );
+
+      // then
+      expect(findAll.length).toEqual(12);
     });
   });
 });

--- a/BE/src/achievement/entities/achievement.repository.ts
+++ b/BE/src/achievement/entities/achievement.repository.ts
@@ -3,18 +3,20 @@ import { TransactionalRepository } from '../../config/transaction-manager/transa
 import { AchievementEntity } from './achievement.entity';
 import { Achievement } from '../domain/achievement.domain';
 import { FindOptionsWhere, LessThan } from 'typeorm';
-import { Next } from '../index';
+import { PaginateAchievementRequest } from '../dto/paginate-achievement-request';
 
 @CustomRepository(AchievementEntity)
 export class AchievementRepository extends TransactionalRepository<AchievementEntity> {
   async findAll(
     userId: number,
-    achievementPaginationOption: Next,
+    achievementPaginationOption: PaginateAchievementRequest,
   ): Promise<Achievement[]> {
     const where: FindOptionsWhere<AchievementEntity> = {
       user: { id: userId },
-      category: { id: achievementPaginationOption.categoryId },
     };
+    if (achievementPaginationOption.categoryId !== 0) {
+      where.category = { id: achievementPaginationOption.categoryId };
+    }
     if (achievementPaginationOption.whereIdLessThan) {
       where.id = LessThan(achievementPaginationOption.whereIdLessThan);
     }


### PR DESCRIPTION
## PR 요약
- categoryId가 0일때 전체 달성기록이 조회되도록 한다.

#### 변경 사항
repository에 분기 추가

##### 스크린샷
<img width="946" alt="image" src="https://github.com/boostcampwm2023/iOS02-moti/assets/34297340/fd41686d-9246-482e-a7e8-7ce0f8cf01e7">
<img width="320" alt="image" src="https://github.com/boostcampwm2023/iOS02-moti/assets/34297340/4d886514-5479-4312-8f11-26eed48c50a3">

#### Linked Issue
close #169 
