### PR TITLE
선택한 카테고리의 달성기록 리스트를 요청한다, 스크롤을 내리면 다음 페이지를 요청한다.

### DIFF
--- a/iOS/moti/moti/Data/Sources/Data/Network/Provider/Provider.swift
+++ b/iOS/moti/moti/Data/Sources/Data/Network/Provider/Provider.swift
@@ -34,11 +34,13 @@ public struct Provider: ProviderProtocol {
             throw NetworkError.url
         }
 
-        Logger.network("[Request(\(endpoint.method.rawValue)) \(endpoint.path)]")
+        #if DEBUG
+        Logger.network("[Request(\(endpoint.method.rawValue)) \(urlRequest.url!.absoluteString)]")
         if let requestBody = urlRequest.httpBody,
            let jsonString = String(data: requestBody, encoding: .utf8) {
             Logger.network("[요청 데이터]\n\(jsonString)")
         }
+        #endif
         
         let (data, response) = try await session.data(for: urlRequest)
         guard let response = response as? HTTPURLResponse else { throw NetworkError.response }
@@ -46,11 +48,13 @@ public struct Provider: ProviderProtocol {
         let statusCode = response.statusCode
         let body = try decoder.decode(type, from: data)
         
+        #if DEBUG
         Logger.network("[Response(\(statusCode))]")
         if let encodingData = try? encoder.encode(body),
            let jsonString = String(data: encodingData, encoding: .utf8) {
             Logger.network("[응답 데이터]\n\(jsonString)")
         }
+        #endif
         
         switch statusCode {
         case 200..<300:

--- a/iOS/moti/moti/Data/Sources/Repository/AchievementListRepository.swift
+++ b/iOS/moti/moti/Data/Sources/Repository/AchievementListRepository.swift
@@ -16,12 +16,26 @@ public struct AchievementListRepository: AchievementListRepositoryProtocol {
         self.provider = provider
     }
     
-    public func fetchAchievementList(requestValue: FetchAchievementListRequestValue? = nil) async throws -> [Achievement] {
+    public func fetchAchievementList(
+        requestValue: FetchAchievementListRequestValue? = nil
+    ) async throws -> ([Achievement], FetchAchievementListRequestValue?) {
         let endpoint = MotiAPI.fetchAchievementList(requestValue: requestValue)
         let responseDTO = try await provider.request(with: endpoint, type: AchievementListResponseDTO.self)
         
         guard let achievementListDataDTO = responseDTO.data else { throw NetworkError.decode }
         guard let achievementListDTO = achievementListDataDTO.data else { throw NetworkError.decode }
-        return achievementListDTO.map { Achievement(dto: $0) }
+        
+        let achievements = achievementListDTO.map { Achievement(dto: $0) }
+        if let nextDTO = achievementListDataDTO.next {
+            let next = FetchAchievementListRequestValue(
+                categoryId: nextDTO.categoryId ?? -1,
+                take: nextDTO.take ?? -1,
+                whereIdLessThan: nextDTO.whereIdLessThan ?? -1
+            )
+            
+            return (achievements, next)
+        } else {
+            return (achievements, nil)
+        }
     }
 }

--- a/iOS/moti/moti/Data/Tests/DataTests/Repository/AchievementListRepositoryTests.swift
+++ b/iOS/moti/moti/Data/Tests/DataTests/Repository/AchievementListRepositoryTests.swift
@@ -11,6 +11,91 @@ import XCTest
 
 final class AchievementListRepositoryTests: XCTestCase {
 
+    let json = """
+    {
+        "success": true,
+        "data": {
+            "data": [
+                {
+                    "id": 300,
+                    "thumbnailUrl": "https://kr.object.ncloudstorage.com/motimate/study3_thumb.jpg",
+                    "title": "tend"
+                },
+                {
+                    "id": 299,
+                    "thumbnailUrl": "https://kr.object.ncloudstorage.com/motimate/study2_thumb.jpg",
+                    "title": "yard"
+                },
+                {
+                    "id": 298,
+                    "thumbnailUrl": "https://kr.object.ncloudstorage.com/motimate/study2_thumb.jpg",
+                    "title": "improve"
+                },
+                {
+                    "id": 297,
+                    "thumbnailUrl": "https://kr.object.ncloudstorage.com/motimate/study1_thumb.jpg",
+                    "title": "tonight"
+                },
+                {
+                    "id": 296,
+                    "thumbnailUrl": "https://kr.object.ncloudstorage.com/motimate/study3_thumb.jpg",
+                    "title": "drug"
+                },
+                {
+                    "id": 295,
+                    "thumbnailUrl": "https://kr.object.ncloudstorage.com/motimate/study3_thumb.jpg",
+                    "title": "plan"
+                },
+                {
+                    "id": 294,
+                    "thumbnailUrl": "https://kr.object.ncloudstorage.com/motimate/study3_thumb.jpg",
+                    "title": "number"
+                },
+                {
+                    "id": 293,
+                    "thumbnailUrl": "https://kr.object.ncloudstorage.com/motimate/study2_thumb.jpg",
+                    "title": "help"
+                },
+                {
+                    "id": 292,
+                    "thumbnailUrl": "https://kr.object.ncloudstorage.com/motimate/study1_thumb.jpg",
+                    "title": "box"
+                },
+                {
+                    "id": 291,
+                    "thumbnailUrl": "https://kr.object.ncloudstorage.com/motimate/study1_thumb.jpg",
+                    "title": "above"
+                },
+                {
+                    "id": 290,
+                    "thumbnailUrl": "https://kr.object.ncloudstorage.com/motimate/study2_thumb.jpg",
+                    "title": "woman"
+                },
+                {
+                    "id": 289,
+                    "thumbnailUrl": "https://kr.object.ncloudstorage.com/motimate/study1_thumb.jpg",
+                    "title": "accept"
+                }
+            ],
+            "count": 12,
+            "next": {
+                "take": 12,
+                "whereIdLessThan": 289
+            }
+        }
+    }
+    """
+    
+    let emptyDataJson = """
+    {
+        "success" : true,
+        "data" : {
+            "count" : 0,
+            "data" : []
+        }
+    }
+    """
+    
     override func setUpWithError() throws {
         // Put setup code here. This method is called before the invocation of each test method in the class.
     }
@@ -19,15 +104,36 @@ final class AchievementListRepositoryTests: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
 
-    // TODO: xcconfig baseURL nil error
     func test_queryParam_없이_AchievementList_요청시_nil을_return하는가() throws {
-        let repository = MockAchievementListRepository()
+        let repository = MockAchievementListRepository(json: json)
         let expectation = XCTestExpectation(description: "test_queryParam_없이_AchievementList_요청시_nil을_return하는가")
         
         Task {
             let result = try await repository.fetchAchievementList()
         
             XCTAssertNotNil(result)
+            
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: 3)
+    }
+    
+    func test_빈_AchievementList_응답을_디코딩하면_빈배열_return() throws {
+        let emptyAchievementList: [Achievement] = []
+        
+        let repository = MockAchievementListRepository(json: emptyDataJson)
+        let expectation = XCTestExpectation(description: "test_빈_AchievementList_응답을_디코딩하면_빈배열_return")
+        
+        Task {
+            let result = try await repository.fetchAchievementList()
+        
+            let achievements = result.0
+            let next = result.1
+            
+            XCTAssertEqual(achievements, emptyAchievementList)
+            XCTAssertNil(next)
+            
             
             expectation.fulfill()
         }

--- a/iOS/moti/moti/Data/Tests/DataTests/Repository/Mock/MockAchievementListRepository.swift
+++ b/iOS/moti/moti/Data/Tests/DataTests/Repository/Mock/MockAchievementListRepository.swift
@@ -10,88 +10,33 @@ import Foundation
 @testable import Data
 
 public struct MockAchievementListRepository: AchievementListRepositoryProtocol {
-    public init() { }
-    public func fetchAchievementList(requestValue: FetchAchievementListRequestValue? = nil) async throws -> [Achievement] {
-        let json = """
-        {
-            "success": true,
-            "data": {
-                "data": [
-                    {
-                        "id": 300,
-                        "thumbnailUrl": "https://kr.object.ncloudstorage.com/motimate/study3_thumb.jpg",
-                        "title": "tend"
-                    },
-                    {
-                        "id": 299,
-                        "thumbnailUrl": "https://kr.object.ncloudstorage.com/motimate/study2_thumb.jpg",
-                        "title": "yard"
-                    },
-                    {
-                        "id": 298,
-                        "thumbnailUrl": "https://kr.object.ncloudstorage.com/motimate/study2_thumb.jpg",
-                        "title": "improve"
-                    },
-                    {
-                        "id": 297,
-                        "thumbnailUrl": "https://kr.object.ncloudstorage.com/motimate/study1_thumb.jpg",
-                        "title": "tonight"
-                    },
-                    {
-                        "id": 296,
-                        "thumbnailUrl": "https://kr.object.ncloudstorage.com/motimate/study3_thumb.jpg",
-                        "title": "drug"
-                    },
-                    {
-                        "id": 295,
-                        "thumbnailUrl": "https://kr.object.ncloudstorage.com/motimate/study3_thumb.jpg",
-                        "title": "plan"
-                    },
-                    {
-                        "id": 294,
-                        "thumbnailUrl": "https://kr.object.ncloudstorage.com/motimate/study3_thumb.jpg",
-                        "title": "number"
-                    },
-                    {
-                        "id": 293,
-                        "thumbnailUrl": "https://kr.object.ncloudstorage.com/motimate/study2_thumb.jpg",
-                        "title": "help"
-                    },
-                    {
-                        "id": 292,
-                        "thumbnailUrl": "https://kr.object.ncloudstorage.com/motimate/study1_thumb.jpg",
-                        "title": "box"
-                    },
-                    {
-                        "id": 291,
-                        "thumbnailUrl": "https://kr.object.ncloudstorage.com/motimate/study1_thumb.jpg",
-                        "title": "above"
-                    },
-                    {
-                        "id": 290,
-                        "thumbnailUrl": "https://kr.object.ncloudstorage.com/motimate/study2_thumb.jpg",
-                        "title": "woman"
-                    },
-                    {
-                        "id": 289,
-                        "thumbnailUrl": "https://kr.object.ncloudstorage.com/motimate/study1_thumb.jpg",
-                        "title": "accept"
-                    }
-                ],
-                "count": 12,
-                "next": {
-                    "take": 12,
-                    "whereIdLessThan": 289
-                }
-            }
-        }
-        """
-        
+    private let json: String
+    
+    public init(json: String) {
+        self.json = json
+    }
+    
+    public func fetchAchievementList(
+        requestValue: FetchAchievementListRequestValue? = nil
+    ) async throws -> ([Achievement], FetchAchievementListRequestValue?) {
         guard let testData = json.data(using: .utf8) else { throw NetworkError.decode }
-        let achievementListResponseDTO = try JSONDecoder().decode(AchievementListResponseDTO.self, from: testData)
         
-        guard let achievementListResponseDataDTO = achievementListResponseDTO.data else { throw NetworkError.decode }
-        guard let achievementSimpleDTOs = achievementListResponseDataDTO.data else { throw NetworkError.decode }
-        return achievementSimpleDTOs.map { Achievement(dto: $0) }
+        let responseDTO = try JSONDecoder().decode(AchievementListResponseDTO.self, from: testData)
+        guard let achievementListDataDTO = responseDTO.data else { throw NetworkError.decode }
+        
+        guard let achievementListDTO = achievementListDataDTO.data else { throw NetworkError.decode }
+        let achievements = achievementListDTO.map { Achievement(dto: $0) }
+        
+        if let nextDTO = achievementListDataDTO.next {
+            let next = FetchAchievementListRequestValue(
+                categoryId: nextDTO.categoryId ?? -1,
+                take: nextDTO.take ?? -1,
+                whereIdLessThan: nextDTO.whereIdLessThan ?? -1
+            )
+            
+            return (achievements, next)
+        } else {
+            return (achievements, nil)
+        }
     }
 }

--- a/iOS/moti/moti/Domain/Sources/Domain/RepositoryProtocol/AchievementListRepositoryProtocol.swift
+++ b/iOS/moti/moti/Domain/Sources/Domain/RepositoryProtocol/AchievementListRepositoryProtocol.swift
@@ -8,5 +8,7 @@
 import Foundation
 
 public protocol AchievementListRepositoryProtocol {
-    func fetchAchievementList(requestValue: FetchAchievementListRequestValue?) async throws -> [Achievement]
+    func fetchAchievementList(
+        requestValue: FetchAchievementListRequestValue?
+    ) async throws -> ([Achievement], FetchAchievementListRequestValue?)
 }

--- a/iOS/moti/moti/Domain/Sources/Domain/UseCase/FetchAchievementListUseCase.swift
+++ b/iOS/moti/moti/Domain/Sources/Domain/UseCase/FetchAchievementListUseCase.swift
@@ -9,10 +9,10 @@ import Foundation
 
 public struct FetchAchievementListRequestValue: RequestValue {
     public let categoryId: Int
-    public let take: Int
-    public let whereIdLessThan: Int
+    public let take: Int?
+    public let whereIdLessThan: Int?
     
-    public init(categoryId: Int, take: Int, whereIdLessThan: Int) {
+    public init(categoryId: Int, take: Int?, whereIdLessThan: Int?) {
         self.categoryId = categoryId
         self.take = take
         self.whereIdLessThan = whereIdLessThan
@@ -28,7 +28,7 @@ public struct FetchAchievementListUseCase {
     
     public func execute(
         requestValue: FetchAchievementListRequestValue? = nil
-    ) async throws -> ([Achievement], FetchAchievementListRequestValue?)  {
+    ) async throws -> ([Achievement], FetchAchievementListRequestValue?) {
         return try await repository.fetchAchievementList(requestValue: requestValue)
     }
 }

--- a/iOS/moti/moti/Domain/Sources/Domain/UseCase/FetchAchievementListUseCase.swift
+++ b/iOS/moti/moti/Domain/Sources/Domain/UseCase/FetchAchievementListUseCase.swift
@@ -11,6 +11,12 @@ public struct FetchAchievementListRequestValue: RequestValue {
     public let categoryId: Int
     public let take: Int
     public let whereIdLessThan: Int
+    
+    public init(categoryId: Int, take: Int, whereIdLessThan: Int) {
+        self.categoryId = categoryId
+        self.take = take
+        self.whereIdLessThan = whereIdLessThan
+    }
 }
 
 public struct FetchAchievementListUseCase {
@@ -20,7 +26,9 @@ public struct FetchAchievementListUseCase {
         self.repository = repository
     }
     
-    public func execute(requestValue: FetchAchievementListRequestValue? = nil) async throws -> [Achievement] {
+    public func execute(
+        requestValue: FetchAchievementListRequestValue? = nil
+    ) async throws -> ([Achievement], FetchAchievementListRequestValue?)  {
         return try await repository.fetchAchievementList(requestValue: requestValue)
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeView.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeView.swift
@@ -56,7 +56,7 @@ final class HomeView: UIView {
     }
     
     // MARK: - Methods
-    func updateAchievementHeader(with category: CategoryItem) {
+    func updateAchievementHeader(with category: CategoryItem) {        
         guard let header = achievementCollectionView.visibleSupplementaryViews(
             ofKind: UICollectionView.elementKindSectionHeader
         ).first as? HeaderView else { return }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewController.swift
@@ -202,6 +202,15 @@ extension HomeViewController: UICollectionViewDelegate {
         layoutView.updateAchievementHeader(with: category)
     }
     
+    func collectionView(_ collectionView: UICollectionView, willDisplaySupplementaryView view: UICollectionReusableView, forElementKind elementKind: String, at indexPath: IndexPath) {
+        guard elementKind == UICollectionView.elementKindSectionHeader,
+              let headerView = view as? HeaderView else { return }
+        
+        if let currentCategory = viewModel.currentCategory {
+            headerView.configure(category: currentCategory)
+        }
+    }
+    
     func collectionView(_ collectionView: UICollectionView, didEndDisplaying cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
         guard let cell = cell as? AchievementCollectionViewCell else { return }
         cell.cancelDownloadImage()

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewController.swift
@@ -15,6 +15,7 @@ final class HomeViewController: BaseViewController<HomeView> {
     weak var coordinator: HomeCoordinator?
     private let viewModel: HomeViewModel
     private var cancellables: Set<AnyCancellable> = []
+    private var isFetchingNextPage = false
     
     init(viewModel: HomeViewModel) {
         self.viewModel = viewModel
@@ -41,9 +42,19 @@ final class HomeViewController: BaseViewController<HomeView> {
     private func bind() {
         viewModel.$achievementState
             .receive(on: DispatchQueue.main)
-            .sink { state in
+            .sink { [weak self] state in
+                guard let self else { return }
                 // state 에 따른 뷰 처리 - 스켈레톤 뷰, fetch 에러 뷰 등
                 Logger.debug(state)
+                switch state {
+                case .finish:
+                    isFetchingNextPage = false
+                case .error(let message):
+                    isFetchingNextPage = false
+                    Logger.error("Fetch Achievement Error: \(message)")
+                default: break
+                }
+                
             }
             .store(in: &cancellables)
         
@@ -72,7 +83,6 @@ final class HomeViewController: BaseViewController<HomeView> {
                 case .none: break
                 case .loading:
                     layoutView.catergoryAddButton.isEnabled = false
-                    break
                 case .finish:
                     layoutView.catergoryAddButton.isEnabled = true
                 case .error(let message):
@@ -186,7 +196,7 @@ extension HomeViewController: UICollectionViewDelegate {
             cell.transform = .identity
         })
         
-        let category = viewModel.findCategory(at: row)
+        let category = viewModel.selectedCategory(at: row)
         Logger.debug("Selected Category: \(category.name)")
         layoutView.updateAchievementHeader(with: category)
     }
@@ -194,5 +204,18 @@ extension HomeViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didEndDisplaying cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
         guard let cell = cell as? AchievementCollectionViewCell else { return }
         cell.cancelDownloadImage()
+    }
+    
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        let actualPos = scrollView.panGestureRecognizer.translation(in: scrollView.superview)
+        let pos = scrollView.contentOffset.y
+        let diff = layoutView.achievementCollectionView.contentSize.height - scrollView.frame.size.height
+        
+        // 아래로 드래그 && 마지막까지 스크롤
+        if actualPos.y < 0 && pos > diff && !isFetchingNextPage {
+            Logger.debug("Fetch New Data")
+            isFetchingNextPage = true
+            viewModel.action(.fetchNextPage)
+        }
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewController.swift
@@ -196,8 +196,9 @@ extension HomeViewController: UICollectionViewDelegate {
             cell.transform = .identity
         })
         
-        let category = viewModel.selectedCategory(at: row)
+        let category = viewModel.findCategory(at: row)
         Logger.debug("Selected Category: \(category.name)")
+        viewModel.action(.fetchCategoryList(category: category))
         layoutView.updateAchievementHeader(with: category)
     }
     

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewModel.swift
@@ -58,7 +58,7 @@ final class HomeViewModel {
         }
     }
     private var nextRequestValue: FetchAchievementListRequestValue?
-    private var currentCategory: CategoryItem?
+    private(set) var currentCategory: CategoryItem?
     
     @Published private(set) var categoryState: CategoryState = .initial
     @Published private(set) var addCategoryState: AddCategoryState = .none

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewModel.swift
@@ -58,6 +58,7 @@ final class HomeViewModel {
         }
     }
     private var nextRequestValue: FetchAchievementListRequestValue?
+    private var currentCategory: CategoryItem?
     
     @Published private(set) var categoryState: CategoryState = .initial
     @Published private(set) var addCategoryState: AddCategoryState = .none
@@ -143,6 +144,11 @@ final class HomeViewModel {
     }
     
     private func fetchCategoryAchievementList(category: CategoryItem) {
+        guard currentCategory != category else {
+            Logger.debug("현재 카테고리입니다.")
+            return
+        }
+        currentCategory = category
         // 새로운 카테고리 데이터를 가져오기 때문에 빈 배열로 초기화
         achievements = []
         


### PR DESCRIPTION
## PR 요약
- 선택한 카테고리의 달성기록 리스트를 요청한다.
- 스크롤을 내리면 다음 페이지를 요청한다.
~~- 버그~~
    ~~- 스크롤을 내리고 카테고리를 변경하면 HeaderView가 변경이 안 됨~~
    ~~- HeaderView가 현재 화면에 보이지 않기 때문에 View를 못 가져오는 현상~~
    ~~- 수정 방법 찾는 중~~
    - 해결 완료 (willDisplaySupplementaryView 사용)

##### 스크린샷
![Simulator Screen Recording - iPhone 15 Pro - 2023-11-23 at 00 49 26](https://github.com/boostcampwm2023/iOS02-moti/assets/89075274/5a97c003-aa1a-4d8e-af5b-d34f038112a8)

#### Linked Issue
close #186 
close #200 
