### PR TITLE
사용자 본인에 대한 카테고리 리스트를 반환하는 API 작성하기

### DIFF
--- a/BE/src/achievement/entities/achievement.entity.ts
+++ b/BE/src/achievement/entities/achievement.entity.ts
@@ -51,8 +51,8 @@ export class AchievementEntity extends BaseTimeEntity {
   static from(achievement: Achievement) {
     const achievementEntity = new AchievementEntity();
     achievementEntity.id = achievement.id;
-    achievementEntity.user = UserEntity.from(achievement.user);
-    achievementEntity.category = CategoryEntity.from(achievement.category);
+    achievementEntity.user = UserEntity.from(achievement?.user);
+    achievementEntity.category = CategoryEntity.from(achievement?.category);
     achievementEntity.title = achievement.title;
     achievementEntity.content = achievement.content;
     achievementEntity.imageUrl = achievement.imageUrl;

--- a/BE/src/category/application/category.service.spec.ts
+++ b/BE/src/category/application/category.service.spec.ts
@@ -76,7 +76,7 @@ describe('CategoryService', () => {
 
       // when
       const retrievedCategories =
-        await categoryService.getCategoriesByUsers(user);
+        await categoryService.getCategoriesByUser(user);
 
       // then
       expect(retrievedCategories).toBeDefined();
@@ -97,7 +97,7 @@ describe('CategoryService', () => {
 
       // when
       const retrievedCategories =
-        await categoryService.getCategoriesByUsers(user);
+        await categoryService.getCategoriesByUser(user);
 
       // then
       expect(retrievedCategories.length).toBe(4);

--- a/BE/src/category/application/category.service.spec.ts
+++ b/BE/src/category/application/category.service.spec.ts
@@ -7,14 +7,20 @@ import { UsersTestModule } from '../../../test/user/users-test.module';
 import { OperateModule } from '../../operate/operate.module';
 import { ConfigModule } from '@nestjs/config';
 import { configServiceModuleOptions } from '../../config/config';
-import { CategoryModule } from '../category.module';
 import { CategoryService } from './category.service';
 import { CategoryCreate } from '../dto/category-create';
+import { AchievementTestModule } from '../../../test/achievement/achievement-test.module';
+import { AchievementFixture } from '../../../test/achievement/achievement-fixture';
+import { Category } from '../domain/category.domain';
+import { CategoryTestModule } from '../../../test/category/category-test.module';
+import { CategoryFixture } from '../../../test/category/category-fixture';
 
 describe('CategoryService', () => {
   let categoryService: CategoryService;
   let dataSource: DataSource;
   let usersFixture: UsersFixture;
+  let categoryFixture: CategoryFixture;
+  let achievementFixture: AchievementFixture;
 
   beforeAll(async () => {
     const app: TestingModule = await Test.createTestingModule({
@@ -23,12 +29,15 @@ describe('CategoryService', () => {
         UsersTestModule,
         OperateModule,
         ConfigModule.forRoot(configServiceModuleOptions),
-        CategoryModule,
+        CategoryTestModule,
+        AchievementTestModule,
       ],
       controllers: [],
       providers: [],
     }).compile();
 
+    categoryFixture = app.get<CategoryFixture>(CategoryFixture);
+    achievementFixture = app.get<AchievementFixture>(AchievementFixture);
     usersFixture = app.get<UsersFixture>(UsersFixture);
     categoryService = app.get<CategoryService>(CategoryService);
     dataSource = app.get<DataSource>(DataSource);
@@ -58,5 +67,52 @@ describe('CategoryService', () => {
     // then
     expect(savedCategory.name).toBe('카테고리1');
     expect(savedCategory.user).toStrictEqual(user);
+  });
+
+  describe('getCategoriesByUsers는 카테고리를 조회할 수 있다', () => {
+    it('user에 대한 카테고리가 없을 때 빈 배열을 반환한다.', async () => {
+      // given
+      const user = await usersFixture.getUser(1);
+
+      // when
+      const retrievedCategories =
+        await categoryService.getCategoriesByUsers(user);
+
+      // then
+      expect(retrievedCategories).toBeDefined();
+      expect(retrievedCategories.length).toBe(0);
+    });
+
+    it('user에 대한 카테고리가 있을 때 카테고리를 반환한다.', async () => {
+      // given
+      const user = await usersFixture.getUser(1);
+      const categories: Category[] = await categoryFixture.getCategories(
+        4,
+        user,
+      );
+      await achievementFixture.getAchievements(4, user, categories[0]);
+      await achievementFixture.getAchievements(5, user, categories[1]);
+      await achievementFixture.getAchievements(7, user, categories[2]);
+      await achievementFixture.getAchievements(10, user, categories[3]);
+
+      // when
+      const retrievedCategories =
+        await categoryService.getCategoriesByUsers(user);
+
+      // then
+      expect(retrievedCategories.length).toBe(4);
+      expect(retrievedCategories[0].categoryId).toEqual(categories[0].id);
+      expect(retrievedCategories[0].insertedAt).toBeInstanceOf(Date);
+      expect(retrievedCategories[0].achievementCount).toBe(4);
+      expect(retrievedCategories[1].categoryId).toEqual(categories[1].id);
+      expect(retrievedCategories[1].insertedAt).toBeInstanceOf(Date);
+      expect(retrievedCategories[1].achievementCount).toBe(5);
+      expect(retrievedCategories[2].categoryId).toEqual(categories[2].id);
+      expect(retrievedCategories[2].insertedAt).toBeInstanceOf(Date);
+      expect(retrievedCategories[2].achievementCount).toBe(7);
+      expect(retrievedCategories[3].categoryId).toEqual(categories[3].id);
+      expect(retrievedCategories[3].insertedAt).toBeInstanceOf(Date);
+      expect(retrievedCategories[3].achievementCount).toBe(10);
+    });
   });
 });

--- a/BE/src/category/application/category.service.ts
+++ b/BE/src/category/application/category.service.ts
@@ -20,7 +20,7 @@ export class CategoryService {
   }
 
   @Transactional({ readonly: true })
-  async getCategoriesByUsers(user: User): Promise<CategoryMetaData[]> {
+  async getCategoriesByUser(user: User): Promise<CategoryMetaData[]> {
     return this.categoryRepository.findByUserWithCount(user);
   }
 }

--- a/BE/src/category/application/category.service.ts
+++ b/BE/src/category/application/category.service.ts
@@ -4,6 +4,7 @@ import { CategoryCreate } from '../dto/category-create';
 import { Transactional } from '../../config/transaction-manager';
 import { Category } from '../domain/category.domain';
 import { User } from '../../users/domain/user.domain';
+import { CategoryMetaData } from '../dto/category-metadata';
 
 @Injectable()
 export class CategoryService {
@@ -16,5 +17,10 @@ export class CategoryService {
   ): Promise<Category> {
     const category = categoryCreate.toModel(user);
     return await this.categoryRepository.saveCategory(category);
+  }
+
+  @Transactional({ readonly: true })
+  async getCategoriesByUsers(user: User): Promise<CategoryMetaData[]> {
+    return this.categoryRepository.findByUserWithCount(user);
   }
 }

--- a/BE/src/category/controller/category.controller.ts
+++ b/BE/src/category/controller/category.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Get,
   HttpCode,
   HttpStatus,
   Post,
@@ -14,6 +15,7 @@ import { AuthenticatedUser } from '../../auth/decorator/athenticated-user.decora
 import { User } from '../../users/domain/user.domain';
 import { AccessTokenGuard } from '../../auth/guard/access-token.guard';
 import { CategoryResponse } from '../dto/category.response';
+import { CategoryListResponse } from '../dto/category-list.response';
 
 @Controller('/api/v1/category')
 @ApiTags('카테고리 API')
@@ -36,5 +38,19 @@ export class CategoryController {
       user,
     );
     return ApiData.success(CategoryResponse.from(category));
+  }
+
+  @Get()
+  @UseGuards(AccessTokenGuard)
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: '카테고리 조회 API',
+    description: '사용자 본인에 대한 카테고리를 조회합니다.',
+  })
+  async getCategories(
+    @AuthenticatedUser() user: User,
+  ): Promise<ApiData<CategoryListResponse>> {
+    const categories = await this.categoryService.getCategoriesByUsers(user);
+    return ApiData.success(new CategoryListResponse(categories));
   }
 }

--- a/BE/src/category/controller/category.controller.ts
+++ b/BE/src/category/controller/category.controller.ts
@@ -17,7 +17,7 @@ import { AccessTokenGuard } from '../../auth/guard/access-token.guard';
 import { CategoryResponse } from '../dto/category.response';
 import { CategoryListResponse } from '../dto/category-list.response';
 
-@Controller('/api/v1/category')
+@Controller('/api/v1/categories')
 @ApiTags('카테고리 API')
 export class CategoryController {
   constructor(private readonly categoryService: CategoryService) {}
@@ -50,7 +50,7 @@ export class CategoryController {
   async getCategories(
     @AuthenticatedUser() user: User,
   ): Promise<ApiData<CategoryListResponse>> {
-    const categories = await this.categoryService.getCategoriesByUsers(user);
+    const categories = await this.categoryService.getCategoriesByUser(user);
     return ApiData.success(new CategoryListResponse(categories));
   }
 }

--- a/BE/src/category/dto/category-list.response.spec.ts
+++ b/BE/src/category/dto/category-list.response.spec.ts
@@ -1,0 +1,99 @@
+import { CategoryMetaData } from './category-metadata';
+import { CategoryListResponse } from './category-list.response';
+
+describe('CategoryListResponse', () => {
+  describe('생성된 카테고리가 없더라도 응답이 가능하다.', () => {
+    it('카테고리 메타데이터가 빈 배열일 때 응답이 가능하다.', () => {
+      // given
+      const categoryMetaData: CategoryMetaData[] = [];
+
+      // when
+      const categoryListResponse = new CategoryListResponse(categoryMetaData);
+
+      // then
+      expect(categoryListResponse).toBeDefined();
+      expect(Object.keys(categoryListResponse.categories)).toHaveLength(1);
+      expect(categoryListResponse.categoryNames).toHaveLength(1);
+      expect(categoryListResponse.categoryNames).toContain('전체');
+      expect(categoryListResponse.categories).toHaveProperty('전체');
+      expect(categoryListResponse.categories['전체'].id).toBe(0);
+      expect(categoryListResponse.categories['전체'].name).toBe('전체');
+      expect(categoryListResponse.categories['전체'].continued).toBe(0);
+      expect(categoryListResponse.categories['전체'].lastChallenged).toBeNull();
+    });
+
+    it('카테고리 메타데이터가 undefined일 때 응답이 가능하다.', () => {
+      // given
+      const categoryMetaData: CategoryMetaData[] = undefined;
+
+      // when
+      const categoryListResponse = new CategoryListResponse(categoryMetaData);
+
+      // then
+      expect(categoryListResponse).toBeDefined();
+      expect(Object.keys(categoryListResponse.categories)).toHaveLength(1);
+      expect(categoryListResponse.categoryNames).toHaveLength(1);
+      expect(categoryListResponse.categoryNames).toContain('전체');
+      expect(categoryListResponse.categories).toHaveProperty('전체');
+      expect(categoryListResponse.categories['전체'].id).toBe(0);
+      expect(categoryListResponse.categories['전체'].name).toBe('전체');
+      expect(categoryListResponse.categories['전체'].continued).toBe(0);
+      expect(categoryListResponse.categories['전체'].lastChallenged).toBeNull();
+    });
+  });
+
+  describe('생성된 카테고리가 있을 때 응답이 가능하다.', () => {
+    it('', () => {
+      // given
+      const categoryMetaData: CategoryMetaData[] = [];
+      categoryMetaData.push(
+        new CategoryMetaData({
+          categoryId: 1,
+          categoryName: '카테고리1',
+          insertedAt: new Date('2021-01-01T00:00:00.000Z').toISOString(),
+          achievementCount: '1',
+        }),
+      );
+      categoryMetaData.push(
+        new CategoryMetaData({
+          categoryId: 2,
+          categoryName: '카테고리2',
+          insertedAt: new Date('2021-01-02T00:00:00.000Z').toISOString(),
+          achievementCount: '2',
+        }),
+      );
+
+      // when
+      const categoryListResponse = new CategoryListResponse(categoryMetaData);
+
+      // then
+      expect(categoryListResponse).toBeDefined();
+      expect(Object.keys(categoryListResponse.categories)).toHaveLength(3);
+      expect(categoryListResponse.categoryNames).toHaveLength(3);
+      expect(categoryListResponse.categories).toHaveProperty('전체');
+      expect(categoryListResponse.categoryNames).toContain('전체');
+      expect(categoryListResponse.categories).toHaveProperty('카테고리1');
+      expect(categoryListResponse.categoryNames).toContain('카테고리1');
+      expect(categoryListResponse.categories).toHaveProperty('카테고리2');
+      expect(categoryListResponse.categoryNames).toContain('카테고리2');
+      expect(categoryListResponse.categories['전체']).toEqual({
+        id: 0,
+        name: '전체',
+        continued: 3,
+        lastChallenged: '2021-01-02T00:00:00.000Z',
+      });
+      expect(categoryListResponse.categories['카테고리1']).toEqual({
+        id: 1,
+        name: '카테고리1',
+        continued: 1,
+        lastChallenged: '2021-01-01T00:00:00.000Z',
+      });
+      expect(categoryListResponse.categories['카테고리2']).toEqual({
+        id: 2,
+        name: '카테고리2',
+        continued: 2,
+        lastChallenged: '2021-01-02T00:00:00.000Z',
+      });
+    });
+  });
+});

--- a/BE/src/category/dto/category-list.response.ts
+++ b/BE/src/category/dto/category-list.response.ts
@@ -1,0 +1,57 @@
+import { CategoryMetaData } from './category-metadata';
+import { ApiProperty } from '@nestjs/swagger';
+
+interface CategoryList {
+  [key: string]: CategoryListElementResponse;
+}
+
+export class CategoryListResponse {
+  @ApiProperty({ description: '카테고리 키 리스트' })
+  categoryNames: string[] = [];
+  @ApiProperty({ description: '카테고리 데이터' })
+  categories: CategoryList = {};
+
+  constructor(categoryMetaData: CategoryMetaData[]) {
+    categoryMetaData = categoryMetaData || [];
+    const totalItem = CategoryListElementResponse.totalCategoryElement();
+    this.categories[totalItem.name] = totalItem;
+    this.categoryNames.push(totalItem.name);
+    categoryMetaData?.forEach((category) => {
+      this.categoryNames.push(category.categoryName);
+
+      if (
+        !totalItem.lastChallenged ||
+        new Date(totalItem.lastChallenged) < category.insertedAt
+      )
+        totalItem.lastChallenged = category.insertedAt.toISOString();
+      totalItem.continued += category.achievementCount;
+
+      this.categories[category.categoryName] = new CategoryListElementResponse(
+        category,
+      );
+    });
+  }
+}
+
+export class CategoryListElementResponse {
+  id: number;
+  name: string;
+  continued: number;
+  lastChallenged: string;
+
+  constructor(category: CategoryMetaData) {
+    this.id = category.categoryId;
+    this.name = category.categoryName;
+    this.continued = category.achievementCount;
+    this.lastChallenged = category.insertedAt?.toISOString() || null;
+  }
+
+  static totalCategoryElement() {
+    return new CategoryListElementResponse({
+      categoryId: 0,
+      categoryName: '전체',
+      insertedAt: null,
+      achievementCount: 0,
+    });
+  }
+}

--- a/BE/src/category/dto/category-metadata.ts
+++ b/BE/src/category/dto/category-metadata.ts
@@ -1,0 +1,17 @@
+import { ICategoryMetaData } from '../index';
+
+export class CategoryMetaData {
+  categoryId: number;
+  categoryName: string;
+  insertedAt: Date;
+  achievementCount: number;
+
+  constructor(categoryMetaData: ICategoryMetaData) {
+    this.categoryId = categoryMetaData.categoryId;
+    this.categoryName = categoryMetaData.categoryName;
+    this.insertedAt = new Date(categoryMetaData.insertedAt);
+    this.achievementCount = isNaN(Number(categoryMetaData.achievementCount))
+      ? 0
+      : parseInt(categoryMetaData.achievementCount);
+  }
+}

--- a/BE/src/category/entities/category.entity.ts
+++ b/BE/src/category/entities/category.entity.ts
@@ -30,7 +30,7 @@ export class CategoryEntity extends BaseTimeEntity {
   static from(category: Category): CategoryEntity {
     const categoryEntity = new CategoryEntity();
     categoryEntity.id = category.id;
-    categoryEntity.user = UserEntity.from(category.user);
+    categoryEntity.user = UserEntity.from(category?.user);
     categoryEntity.name = category.name;
     return categoryEntity;
   }

--- a/BE/src/category/entities/category.entity.ts
+++ b/BE/src/category/entities/category.entity.ts
@@ -1,15 +1,19 @@
 import {
   Column,
   Entity,
+  Index,
   JoinColumn,
   ManyToOne,
+  OneToMany,
   PrimaryGeneratedColumn,
 } from 'typeorm';
 import { BaseTimeEntity } from '../../common/entities/base.entity';
 import { UserEntity } from '../../users/entities/user.entity';
 import { Category } from '../domain/category.domain';
+import { AchievementEntity } from '../../achievement/entities/achievement.entity';
 
 @Entity({ name: 'category' })
+@Index(['user'])
 export class CategoryEntity extends BaseTimeEntity {
   @PrimaryGeneratedColumn()
   id: number;
@@ -20,6 +24,9 @@ export class CategoryEntity extends BaseTimeEntity {
 
   @Column({ name: 'name' })
   name: string;
+
+  @OneToMany(() => AchievementEntity, (achievement) => achievement.category)
+  achievements: AchievementEntity[];
 
   toModel(): Category {
     const category = new Category(this.user?.toModel(), this.name);

--- a/BE/src/category/entities/category.repository.spec.ts
+++ b/BE/src/category/entities/category.repository.spec.ts
@@ -6,15 +6,21 @@ import { typeOrmModuleOptions } from '../../config/typeorm';
 import { OperateModule } from '../../operate/operate.module';
 import { ConfigModule } from '@nestjs/config';
 import { configServiceModuleOptions } from '../../config/config';
-import { CategoryModule } from '../category.module';
 import { UsersFixture } from '../../../test/user/users-fixture';
 import { Category } from '../domain/category.domain';
 import { UsersTestModule } from '../../../test/user/users-test.module';
+import { transactionTest } from '../../../test/common/transaction-test';
+import { AchievementFixture } from '../../../test/achievement/achievement-fixture';
+import { AchievementTestModule } from '../../../test/achievement/achievement-test.module';
+import { CategoryTestModule } from '../../../test/category/category-test.module';
+import { CategoryFixture } from '../../../test/category/category-fixture';
 
 describe('CategoryRepository', () => {
   let categoryRepository: CategoryRepository;
+  let categoryFixture: CategoryFixture;
   let dataSource: DataSource;
   let usersFixture: UsersFixture;
+  let achievementFixture: AchievementFixture;
 
   beforeAll(async () => {
     const app: TestingModule = await Test.createTestingModule({
@@ -23,12 +29,15 @@ describe('CategoryRepository', () => {
         UsersTestModule,
         OperateModule,
         ConfigModule.forRoot(configServiceModuleOptions),
-        CategoryModule,
+        CategoryTestModule,
+        AchievementTestModule,
       ],
       controllers: [],
       providers: [],
     }).compile();
 
+    categoryFixture = app.get<CategoryFixture>(CategoryFixture);
+    achievementFixture = app.get<AchievementFixture>(AchievementFixture);
     usersFixture = app.get<UsersFixture>(UsersFixture);
     categoryRepository = app.get<CategoryRepository>(CategoryRepository);
     dataSource = app.get<DataSource>(DataSource);
@@ -45,31 +54,78 @@ describe('CategoryRepository', () => {
   });
 
   it('saveCategory는 카테고리를 생성할 수 있다.', async () => {
-    // given
-    const user = await usersFixture.getUser('ABC');
-    const category = new Category(user, '카테고리1');
+    await transactionTest(dataSource, async () => {
+      // given
+      const user = await usersFixture.getUser('ABC');
+      const category = new Category(user, '카테고리1');
 
-    // when
-    const savedCategory = await categoryRepository.saveCategory(category);
+      // when
+      const savedCategory = await categoryRepository.saveCategory(category);
 
-    // then
-    expect(savedCategory.name).toBe('카테고리1');
-    expect(savedCategory.user).toEqual(user);
+      // then
+      expect(savedCategory.name).toBe('카테고리1');
+      expect(savedCategory.user).toEqual(user);
+    });
   });
 
   it('findById는 id로 user를 제외된 카테고리를 조회할 수 있다.', async () => {
-    // given
-    const user = await usersFixture.getUser(1);
-    const category = new Category(user, '카테고리1');
-    const savedCategory = await categoryRepository.saveCategory(category);
+    await transactionTest(dataSource, async () => {
+      // given
+      const user = await usersFixture.getUser(1);
+      const category = new Category(user, '카테고리1');
+      const savedCategory = await categoryRepository.saveCategory(category);
 
-    // when
-    const retrievedCategory = await categoryRepository.findById(
-      savedCategory.id,
-    );
+      // when
+      const retrievedCategory = await categoryRepository.findById(
+        savedCategory.id,
+      );
 
-    // then
-    expect(retrievedCategory.name).toBe('카테고리1');
-    expect(retrievedCategory.user).toBeUndefined();
+      // then
+      expect(retrievedCategory.name).toBe('카테고리1');
+      expect(retrievedCategory.user).toBeUndefined();
+    });
+  });
+
+  it('findByUserWithCount는 사용자가 소유한 카테고리가 없으면 빈 배열을 반환한다.', async () => {
+    await transactionTest(dataSource, async () => {
+      const user = await usersFixture.getUser(1);
+
+      const retrievedCategories =
+        await categoryRepository.findByUserWithCount(user);
+
+      expect(retrievedCategories).toBeDefined();
+      expect(retrievedCategories.length).toBe(0);
+    });
+  });
+
+  it('findByUserWithCount', async () => {
+    await transactionTest(dataSource, async () => {
+      const user = await usersFixture.getUser(1);
+      const categories: Category[] = await categoryFixture.getCategories(
+        4,
+        user,
+      );
+      await achievementFixture.getAchievements(4, user, categories[0]);
+      await achievementFixture.getAchievements(5, user, categories[1]);
+      await achievementFixture.getAchievements(7, user, categories[2]);
+      await achievementFixture.getAchievements(10, user, categories[3]);
+
+      const retrievedCategories =
+        await categoryRepository.findByUserWithCount(user);
+
+      expect(retrievedCategories.length).toBe(4);
+      expect(retrievedCategories[0].categoryId).toEqual(categories[0].id);
+      expect(retrievedCategories[0].insertedAt).toBeInstanceOf(Date);
+      expect(retrievedCategories[0].achievementCount).toBe(4);
+      expect(retrievedCategories[1].categoryId).toEqual(categories[1].id);
+      expect(retrievedCategories[1].insertedAt).toBeInstanceOf(Date);
+      expect(retrievedCategories[1].achievementCount).toBe(5);
+      expect(retrievedCategories[2].categoryId).toEqual(categories[2].id);
+      expect(retrievedCategories[2].insertedAt).toBeInstanceOf(Date);
+      expect(retrievedCategories[2].achievementCount).toBe(7);
+      expect(retrievedCategories[3].categoryId).toEqual(categories[3].id);
+      expect(retrievedCategories[3].insertedAt).toBeInstanceOf(Date);
+      expect(retrievedCategories[3].achievementCount).toBe(10);
+    });
   });
 });

--- a/BE/src/category/entities/category.repository.ts
+++ b/BE/src/category/entities/category.repository.ts
@@ -2,6 +2,9 @@ import { CustomRepository } from '../../config/typeorm/custom-repository.decorat
 import { CategoryEntity } from './category.entity';
 import { Category } from '../domain/category.domain';
 import { TransactionalRepository } from '../../config/transaction-manager/transactional-repository';
+import { User } from '../../users/domain/user.domain';
+import { ICategoryMetaData } from '../index';
+import { CategoryMetaData } from '../dto/category-metadata';
 
 @CustomRepository(CategoryEntity)
 export class CategoryRepository extends TransactionalRepository<CategoryEntity> {
@@ -14,5 +17,21 @@ export class CategoryRepository extends TransactionalRepository<CategoryEntity> 
   async findById(id: number): Promise<Category> {
     const category = await this.repository.findOne({ where: { id: id } });
     return category?.toModel();
+  }
+
+  async findByUserWithCount(user: User): Promise<CategoryMetaData[]> {
+    const categories = await this.repository
+      .createQueryBuilder('category')
+      .select('category.id', 'categoryId')
+      .addSelect('category.name', 'categoryName')
+      .addSelect('MAX(achievement.created_at)', 'insertedAt')
+      .addSelect('COUNT(achievement.id)', 'achievementCount')
+      .leftJoin('category.achievements', 'achievement')
+      .where('category.user_id = :user', { user: user.id })
+      .orderBy('category.id', 'ASC')
+      .groupBy('category.id')
+      .getRawMany<ICategoryMetaData>();
+
+    return categories.map((category) => new CategoryMetaData(category));
   }
 }

--- a/BE/src/category/index.ts
+++ b/BE/src/category/index.ts
@@ -1,0 +1,6 @@
+export interface ICategoryMetaData {
+  categoryId: number;
+  categoryName: string;
+  insertedAt: string;
+  achievementCount: string;
+}

--- a/BE/test/achievement/achievement-fixture.ts
+++ b/BE/test/achievement/achievement-fixture.ts
@@ -15,6 +15,19 @@ export class AchievementFixture {
     return await this.achievementRepository.saveAchievement(achievement);
   }
 
+  async getAchievements(
+    count: number,
+    user: User,
+    category: Category,
+  ): Promise<Achievement[]> {
+    const achievements: Achievement[] = [];
+    for (let i = 0; i < count; i++) {
+      const achievement = await this.getAchievement(user, category);
+      achievements.push(achievement);
+    }
+    return achievements;
+  }
+
   static achievement(user: User, category: Category) {
     return new Achievement(
       user,

--- a/BE/test/category/category-fixture.ts
+++ b/BE/test/category/category-fixture.ts
@@ -5,14 +5,36 @@ import { CategoryRepository } from '../../src/category/entities/category.reposit
 
 @Injectable()
 export class CategoryFixture {
+  private static id = 0;
+
   constructor(private readonly categoryRepository: CategoryRepository) {}
 
-  async getCategory(user: User, name: string): Promise<Category> {
-    const category = CategoryFixture.category(user, name);
+  async getCategory(user: User, name?: string): Promise<Category> {
+    const category = CategoryFixture.category(
+      user,
+      name || CategoryFixture.getDummyCategoryName(),
+    );
     return await this.categoryRepository.saveCategory(category);
+  }
+
+  async getCategories(
+    count: number,
+    user: User,
+    name?: string,
+  ): Promise<Category[]> {
+    const categories: Category[] = [];
+    for (let i = 0; i < count; i++) {
+      const category = await this.getCategory(user, name);
+      categories.push(category);
+    }
+    return categories;
   }
 
   static category(user: User, name: string) {
     return new Category(user, name);
+  }
+
+  static getDummyCategoryName() {
+    return `카테고리${++CategoryFixture.id}`;
   }
 }


### PR DESCRIPTION
## PR 요약
* 사용자 본인에 대한 카테고리 리스트 조회 API

#### 변경 사항

* 사용자 본인에 대한 카테고리 리스트 조회 API
* fixture 클래스에 다수의 엔티티 생성 메서드 추가

##### 스크린샷

![image](https://github.com/boostcampwm2023/iOS02-moti/assets/75921696/bfdd2671-6fbb-4745-9cad-4f66ad2fdc98)


#### Linked Issue
close #67 
