### PR TITLE
Achievement를 주입받아 EditAchievementViewController 생성

### DIFF
--- a/iOS/moti/moti/Presentation/Sources/Presentation/Capture/CaptureCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Capture/CaptureCoordinator.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import Core
+import Domain
 
 final class CaptureCoordinator: Coordinator {
     var parentCoordinator: Coordinator?

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Common/TextViewBottomSheet.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Common/TextViewBottomSheet.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import Combine
 
 final class TextViewBottomSheet: UIViewController {
 
@@ -15,15 +16,79 @@ final class TextViewBottomSheet: UIViewController {
         return textView
     }()
     
+    private var isPlaceHolder = true
+    private let placeholder = "(선택) 도전 성공한 소감이 어떠신가요?\n소감을 기록해 보세요!"
+    
+    var text: String {
+        return isPlaceHolder ? "" : textView.text
+    }
+    
+    // MARK: - Init
+    init(text: String? = nil) {
+        super.init(nibName: nil, bundle: nil)
+        if let text {
+            showText(text)
+        } else {
+            showPlaceholder()
+        }
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Life Cycles
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        
+        textView.delegate = self
+        
         view.backgroundColor = textView.backgroundColor
         view.addSubview(textView)
         textView.atl
             .top(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 40)
             .bottom(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
             .horizontal(equalTo: view.safeAreaLayoutGuide, constant: 20)
+    }
+    
+    // MARK: - Methods
+    func update(body: String) {
+        if body.isEmpty {
+            showPlaceholder()
+        } else {
+            showText(body)
+        }
+    }
+    
+    private func showPlaceholder() {
+        isPlaceHolder = true
+        textView.text = placeholder
+        textView.textColor = .placeholderText
+    }
+    
+    private func hidePlaceholder() {
+        isPlaceHolder = false
+        textView.text = ""
+        textView.textColor = .label
+    }
+    
+    private func showText(_ text: String) {
+        hidePlaceholder()
+        textView.text = text
+    }
+}
+
+extension TextViewBottomSheet: UITextViewDelegate {
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        if isPlaceHolder {
+            hidePlaceholder()
+        }
+    }
+    
+    func textViewDidEndEditing(_ textView: UITextView) {
+        if textView.text.isEmpty {
+            showPlaceholder()
+        }
     }
 }
 

--- a/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementCoordinator.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import Core
+import Data
 
 final class EditAchievementCoordinator: Coordinator {
     var parentCoordinator: Coordinator?
@@ -26,7 +27,13 @@ final class EditAchievementCoordinator: Coordinator {
     }
     
     func startAfterCapture(image: UIImage) {
-        let editAchievementVC = EditAchievementViewController(image: image)
+        let editAchievementVM = EditAchievementViewModel(
+            fetchCategoryListUseCase: .init(repository: CategoryListRepository())
+        )
+        let editAchievementVC = EditAchievementViewController(
+            viewModel: editAchievementVM,
+            image: image
+        )
         editAchievementVC.coordinator = self
         
         editAchievementVC.navigationItem.leftBarButtonItem = UIBarButtonItem(

--- a/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementCoordinator.swift
@@ -8,6 +8,7 @@
 import UIKit
 import Core
 import Data
+import Domain
 
 final class EditAchievementCoordinator: Coordinator {
     var parentCoordinator: Coordinator?
@@ -24,6 +25,26 @@ final class EditAchievementCoordinator: Coordinator {
     
     func start() {
         
+    }
+    
+    func start(achievement: Achievement) {
+        let editAchievementVM = EditAchievementViewModel(
+            fetchCategoryListUseCase: .init(repository: CategoryListRepository())
+        )
+        let editAchievementVC = EditAchievementViewController(
+            viewModel: editAchievementVM,
+            achievement: achievement
+        )
+        editAchievementVC.coordinator = self
+        
+        editAchievementVC.navigationItem.rightBarButtonItem = UIBarButtonItem(
+            barButtonSystemItem: .done,
+            target: self,
+            action: #selector(doneButtonAction)
+        )
+        
+        navigationController.pushViewController(editAchievementVC, animated: true)
+        navigationController.setNavigationBarHidden(false, animated: false)
     }
     
     func startAfterCapture(image: UIImage) {

--- a/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementView.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementView.swift
@@ -8,10 +8,11 @@
 import UIKit
 import Design
 import Domain
+import Jeongfisher
 
 final class EditAchievementView: UIView {
     // MARK: - Views
-    let resultImageView: UIImageView = {
+    private let resultImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.contentMode = .scaleAspectFill
         imageView.backgroundColor = .gray
@@ -23,6 +24,7 @@ final class EditAchievementView: UIView {
         let textField = UITextField()
         textField.font = .largeBold
         textField.placeholder = "도전 성공"
+        textField.returnKeyType = .done
         return textField
     }()
     
@@ -54,6 +56,7 @@ final class EditAchievementView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupUI()
+        titleTextField.delegate = self
     }
     
     required init?(coder: NSCoder) {
@@ -66,21 +69,28 @@ final class EditAchievementView: UIView {
         
         if let category {
             titleTextField.placeholder = "\(category) 도전 성공"
-            categoryButton.setTitle(category, for: .normal)
+            update(category: category)
         }
     }
     
-    func update(image: UIImage) {
-        resultImageView.image = image
-    }
-    
-    func update(title: String) {
-        titleTextField.text = title
+    func configure(achievement: Achievement) {
+        if let url = achievement.imageURL {
+            resultImageView.jf.setImage(with: url)
+        }
+        
+        titleTextField.text = achievement.title
+        if let category = achievement.category {
+            update(category: category)
+        }
     }
     
     func update(category: String) {
         categoryButton.setTitle(category, for: .normal)
         categoryButton.setTitleColor(.label, for: .normal)
+    }
+    
+    func selectCategory(row: Int, inComponent: Int) {
+        categoryPickerView.selectRow(row, inComponent: inComponent, animated: false)
     }
     
     func showCategoryPicker() {
@@ -136,5 +146,13 @@ extension EditAchievementView {
         selectDoneButton.atl
             .right(equalTo: categoryPickerView.rightAnchor, constant: -10)
             .top(equalTo: categoryPickerView.topAnchor, constant: 10)
+    }
+}
+
+// MARK: - UITextFieldDelegate
+extension EditAchievementView: UITextFieldDelegate {
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+        return true
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementView.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementView.swift
@@ -6,8 +6,6 @@
 //
 
 import UIKit
-
-import UIKit
 import Design
 import Domain
 

--- a/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementViewController.swift
@@ -8,18 +8,24 @@
 import UIKit
 import Core
 import Design
+import Combine
 
 final class EditAchievementViewController: BaseViewController<EditAchievementView> {
     
     // MARK: - Properties
     weak var coordinator: EditAchievementCoordinator?
-    private let image: UIImage
+    private let viewModel: EditAchievementViewModel
+    private var cancellables: Set<AnyCancellable> = []
     
-    private let categories: [String] = ["카테고리1", "카테고리2", "카테고리3", "카테고리4", "카테고리5"]
+    private let image: UIImage
     private var bottomSheet = TextViewBottomSheet()
     
     // MARK: - Init
-    init(image: UIImage) {
+    init(
+        viewModel: EditAchievementViewModel,
+        image: UIImage
+    ) {
+        self.viewModel = viewModel
         self.image = image
         super.init(nibName: nil, bundle: nil)
     }
@@ -32,12 +38,15 @@ final class EditAchievementViewController: BaseViewController<EditAchievementVie
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        layoutView.configure(image: image)
-        showBottomSheet()
+        viewModel.action(.fetchCategories)
         addTarget()
-
+        bind()
+        
         layoutView.categoryPickerView.delegate = self
         layoutView.categoryPickerView.dataSource = self
+        
+        layoutView.configure(image: image)
+        showBottomSheet()
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -47,6 +56,19 @@ final class EditAchievementViewController: BaseViewController<EditAchievementVie
     
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         view.endEditing(true)
+    }
+    
+    private func bind() {
+        viewModel.$categoryState
+            .receive(on: RunLoop.main)
+            .sink { [weak self] state in
+                switch state {
+                case .none, .loading: break
+                case .finish:
+                    self?.layoutView.categoryPickerView.reloadAllComponents()
+                }
+            }
+            .store(in: &cancellables)
     }
     
     private func addTarget() {
@@ -97,7 +119,7 @@ extension EditAchievementViewController {
 
 extension EditAchievementViewController: UIPickerViewDelegate {
     func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
-        layoutView.update(category: categories[row])
+        layoutView.update(category: viewModel.findCategory(at: row).name)
     }
 }
 
@@ -107,10 +129,10 @@ extension EditAchievementViewController: UIPickerViewDataSource {
     }
 
     func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
-        return categories.count
+        return viewModel.categories.count
     }
 
     func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
-        return categories[row]
+        return viewModel.findCategory(at: row).name
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementViewModel.swift
@@ -22,6 +22,9 @@ final class EditAchievementViewModel {
     
     private let fetchCategoryListUseCase: FetchCategoryListUseCase
     private(set) var categories: [CategoryItem] = []
+    var firstCategory: CategoryItem? {
+        return categories.first
+    }
     
     @Published private(set) var categoryState: CategoryState = .none
     
@@ -40,6 +43,13 @@ final class EditAchievementViewModel {
     
     func findCategory(at index: Int) -> CategoryItem {
         return categories[index]
+    }
+    
+    func findCategoryIndex(_ name: String) -> Int? {
+        for (index, category) in categories.enumerated() where name == category.name {
+            return index
+        }
+        return nil
     }
     
     private func fetchCategories() {

--- a/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementViewModel.swift
@@ -1,0 +1,61 @@
+//
+//  EditAchievementViewModel.swift
+//
+//
+//  Created by 유정주 on 11/23/23.
+//
+
+import Foundation
+import Domain
+
+final class EditAchievementViewModel {
+    
+    enum Action {
+        case fetchCategories
+    }
+    
+    enum CategoryState {
+        case none
+        case loading
+        case finish
+    }
+    
+    private let fetchCategoryListUseCase: FetchCategoryListUseCase
+    private(set) var categories: [CategoryItem] = []
+    
+    @Published private(set) var categoryState: CategoryState = .none
+    
+    init(
+        fetchCategoryListUseCase: FetchCategoryListUseCase
+    ) {
+        self.fetchCategoryListUseCase = fetchCategoryListUseCase
+    }
+
+    func action(_ action: Action) {
+        switch action {
+        case .fetchCategories:
+            fetchCategories()
+        }
+    }
+    
+    func findCategory(at index: Int) -> CategoryItem {
+        return categories[index]
+    }
+    
+    private func fetchCategories() {
+        Task {
+            do {
+                categoryState = .loading
+                categories = try await fetchCategoryListUseCase.execute()
+                if !categories.isEmpty {
+                    // 전체 카테고리 제거
+                    categories.removeFirst()
+                }
+            } catch {
+                categories = []
+            }
+            
+            categoryState = .finish
+        }
+    }
+}


### PR DESCRIPTION
## PR 요약
- Achievement를 주입받아 EditAchievementViewController 생성
- EditAchievementViewController에서 카테고리 리스트 API 호출

#### 변경 사항
- 상세 화면 - 편집을 누를 때 EditAchievementViewController에 achievement를 전달해서 생성하세요.

#### Linked Issue
close #210 
close #211 
