### PR TITLE
인증된 사용자에 대한 카테고리 목록 조회 API 포맷 변경

### DIFF
--- a/BE/src/category/category.module.ts
+++ b/BE/src/category/category.module.ts
@@ -3,9 +3,10 @@ import { CategoryController } from './controller/category.controller';
 import { CategoryService } from './application/category.service';
 import { CustomTypeOrmModule } from '../config/typeorm/custom-typeorm.module';
 import { CategoryRepository } from './entities/category.repository';
+import { CategoryLegacyController } from './controller/category-legacy.controller';
 
 @Module({
-  controllers: [CategoryController],
+  controllers: [CategoryController, CategoryLegacyController],
   imports: [CustomTypeOrmModule.forCustomRepository([CategoryRepository])],
   providers: [CategoryService],
 })

--- a/BE/src/category/controller/category-legacy.controller.ts
+++ b/BE/src/category/controller/category-legacy.controller.ts
@@ -1,0 +1,35 @@
+import {
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  UseGuards,
+} from '@nestjs/common';
+import { CategoryService } from '../application/category.service';
+import { AccessTokenGuard } from '../../auth/guard/access-token.guard';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { AuthenticatedUser } from '../../auth/decorator/athenticated-user.decorator';
+import { User } from '../../users/domain/user.domain';
+import { ApiData } from '../../common/api/api-data';
+import { CategoryListLegacyResponse } from '../dto/category-list-legacy.response';
+
+@Controller('/api/legacy/categories')
+@ApiTags('카테고리 API - Legacy')
+export class CategoryLegacyController {
+  constructor(private readonly categoryService: CategoryService) {}
+
+  @Get()
+  @UseGuards(AccessTokenGuard)
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: '카테고리 조회 API',
+    description:
+      '사용자 본인에 대한 카테고리를 조회합니다.(Legacy)\nAPI 포맷이 변경되었습니다.',
+  })
+  async getCategoriesLegacy(
+    @AuthenticatedUser() user: User,
+  ): Promise<ApiData<CategoryListLegacyResponse>> {
+    const categories = await this.categoryService.getCategoriesByUser(user);
+    return ApiData.success(new CategoryListLegacyResponse(categories));
+  }
+}

--- a/BE/src/category/controller/category.controller.ts
+++ b/BE/src/category/controller/category.controller.ts
@@ -15,7 +15,7 @@ import { AuthenticatedUser } from '../../auth/decorator/athenticated-user.decora
 import { User } from '../../users/domain/user.domain';
 import { AccessTokenGuard } from '../../auth/guard/access-token.guard';
 import { CategoryResponse } from '../dto/category.response';
-import { CategoryListResponse } from '../dto/category-list.response';
+import { CategoryListElementResponse } from '../dto/category-list-element.response';
 
 @Controller('/api/v1/categories')
 @ApiTags('카테고리 API')
@@ -49,8 +49,8 @@ export class CategoryController {
   })
   async getCategories(
     @AuthenticatedUser() user: User,
-  ): Promise<ApiData<CategoryListResponse>> {
+  ): Promise<ApiData<CategoryListElementResponse[]>> {
     const categories = await this.categoryService.getCategoriesByUser(user);
-    return ApiData.success(new CategoryListResponse(categories));
+    return ApiData.success(CategoryListElementResponse.build(categories));
   }
 }

--- a/BE/src/category/dto/category-list-element.response.ts
+++ b/BE/src/category/dto/category-list-element.response.ts
@@ -1,0 +1,45 @@
+import { CategoryMetaData } from './category-metadata';
+
+export class CategoryListElementResponse {
+  id: number;
+  name: string;
+  continued: number;
+  lastChallenged: string;
+
+  constructor(category: CategoryMetaData) {
+    this.id = category.categoryId;
+    this.name = category.categoryName;
+    this.continued = category.achievementCount;
+    this.lastChallenged = category.insertedAt?.toISOString() || null;
+  }
+
+  static totalCategoryElement() {
+    return new CategoryListElementResponse({
+      categoryId: 0,
+      categoryName: '전체',
+      insertedAt: null,
+      achievementCount: 0,
+    });
+  }
+
+  static build(
+    categoryMetaData: CategoryMetaData[],
+  ): CategoryListElementResponse[] {
+    const totalItem = CategoryListElementResponse.totalCategoryElement();
+    const categories: CategoryListElementResponse[] = [];
+    categories.push(totalItem);
+
+    categoryMetaData?.forEach((category) => {
+      if (
+        !totalItem.lastChallenged ||
+        new Date(totalItem.lastChallenged) < category.insertedAt
+      )
+        totalItem.lastChallenged = category.insertedAt.toISOString();
+      totalItem.continued += category.achievementCount;
+
+      categories.push(new CategoryListElementResponse(category));
+    });
+
+    return categories;
+  }
+}

--- a/BE/src/category/dto/category-list-legacy.response.ts
+++ b/BE/src/category/dto/category-list-legacy.response.ts
@@ -1,15 +1,16 @@
 import { CategoryMetaData } from './category-metadata';
 import { ApiProperty } from '@nestjs/swagger';
+import { CategoryListElementResponse } from './category-list-element.response';
 
-interface CategoryList {
+interface CategoryLegacyList {
   [key: string]: CategoryListElementResponse;
 }
 
-export class CategoryListResponse {
+export class CategoryListLegacyResponse {
   @ApiProperty({ description: '카테고리 키 리스트' })
   categoryNames: string[] = [];
   @ApiProperty({ description: '카테고리 데이터' })
-  categories: CategoryList = {};
+  categories: CategoryLegacyList = {};
 
   constructor(categoryMetaData: CategoryMetaData[]) {
     categoryMetaData = categoryMetaData || [];
@@ -29,29 +30,6 @@ export class CategoryListResponse {
       this.categories[category.categoryName] = new CategoryListElementResponse(
         category,
       );
-    });
-  }
-}
-
-export class CategoryListElementResponse {
-  id: number;
-  name: string;
-  continued: number;
-  lastChallenged: string;
-
-  constructor(category: CategoryMetaData) {
-    this.id = category.categoryId;
-    this.name = category.categoryName;
-    this.continued = category.achievementCount;
-    this.lastChallenged = category.insertedAt?.toISOString() || null;
-  }
-
-  static totalCategoryElement() {
-    return new CategoryListElementResponse({
-      categoryId: 0,
-      categoryName: '전체',
-      insertedAt: null,
-      achievementCount: 0,
     });
   }
 }

--- a/BE/src/category/dto/category-list-regacy.response.spec.ts
+++ b/BE/src/category/dto/category-list-regacy.response.spec.ts
@@ -1,14 +1,16 @@
 import { CategoryMetaData } from './category-metadata';
-import { CategoryListResponse } from './category-list.response';
+import { CategoryListLegacyResponse } from './category-list-legacy.response';
 
-describe('CategoryListResponse', () => {
+describe('CategoryListLegacyResponse', () => {
   describe('생성된 카테고리가 없더라도 응답이 가능하다.', () => {
     it('카테고리 메타데이터가 빈 배열일 때 응답이 가능하다.', () => {
       // given
       const categoryMetaData: CategoryMetaData[] = [];
 
       // when
-      const categoryListResponse = new CategoryListResponse(categoryMetaData);
+      const categoryListResponse = new CategoryListLegacyResponse(
+        categoryMetaData,
+      );
 
       // then
       expect(categoryListResponse).toBeDefined();
@@ -27,7 +29,9 @@ describe('CategoryListResponse', () => {
       const categoryMetaData: CategoryMetaData[] = undefined;
 
       // when
-      const categoryListResponse = new CategoryListResponse(categoryMetaData);
+      const categoryListResponse = new CategoryListLegacyResponse(
+        categoryMetaData,
+      );
 
       // then
       expect(categoryListResponse).toBeDefined();
@@ -64,7 +68,9 @@ describe('CategoryListResponse', () => {
       );
 
       // when
-      const categoryListResponse = new CategoryListResponse(categoryMetaData);
+      const categoryListResponse = new CategoryListLegacyResponse(
+        categoryMetaData,
+      );
 
       // then
       expect(categoryListResponse).toBeDefined();


### PR DESCRIPTION
## PR 요약
인증된 사용자에 대한 카테고리 목록 조회 API 포맷 변경

#### 변경 사항
* 기존 레거시 API 보존
* 카테고리 리스트 조회에 대한 새로운 API 래핑

##### 스크린샷

* `/api/v1/categories`
![image](https://github.com/boostcampwm2023/iOS02-moti/assets/75921696/e6b171bb-b477-4e19-bc14-0a1e35141740)

* `/api/legacy/categories`
![image](https://github.com/boostcampwm2023/iOS02-moti/assets/75921696/f82a5cab-31dc-4c57-8399-173fa516bc34)


#### Linked Issue
close #187
