### PR TITLE
[iOS] feat: bottom sheet에 완료 버튼 추가

### DIFF
--- a/iOS/moti/moti/Presentation/Sources/Presentation/Common/TextViewBottomSheet.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Common/TextViewBottomSheet.swift
@@ -16,6 +16,13 @@ final class TextViewBottomSheet: UIViewController {
         return textView
     }()
     
+    private let doneButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("완료", for: .normal)
+        button.isHidden = true
+        return button
+    }()
+    
     private var isPlaceHolder = true
     private let placeholder = "(선택) 도전 성공한 소감이 어떠신가요?\n소감을 기록해 보세요!"
     
@@ -49,6 +56,17 @@ final class TextViewBottomSheet: UIViewController {
             .top(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 40)
             .bottom(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
             .horizontal(equalTo: view.safeAreaLayoutGuide, constant: 20)
+        
+        view.addSubview(doneButton)
+        doneButton.atl
+            .top(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 10)
+            .right(equalTo: view.safeAreaLayoutGuide.rightAnchor, constant: -10)
+        doneButton.addTarget(self, action: #selector(doneButtonClicked), for: .touchUpInside)
+    }
+    
+    // MARK: - Actions
+    @objc private func doneButtonClicked(_ sender: UIButton) {
+        textView.resignFirstResponder()
     }
     
     // MARK: - Methods
@@ -80,12 +98,14 @@ final class TextViewBottomSheet: UIViewController {
 
 extension TextViewBottomSheet: UITextViewDelegate {
     func textViewDidBeginEditing(_ textView: UITextView) {
+        doneButton.isHidden = false
         if isPlaceHolder {
             hidePlaceholder()
         }
     }
     
     func textViewDidEndEditing(_ textView: UITextView) {
+        doneButton.isHidden = true
         if textView.text.isEmpty {
             showPlaceholder()
         }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementCoordinator.swift
@@ -68,7 +68,7 @@ final class EditAchievementCoordinator: Coordinator {
             action: #selector(doneButtonAction)
         )
         
-        navigationController.pushViewController(editAchievementVC, animated: true)
+        navigationController.pushViewController(editAchievementVC, animated: false)
         navigationController.setNavigationBarHidden(false, animated: false)
     }
     

--- a/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementViewController.swift
@@ -60,7 +60,10 @@ final class EditAchievementViewController: BaseViewController<EditAchievementVie
         
         layoutView.categoryPickerView.delegate = self
         layoutView.categoryPickerView.dataSource = self
-        
+    }
+    
+    override func viewIsAppearing(_ animated: Bool) {
+        super.viewIsAppearing(animated)
         showBottomSheet()
     }
     


### PR DESCRIPTION
## PR 요약
- 키보드가 올라왔을 때 완료 버튼을 표시
- 완료 버튼을 누르면 bottom sheet이 내려감
- 다시 촬영을 할 때 session만 start 하는거로 변경함. 기존에는 카메라를 전부 다시 세팅
- 촬영한 뒤 편집 화면으로 이동할 때 애니메이션 제거

##### 스크린샷
<img src = "https://github.com/boostcampwm2023/iOS02-moti/assets/89075274/d134c8b8-59c0-440b-80df-2265ed021ead" width = "30%">
<img src = "https://github.com/boostcampwm2023/iOS02-moti/assets/89075274/aa18e22b-7ad4-45e7-b849-564e9b09f0b3" width = "30%">

#### Linked Issue
close #247 
