### PR TITLE
[BE] chore: v0.1에 대한 plist 링크 추가

### DIFF
--- a/BE/public/index.html
+++ b/BE/public/index.html
@@ -5,6 +5,9 @@
 </head>
 <body>
 <p>모티 앱 v0.0 <a href="itms-services://?action=download-manifest&amp;url=https://kr.object.ncloudstorage.com/motimate-deploy/manifest.plist">Download</a></p>
-<p>Last updated: 2023-11-16 23:18</p>
+
+<p>모티 앱 v0.1 <a href="itms-services://?action=download-manifest&amp;url=https://kr.object.ncloudstorage.com/motimate-deploy/manifest-0.1.plist">Download</a></p>
+<p>Last updated: 2023-11-23 20:02</p>
+
 </body>
 </html>


### PR DESCRIPTION
## PR 요약
- 배포 홈페이지에 v0.1에대한 plist 링크 추가
 

##### 스크린샷
<img width="266" alt="image" src="https://github.com/boostcampwm2023/iOS02-moti/assets/34297340/77c585d1-e167-4107-8bd9-ae16f51def9b">
