### PR TITLE
다음 페이지네이션에 필요한 query param 응답 관련 버그

### DIFF
--- a/BE/src/achievement/dto/paginate-achievement-response.spec.ts
+++ b/BE/src/achievement/dto/paginate-achievement-response.spec.ts
@@ -20,6 +20,7 @@ describe('PaginateAchievementResponse test', () => {
     );
     expect(response.next).toEqual({ take: 12, whereIdLessThan: 88 });
   });
+
   test('다음 페이지 네이션 요청을 위한 정보를 가지고 있는 next을 생성한다. - categoryId 필터링 추가', () => {
     const paginateAchievementRequest = new PaginateAchievementRequest();
     paginateAchievementRequest.take = 12;
@@ -30,6 +31,21 @@ describe('PaginateAchievementResponse test', () => {
     );
     expect(response.next).toEqual({
       categoryId: 1,
+      take: 12,
+      whereIdLessThan: 88,
+    });
+  });
+
+  test('다음 페이지 네이션 요청을 위한 정보를 가지고 있는 next을 생성한다. - categoryId가 0인 경우', () => {
+    const paginateAchievementRequest = new PaginateAchievementRequest();
+    paginateAchievementRequest.take = 12;
+    paginateAchievementRequest.categoryId = 0;
+    const response = new PaginateAchievementResponse(
+      paginateAchievementRequest,
+      achievementResponses.slice(0, paginateAchievementRequest.take),
+    );
+    expect(response.next).toEqual({
+      categoryId: 0,
       take: 12,
       whereIdLessThan: 88,
     });

--- a/BE/src/achievement/dto/paginate-achievement-response.ts
+++ b/BE/src/achievement/dto/paginate-achievement-response.ts
@@ -35,9 +35,6 @@ export class PaginateAchievementResponse {
 
     if (next) {
       for (const key of Object.keys(paginateAchievementRequest)) {
-        if (!paginateAchievementRequest[key]) {
-          continue;
-        }
         if (key !== 'whereIdLessThan') {
           next[key] = paginateAchievementRequest[key];
         }


### PR DESCRIPTION
## PR 요약
- categoryId=0일때, next에 categoryId=0이 포함되지 않는 이슈 수정


##### 스크린샷
<img width="919" alt="image" src="https://github.com/boostcampwm2023/iOS02-moti/assets/34297340/c7bddbd3-04be-45bd-bba4-fdb4492a0262">


#### Linked Issue
close #203 
