### PR TITLE
커스텀 ParseIntPipe 만들기

### DIFF
--- a/BE/src/achievement/controller/achievement.controller.ts
+++ b/BE/src/achievement/controller/achievement.controller.ts
@@ -1,11 +1,4 @@
-import {
-  Controller,
-  Get,
-  Param,
-  ParseIntPipe,
-  Query,
-  UseGuards,
-} from '@nestjs/common';
+import { Controller, Get, Param, Query, UseGuards } from '@nestjs/common';
 import { AchievementService } from '../application/achievement.service';
 import { AccessTokenGuard } from '../../auth/guard/access-token.guard';
 import { AuthenticatedUser } from '../../auth/decorator/athenticated-user.decorator';
@@ -15,6 +8,7 @@ import { PaginateAchievementRequest } from '../dto/paginate-achievement-request'
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { PaginateAchievementResponse } from '../dto/paginate-achievement-response';
 import { AchievementDetailResponse } from '../dto/achievement-detail-response';
+import { ParseIntPipe } from '../../common/pipe/parse-int.pipe';
 
 @Controller('/api/v1/achievements')
 @ApiTags('달성기록 API')

--- a/BE/src/common/pipe/parse-int.pipe.spec.ts
+++ b/BE/src/common/pipe/parse-int.pipe.spec.ts
@@ -1,0 +1,46 @@
+import { ParseIntPipe } from './parse-int.pipe';
+import { ArgumentMetadata } from '@nestjs/common';
+import { MotimateException } from '../exception/motimate.excpetion';
+
+describe('Custom ParseIntPipe test', () => {
+  it('numeric 인자가 들어온 경우에는 int로 변경한다.', async () => {
+    const target: ParseIntPipe = new ParseIntPipe();
+    const metadata: ArgumentMetadata = {
+      data: 'id',
+      metatype: Number,
+      type: 'param',
+    };
+    const parsedInt = target.transform('1', metadata);
+    expect(parsedInt).toBe(1);
+  });
+
+  it('numeric 인자가 아닌 경우에는 MotimateException 던진다.', async () => {
+    const target: ParseIntPipe = new ParseIntPipe();
+    const metadata: ArgumentMetadata = {
+      data: 'id',
+      metatype: Number,
+      type: 'param',
+    };
+    expect(() => target.transform('abc', metadata)).toThrow(
+      new MotimateException({
+        statusCode: 400,
+        message: 'id must be int numeric string',
+      }),
+    );
+  });
+
+  it('소수가 들어오는 경우에는 MotimateException 던진다.', async () => {
+    const target: ParseIntPipe = new ParseIntPipe();
+    const metadata: ArgumentMetadata = {
+      data: 'id',
+      metatype: Number,
+      type: 'param',
+    };
+    expect(() => target.transform('3.14', metadata)).toThrow(
+      new MotimateException({
+        statusCode: 400,
+        message: 'id must be int numeric string',
+      }),
+    );
+  });
+});

--- a/BE/src/common/pipe/parse-int.pipe.ts
+++ b/BE/src/common/pipe/parse-int.pipe.ts
@@ -1,0 +1,18 @@
+import { PipeTransform, Injectable, ArgumentMetadata } from '@nestjs/common';
+import { MotimateException } from '../exception/motimate.excpetion';
+
+@Injectable()
+export class ParseIntPipe implements PipeTransform {
+  transform(value: any, metadata: ArgumentMetadata) {
+    if (isNaN(value) || !this.isIntNumeric(value)) {
+      throw new MotimateException({
+        statusCode: 400,
+        message: `${metadata.data} must be int numeric string`,
+      });
+    }
+    return parseInt(value);
+  }
+  private isIntNumeric(str: string) {
+    return /^\d+$/.test(str);
+  }
+}


### PR DESCRIPTION
## PR 요약
- 응답의 일관성을 위해 MotimateException을 던지도록 수정

##### 스크린샷
- 기존 ParseIntPipe
<img width="589" alt="image" src="https://github.com/boostcampwm2023/iOS02-moti/assets/34297340/491531b3-a0b9-42b5-ba8d-eebfec157b37">

- 커스텀 ParseIntPipe
<img width="612" alt="image" src="https://github.com/boostcampwm2023/iOS02-moti/assets/34297340/aaceaf00-b91b-43f9-86f3-a444c29fcf95">




#### Linked Issue
close #198 
