### PR TITLE
카테고리 저장 API 포맷 변경

### DIFF
--- a/BE/src/achievement/dto/achievement-detail-response.ts
+++ b/BE/src/achievement/dto/achievement-detail-response.ts
@@ -1,6 +1,7 @@
 import { IAchievementDetail } from '../index';
 import { ApiProperty } from '@nestjs/swagger';
 import { CategoryInfo } from './category-info';
+import { dateFormat } from '../../common/utils/date-formatter';
 
 export class AchievementDetailResponse {
   // @ApiProperty({ type: [AchievementResponse], description: 'data' })
@@ -13,7 +14,7 @@ export class AchievementDetailResponse {
   @ApiProperty({ description: 'content' })
   content: string;
   @ApiProperty({ description: 'createdAt' })
-  createdAt: Date;
+  createdAt: string;
   @ApiProperty({ type: CategoryInfo, description: 'data' })
   category: CategoryInfo;
   constructor(achievementDetail: IAchievementDetail) {
@@ -21,7 +22,7 @@ export class AchievementDetailResponse {
     this.title = achievementDetail.title;
     this.content = achievementDetail.content;
     this.imageUrl = achievementDetail.imageUrl;
-    this.createdAt = new Date(achievementDetail.createdAt);
+    this.createdAt = dateFormat(new Date(achievementDetail.createdAt));
     this.category = new CategoryInfo(
       achievementDetail.categoryId,
       achievementDetail.categoryName,

--- a/BE/src/auth/decorator/athenticated-user.decorator.ts
+++ b/BE/src/auth/decorator/athenticated-user.decorator.ts
@@ -1,20 +1,11 @@
-import {
-  createParamDecorator,
-  ExecutionContext,
-  InternalServerErrorException,
-} from '@nestjs/common';
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { InvalidTokenException } from '../exception/invalid-token.exception';
 
 export const AuthenticatedUser = createParamDecorator(
   (data, context: ExecutionContext) => {
     const req = context.switchToHttp().getRequest();
-
     const user = req.user;
-
-    if (!user) {
-      throw new InternalServerErrorException(
-        'request user 프로퍼티가 없습니다.',
-      );
-    }
+    if (!user) throw new InvalidTokenException();
 
     return user;
   },

--- a/BE/src/category/dto/category-list-element.response.ts
+++ b/BE/src/category/dto/category-list-element.response.ts
@@ -1,4 +1,5 @@
 import { CategoryMetaData } from './category-metadata';
+import { dateFormat } from '../../common/utils/date-formatter';
 
 export class CategoryListElementResponse {
   id: number;
@@ -10,7 +11,7 @@ export class CategoryListElementResponse {
     this.id = category.categoryId;
     this.name = category.categoryName;
     this.continued = category.achievementCount;
-    this.lastChallenged = category.insertedAt?.toISOString() || null;
+    this.lastChallenged = dateFormat(category.insertedAt);
   }
 
   static totalCategoryElement() {
@@ -34,7 +35,7 @@ export class CategoryListElementResponse {
         !totalItem.lastChallenged ||
         new Date(totalItem.lastChallenged) < category.insertedAt
       )
-        totalItem.lastChallenged = category.insertedAt.toISOString();
+        totalItem.lastChallenged = dateFormat(category.insertedAt);
       totalItem.continued += category.achievementCount;
 
       categories.push(new CategoryListElementResponse(category));

--- a/BE/src/category/dto/category-list-legacy.response.ts
+++ b/BE/src/category/dto/category-list-legacy.response.ts
@@ -1,6 +1,7 @@
 import { CategoryMetaData } from './category-metadata';
 import { ApiProperty } from '@nestjs/swagger';
 import { CategoryListElementResponse } from './category-list-element.response';
+import { dateFormat } from '../../common/utils/date-formatter';
 
 interface CategoryLegacyList {
   [key: string]: CategoryListElementResponse;
@@ -24,7 +25,7 @@ export class CategoryListLegacyResponse {
         !totalItem.lastChallenged ||
         new Date(totalItem.lastChallenged) < category.insertedAt
       )
-        totalItem.lastChallenged = category.insertedAt.toISOString();
+        totalItem.lastChallenged = dateFormat(category.insertedAt);
       totalItem.continued += category.achievementCount;
 
       this.categories[category.categoryName] = new CategoryListElementResponse(

--- a/BE/src/category/dto/category-list-regacy.response.spec.ts
+++ b/BE/src/category/dto/category-list-regacy.response.spec.ts
@@ -47,7 +47,7 @@ describe('CategoryListLegacyResponse', () => {
   });
 
   describe('생성된 카테고리가 있을 때 응답이 가능하다.', () => {
-    it('', () => {
+    it('다수의 카테고리에 대해 응답이 가능하다.', () => {
       // given
       const categoryMetaData: CategoryMetaData[] = [];
       categoryMetaData.push(

--- a/BE/src/category/dto/category-list-regacy.response.spec.ts
+++ b/BE/src/category/dto/category-list-regacy.response.spec.ts
@@ -86,19 +86,19 @@ describe('CategoryListLegacyResponse', () => {
         id: 0,
         name: '전체',
         continued: 3,
-        lastChallenged: '2021-01-02T00:00:00.000Z',
+        lastChallenged: '2021-01-02T00:00:00Z',
       });
       expect(categoryListResponse.categories['카테고리1']).toEqual({
         id: 1,
         name: '카테고리1',
         continued: 1,
-        lastChallenged: '2021-01-01T00:00:00.000Z',
+        lastChallenged: '2021-01-01T00:00:00Z',
       });
       expect(categoryListResponse.categories['카테고리2']).toEqual({
         id: 2,
         name: '카테고리2',
         continued: 2,
-        lastChallenged: '2021-01-02T00:00:00.000Z',
+        lastChallenged: '2021-01-02T00:00:00Z',
       });
     });
   });

--- a/BE/src/category/dto/category-metadata.ts
+++ b/BE/src/category/dto/category-metadata.ts
@@ -9,7 +9,7 @@ export class CategoryMetaData {
   constructor(categoryMetaData: ICategoryMetaData) {
     this.categoryId = categoryMetaData.categoryId;
     this.categoryName = categoryMetaData.categoryName;
-    this.insertedAt = new Date(categoryMetaData.insertedAt);
+    this.insertedAt = categoryMetaData.insertedAt ? new Date() : null;
     this.achievementCount = isNaN(Number(categoryMetaData.achievementCount))
       ? 0
       : parseInt(categoryMetaData.achievementCount);

--- a/BE/src/category/dto/category-metadata.ts
+++ b/BE/src/category/dto/category-metadata.ts
@@ -9,7 +9,9 @@ export class CategoryMetaData {
   constructor(categoryMetaData: ICategoryMetaData) {
     this.categoryId = categoryMetaData.categoryId;
     this.categoryName = categoryMetaData.categoryName;
-    this.insertedAt = categoryMetaData.insertedAt ? new Date() : null;
+    this.insertedAt = categoryMetaData.insertedAt
+      ? new Date(categoryMetaData.insertedAt)
+      : null;
     this.achievementCount = isNaN(Number(categoryMetaData.achievementCount))
       ? 0
       : parseInt(categoryMetaData.achievementCount);

--- a/BE/src/category/dto/category.response.ts
+++ b/BE/src/category/dto/category.response.ts
@@ -2,14 +2,18 @@ import { ApiProperty } from '@nestjs/swagger';
 import { Category } from '../domain/category.domain';
 
 export class CategoryResponse {
+  @ApiProperty({ description: '카테고리 아이디' })
+  id: number;
+
   @ApiProperty({ description: '카테고리 이름' })
   name: string;
 
-  constructor(name: string) {
+  constructor(id: number, name: string) {
+    this.id = id;
     this.name = name;
   }
 
   static from(category: Category) {
-    return new CategoryResponse(category.name);
+    return new CategoryResponse(category.id, category.name);
   }
 }

--- a/BE/src/common/utils/date-formatter.spec.ts
+++ b/BE/src/common/utils/date-formatter.spec.ts
@@ -1,0 +1,23 @@
+import { dateFormat } from './date-formatter';
+
+describe('DateFormatter', () => {
+  it('날짜 포맷이 적용되어야 한다.', () => {
+    // given
+    const date = new Date('2021-01-01T00:00:00.000Z');
+
+    // when
+    const formattedDate = dateFormat(date);
+
+    // then
+    expect(formattedDate).toBe('2021-01-01T00:00:00Z');
+  });
+
+  it('날짜 포맷이 적용되어야 한다.', () => {
+    // given
+    // when
+    const formattedDate = dateFormat(undefined);
+
+    // then
+    expect(formattedDate).toBeNull();
+  });
+});

--- a/BE/src/common/utils/date-formatter.ts
+++ b/BE/src/common/utils/date-formatter.ts
@@ -1,0 +1,3 @@
+export function dateFormat(date: Date): string {
+  return date?.toISOString().slice(0, -5).concat('Z') || null;
+}


### PR DESCRIPTION
## PR 요약
카테고리 저장 API 포맷 변경 

#### 변경 사항
카테고리 저장 API 포맷 변경

##### 스크린샷

![image](https://github.com/boostcampwm2023/iOS02-moti/assets/75921696/0ebf5136-6ed5-4070-8596-f5fe363d1eae)

* 저장된 카테고리의 아이디 추가

![image](https://github.com/boostcampwm2023/iOS02-moti/assets/75921696/17ab4f7f-5f35-4d43-94de-23e807ce4e31)

* 날짜 형식 변경

#### Linked Issue
close #193
