### PR TITLE
달성 기록 (상세 정보) 화면 UI를 구현한다

### DIFF
--- a/iOS/moti/moti/Presentation/Sources/Presentation/Detail/DetailAchievementCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Detail/DetailAchievementCoordinator.swift
@@ -1,0 +1,37 @@
+//
+//  DetailAchievementCoordinator.swift
+//
+//
+//  Created by Kihyun Lee on 11/22/23.
+//
+
+import UIKit
+import Core
+
+public final class DetailAchievementCoordinator: Coordinator {
+    public var parentCoordinator: Coordinator?
+    public var childCoordinators: [Coordinator] = []
+    public var navigationController: UINavigationController
+    
+    public init(
+        _ navigationController: UINavigationController,
+        _ parentCoordinator: Coordinator?
+    ) {
+        self.navigationController = navigationController
+        self.parentCoordinator = parentCoordinator
+    }
+    
+    public func start() {
+        let detailAchievementVC = DetailAchievementViewController()
+        detailAchievementVC.coordinator = self
+        
+        detailAchievementVC.navigationItem.rightBarButtonItems = [
+            UIBarButtonItem(title: "편집", style: .plain, target: self, action: nil),
+            UIBarButtonItem(title: "삭제", style: .plain, target: self, action: nil)
+        ]
+        
+        detailAchievementVC.navigationItem.rightBarButtonItem = UIBarButtonItem(title: "편집", style: .plain, target: self, action: nil)
+        
+        navigationController.pushViewController(detailAchievementVC, animated: true)
+    }
+}

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Detail/DetailAchievementView.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Detail/DetailAchievementView.swift
@@ -1,0 +1,40 @@
+//
+//  DetailAchievementView.swift
+//
+//
+//  Created by Kihyun Lee on 11/22/23.
+//
+
+import UIKit
+import Design
+
+final class DetailAchievementView: UIView {
+    
+    // MARK: - Views
+    let achievementView = AchievementView()
+    
+    // MARK: - Init
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupUI()
+    }
+}
+
+private extension DetailAchievementView {
+    func setupUI() {
+        setupAchievementView()
+    }
+    
+    func setupAchievementView() {
+        addSubview(achievementView)
+        achievementView.atl
+            .top(equalTo: safeAreaLayoutGuide.topAnchor)
+            .bottom(equalTo: bottomAnchor)
+            .horizontal(equalTo: safeAreaLayoutGuide)
+    }
+}

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Detail/DetailAchievementViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Detail/DetailAchievementViewController.swift
@@ -1,0 +1,24 @@
+//
+//  DetailAchievementViewController.swift
+//
+//
+//  Created by Kihyun Lee on 11/22/23.
+//
+
+import UIKit
+import Design
+
+final class DetailAchievementViewController: BaseViewController<DetailAchievementView> {
+    weak var coordinator: DetailAchievementCoordinator?
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        layoutView.achievementView.update(image: MotiImage.sample1)
+        layoutView.achievementView.categoryButton.addTarget(self, action: #selector(showPicker), for: .touchUpInside)
+    }
+    
+    @objc private func showPicker() {
+        layoutView.achievementView.showCategoryPicker()
+    }
+}

--- a/iOS/moti/moti/Presentation/Sources/Presentation/TabBar/TabBarCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/TabBar/TabBarCoordinator.swift
@@ -105,10 +105,22 @@ private extension TabBarCoordinator {
             image: SymbolImage.ellipsisCircle,
             style: .done,
             target: self,
-            action: nil
+            action: #selector(moveTest)
         )
 
         viewController.navigationItem.rightBarButtonItems = [profileItem, moreItem]
+    }
+    
+    @objc private func moveTest() {
+        let detailAchievementVC = DetailAchievementViewController()
+        detailAchievementVC.navigationItem.rightBarButtonItems = [
+            UIBarButtonItem(title: "삭제", style: .plain, target: self, action: nil),
+            UIBarButtonItem(title: "편집", style: .plain, target: self, action: nil)
+        ]
+        
+        let navVC = UINavigationController(rootViewController: detailAchievementVC)
+//        navigationController.pushViewController(detailAchievementVC, animated: true)
+        navigationController.present(navVC, animated: true)
     }
 }
 


### PR DESCRIPTION
## PR 요약
달성 기록 (상세 정보) 화면 UI 구현
- 네비게이션 바의 편집, 삭제 버튼
- AchievementView 사용
- 현재 더보기(3dot) 버튼을 누르면 이동하도록 테스트 (push가 아닌 present로)
- 홈 뷰에서 썸네일을 누르면 이동하도록 변경 예정
- Back 버튼도 예정

##### 스크린샷
<img width="50%" src="https://github.com/boostcampwm2023/iOS02-moti/assets/60506170/fb28c8d2-a38c-444e-a5d9-9b0e7b6f1f55">

#### Linked Issue
close #183 
