### PR TITLE
swagger 옵션 추가 및 보완하기

### DIFF
--- a/BE/src/achievement/controller/achievement.controller.ts
+++ b/BE/src/achievement/controller/achievement.controller.ts
@@ -12,7 +12,12 @@ import { AuthenticatedUser } from '../../auth/decorator/athenticated-user.decora
 import { User } from '../../users/domain/user.domain';
 import { ApiData } from '../../common/api/api-data';
 import { PaginateAchievementRequest } from '../dto/paginate-achievement-request';
-import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
 import { PaginateAchievementResponse } from '../dto/paginate-achievement-response';
 import { AchievementDetailResponse } from '../dto/achievement-detail-response';
 
@@ -32,6 +37,7 @@ export class AchievementController {
     description: '달성기록 리스트',
     type: PaginateAchievementResponse,
   })
+  @ApiBearerAuth('accessToken')
   async getAchievements(
     @AuthenticatedUser() user: User,
     @Query() paginateAchievementRequest: PaginateAchievementRequest,
@@ -54,6 +60,7 @@ export class AchievementController {
     description: '달성기록 상세정보',
     type: AchievementDetailResponse,
   })
+  @ApiBearerAuth('accessToken')
   async getAchievement(
     @AuthenticatedUser() user: User,
     @Param('id', ParseIntPipe) id: number,

--- a/BE/src/achievement/dto/paginate-achievement-request.ts
+++ b/BE/src/achievement/dto/paginate-achievement-request.ts
@@ -4,17 +4,17 @@ import { ApiProperty } from '@nestjs/swagger';
 export class PaginateAchievementRequest {
   @IsNumber()
   @IsOptional()
-  @ApiProperty({ description: 'next cursor id' })
+  @ApiProperty({ description: 'next cursor id', required: false })
   whereIdLessThan?: number;
 
   @IsNumber()
   @IsOptional()
-  @ApiProperty({ description: 'take' })
+  @ApiProperty({ description: 'take', required: false })
   take: number;
 
   @IsNumber()
   @IsOptional()
-  @ApiProperty({ description: 'categoryId' })
+  @ApiProperty({ description: 'categoryId', required: false })
   categoryId: number;
 
   constructor(

--- a/BE/src/admin/controller/admin-rest.controller.ts
+++ b/BE/src/admin/controller/admin-rest.controller.ts
@@ -14,7 +14,13 @@ import { User } from '../../users/domain/user.domain';
 import { AdminLogin } from '../dto/admin-login';
 import { ApiData } from '../../common/api/api-data';
 import { AdminToken } from '../dto/admin-token';
-import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
 import { AdminTokenGuard } from '../../auth/guard/admin-token.guard';
 
 @Controller('/api/v1/admin')
@@ -28,6 +34,9 @@ export class AdminRestController {
   @ApiOperation({
     summary: '어드민 등록 요청 API',
     description: '어드민 등록 요청',
+  })
+  @ApiResponse({
+    description: '요청 접수완료',
   })
   @ApiBearerAuth('accessToken')
   async registerAdmin(
@@ -45,6 +54,10 @@ export class AdminRestController {
     summary: '어드민 로그인 API',
     description: 'email, password',
   })
+  @ApiResponse({
+    description: 'AdminToken',
+    type: AdminToken,
+  })
   async loginAdmin(
     @Body() loginRequest: AdminLogin,
   ): Promise<ApiData<AdminToken>> {
@@ -58,6 +71,10 @@ export class AdminRestController {
     summary: '어드민 요청 수락 API',
     description: '어드민 계정만 요청을 수락 가능',
   })
+  @ApiResponse({
+    description: '어드민 등록 완료',
+  })
+  @ApiQuery({ name: 'email' })
   @ApiBearerAuth('accessToken')
   async acceptAdminRegister(
     @AuthenticatedUser() accepter: User,

--- a/BE/src/admin/controller/admin-rest.controller.ts
+++ b/BE/src/admin/controller/admin-rest.controller.ts
@@ -14,7 +14,7 @@ import { User } from '../../users/domain/user.domain';
 import { AdminLogin } from '../dto/admin-login';
 import { ApiData } from '../../common/api/api-data';
 import { AdminToken } from '../dto/admin-token';
-import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { AdminTokenGuard } from '../../auth/guard/admin-token.guard';
 
 @Controller('/api/v1/admin')
@@ -29,6 +29,7 @@ export class AdminRestController {
     summary: '어드민 등록 요청 API',
     description: '어드민 등록 요청',
   })
+  @ApiBearerAuth('accessToken')
   async registerAdmin(
     @Body() registerRequest: AdminRegister,
     @AuthenticatedUser() user: User,
@@ -57,6 +58,7 @@ export class AdminRestController {
     summary: '어드민 요청 수락 API',
     description: '어드민 계정만 요청을 수락 가능',
   })
+  @ApiBearerAuth('accessToken')
   async acceptAdminRegister(
     @AuthenticatedUser() accepter: User,
     @Query() email: string,

--- a/BE/src/admin/dto/admin-login.ts
+++ b/BE/src/admin/dto/admin-login.ts
@@ -1,14 +1,17 @@
 import { IsNotEmptyString } from '../../config/config/validation-decorator';
 import { IsEmail } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class AdminLogin {
   @IsEmail(
     { domain_specific_validation: true, allow_display_name: false },
     { message: '이메일을 확인해주세요' },
   )
+  @ApiProperty({ description: 'email' })
   email: string;
 
   @IsNotEmptyString({ message: '비밀번호를 확인해주세요' })
+  @ApiProperty({ description: 'password' })
   password: string;
 
   constructor(email: string, password: string) {

--- a/BE/src/admin/dto/admin-register.ts
+++ b/BE/src/admin/dto/admin-register.ts
@@ -5,20 +5,24 @@ import {
 } from '../../config/config/validation-decorator';
 import { User } from '../../users/domain/user.domain';
 import { Admin } from '../domain/admin.domain';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class AdminRegister {
   @IsEmail(
     { domain_specific_validation: true, allow_display_name: false },
     { message: '이메일을 확인해주세요' },
   )
+  @ApiProperty({ description: 'email' })
   email: string;
 
   @IsNotEmptyString({ message: '비밀번호를 확인해주세요' })
+  @ApiProperty({ description: 'password' })
   password: string;
 
   @IsSameValueAs('password', {
     message: '비밀번호와 일치하지 않습니다.',
   })
+  @ApiProperty({ description: 'repeatedPassword' })
   repeatedPassword: string;
 
   constructor(email: string, password: string, repeatedPassword: string) {

--- a/BE/src/auth/controller/auth.controller.ts
+++ b/BE/src/auth/controller/auth.controller.ts
@@ -5,6 +5,7 @@ import {
   ApiBearerAuth,
   ApiCreatedResponse,
   ApiOperation,
+  ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
 import { ApiData } from '../../common/api/api-data';
@@ -13,6 +14,7 @@ import { RefreshAuthRequestDto } from '../dto/refresh-auth-request.dto';
 import { AccessTokenGuard } from '../guard/access-token.guard';
 import { User } from '../../users/domain/user.domain';
 import { AuthenticatedUser } from '../decorator/athenticated-user.decorator';
+import { RefreshAuthResponseDto } from '../dto/refresh-auth-response.dto';
 
 @Controller('/api/v1/auth')
 @ApiTags('auth API')
@@ -36,6 +38,15 @@ export class AuthController {
 
   @Post('refresh')
   @UseGuards(AccessTokenGuard)
+  @ApiOperation({
+    summary: 'refresh API',
+    description: 'refreshToken을 통해 accessToken을 재발급한다.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '새로운 accessToken과 유저정보',
+    type: RefreshAuthResponseDto,
+  })
   @ApiBearerAuth('accessToken')
   async refresh(
     @AuthenticatedUser() user: User,

--- a/BE/src/auth/controller/auth.controller.ts
+++ b/BE/src/auth/controller/auth.controller.ts
@@ -1,7 +1,12 @@
 import { Body, Controller, Post, UseGuards } from '@nestjs/common';
 import { AuthService } from '../application/auth.service';
 import { AppleLoginRequest } from '../dto/apple-login-request.dto';
-import { ApiCreatedResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import {
+  ApiBearerAuth,
+  ApiCreatedResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
 import { ApiData } from '../../common/api/api-data';
 import { AppleLoginResponse } from '../dto/apple-login-response.dto';
 import { RefreshAuthRequestDto } from '../dto/refresh-auth-request.dto';
@@ -31,6 +36,7 @@ export class AuthController {
 
   @Post('refresh')
   @UseGuards(AccessTokenGuard)
+  @ApiBearerAuth('accessToken')
   async refresh(
     @AuthenticatedUser() user: User,
     @Body() refreshAuthRequestDto: RefreshAuthRequestDto,

--- a/BE/src/category/controller/category-legacy.controller.ts
+++ b/BE/src/category/controller/category-legacy.controller.ts
@@ -7,7 +7,7 @@ import {
 } from '@nestjs/common';
 import { CategoryService } from '../application/category.service';
 import { AccessTokenGuard } from '../../auth/guard/access-token.guard';
-import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { AuthenticatedUser } from '../../auth/decorator/athenticated-user.decorator';
 import { User } from '../../users/domain/user.domain';
 import { ApiData } from '../../common/api/api-data';
@@ -26,6 +26,7 @@ export class CategoryLegacyController {
     description:
       '사용자 본인에 대한 카테고리를 조회합니다.(Legacy)\nAPI 포맷이 변경되었습니다.',
   })
+  @ApiBearerAuth('accessToken')
   async getCategoriesLegacy(
     @AuthenticatedUser() user: User,
   ): Promise<ApiData<CategoryListLegacyResponse>> {

--- a/BE/src/category/controller/category.controller.ts
+++ b/BE/src/category/controller/category.controller.ts
@@ -9,7 +9,7 @@ import {
 } from '@nestjs/common';
 import { CategoryService } from '../application/category.service';
 import { CategoryCreate } from '../dto/category-create';
-import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { ApiData } from '../../common/api/api-data';
 import { AuthenticatedUser } from '../../auth/decorator/athenticated-user.decorator';
 import { User } from '../../users/domain/user.domain';
@@ -29,6 +29,7 @@ export class CategoryController {
     summary: '카테고리 생성 API',
     description: '카테고리를 생성합니다.',
   })
+  @ApiBearerAuth('accessToken')
   async saveCategory(
     @Body() categoryCreate: CategoryCreate,
     @AuthenticatedUser() user: User,
@@ -47,6 +48,7 @@ export class CategoryController {
     summary: '카테고리 조회 API',
     description: '사용자 본인에 대한 카테고리를 조회합니다.',
   })
+  @ApiBearerAuth('accessToken')
   async getCategories(
     @AuthenticatedUser() user: User,
   ): Promise<ApiData<CategoryListElementResponse[]>> {

--- a/BE/src/category/controller/category.controller.ts
+++ b/BE/src/category/controller/category.controller.ts
@@ -9,7 +9,13 @@ import {
 } from '@nestjs/common';
 import { CategoryService } from '../application/category.service';
 import { CategoryCreate } from '../dto/category-create';
-import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import {
+  ApiBearerAuth,
+  ApiCreatedResponse,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
 import { ApiData } from '../../common/api/api-data';
 import { AuthenticatedUser } from '../../auth/decorator/athenticated-user.decorator';
 import { User } from '../../users/domain/user.domain';
@@ -29,6 +35,10 @@ export class CategoryController {
     summary: '카테고리 생성 API',
     description: '카테고리를 생성합니다.',
   })
+  @ApiCreatedResponse({
+    description: '카테고리 생성',
+    type: CategoryResponse,
+  })
   @ApiBearerAuth('accessToken')
   async saveCategory(
     @Body() categoryCreate: CategoryCreate,
@@ -47,6 +57,10 @@ export class CategoryController {
   @ApiOperation({
     summary: '카테고리 조회 API',
     description: '사용자 본인에 대한 카테고리를 조회합니다.',
+  })
+  @ApiResponse({
+    description: '카테고리 리스트',
+    type: [CategoryListElementResponse],
   })
   @ApiBearerAuth('accessToken')
   async getCategories(

--- a/BE/src/category/dto/category-list-element.response.ts
+++ b/BE/src/category/dto/category-list-element.response.ts
@@ -1,10 +1,18 @@
 import { CategoryMetaData } from './category-metadata';
 import { dateFormat } from '../../common/utils/date-formatter';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class CategoryListElementResponse {
+  @ApiProperty({ description: 'id' })
   id: number;
+  @ApiProperty({ description: 'name' })
   name: string;
+  @ApiProperty({ description: 'continued' })
   continued: number;
+  @ApiProperty({
+    description: 'lastChallenged',
+    example: '2023-11-23T15:35:26Z',
+  })
   lastChallenged: string;
 
   constructor(category: CategoryMetaData) {

--- a/BE/src/category/dto/category-list-legacy.response.ts
+++ b/BE/src/category/dto/category-list-legacy.response.ts
@@ -10,7 +10,6 @@ interface CategoryLegacyList {
 export class CategoryListLegacyResponse {
   @ApiProperty({ description: '카테고리 키 리스트' })
   categoryNames: string[] = [];
-  @ApiProperty({ description: '카테고리 데이터' })
   categories: CategoryLegacyList = {};
 
   constructor(categoryMetaData: CategoryMetaData[]) {

--- a/BE/src/config/swagger/index.ts
+++ b/BE/src/config/swagger/index.ts
@@ -10,6 +10,16 @@ export const swaggerConfig = (app: INestApplication) => {
     .setDescription(configService.get<string>('SWAGGER_DESCRIPTION'))
     .setVersion(configService.get<string>('SWAGGER_VERSION'))
     .addTag(configService.get<string>('SWAGGER_TAG'))
+    .addBearerAuth(
+      {
+        type: 'http',
+        scheme: 'bearer',
+        name: 'accessToken',
+        description: 'motimate access token (jwt)',
+        in: 'header',
+      },
+      'accessToken',
+    )
     .build();
 
   const document = SwaggerModule.createDocument(app, config);

--- a/BE/src/operate/controller/operate-mvc.controller.ts
+++ b/BE/src/operate/controller/operate-mvc.controller.ts
@@ -1,9 +1,21 @@
 import { Controller, Get, Res } from '@nestjs/common';
 import { Response } from 'express';
+import { ApiOperation, ApiResponse } from '@nestjs/swagger';
 
 @Controller('operate')
 export class OperateMvcController {
   @Get()
+  @ApiOperation({
+    summary: '모티 메이트 앱 배포 사이트',
+    description: '모티 메이트 앱 배포 사이트',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '모티 메이트 앱 배포 사이트',
+    content: {
+      'text/html': {},
+    },
+  })
   async getOperate(@Res() res: Response) {
     res.sendFile('index.html', { root: 'public' });
   }

--- a/BE/src/operate/controller/operate.controller.ts
+++ b/BE/src/operate/controller/operate.controller.ts
@@ -1,7 +1,7 @@
 import { Body, Controller, Get, Patch, Post, Put } from '@nestjs/common';
 import { OperateService } from '../application/operate.service';
 import { MotiPolicyResponse } from '../dto/moti-policy-response';
-import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { MotiPolicyCreate } from '../dto/moti-policy-create';
 import { ApiData } from '../../common/api/api-data';
 import { MotiPolicyIdempotentUpdate } from '../dto/moti-policy-idempotent-update';
@@ -17,6 +17,10 @@ export class OperateController {
     summary: '모티메이트 운영정책 초기화 API',
     description: '운영 정책은 1개만 등록 가능',
   })
+  @ApiResponse({
+    description: '운영 정책',
+    type: MotiPolicyResponse,
+  })
   async initPolicy(
     @Body() initPolicy: MotiPolicyCreate,
   ): Promise<ApiData<MotiPolicyResponse>> {
@@ -29,6 +33,10 @@ export class OperateController {
     summary: '모티메이트 운영정책 조회 API',
     description: '모티메이트의 현재 버전, 최소 번전, 보안 정책을 조회',
   })
+  @ApiResponse({
+    description: '운영 정책',
+    type: MotiPolicyResponse,
+  })
   async getPolicy(): Promise<ApiData<MotiPolicyResponse>> {
     const policy = await this.operateService.retrieveMotimateOperation();
     return ApiData.success(MotiPolicyResponse.from(policy));
@@ -38,6 +46,10 @@ export class OperateController {
   @ApiOperation({
     summary: '모티메이트 운영정책 업데이트 API',
     description: '모티메이트의 현재 버전, 최소 번전, 보안 정책을 업데이트',
+  })
+  @ApiResponse({
+    description: '운영 정책',
+    type: MotiPolicyResponse,
   })
   async updateIdempotentPolicy(
     @Body() updatePolicyUpdate: MotiPolicyIdempotentUpdate,
@@ -51,6 +63,10 @@ export class OperateController {
   @ApiOperation({
     summary: '모티메이트 운영정책 업데이트 API',
     description: '모티메이트의 현재 버전, 최소 번전, 보안 정책을 업데이트',
+  })
+  @ApiResponse({
+    description: '운영 정책',
+    type: MotiPolicyResponse,
   })
   async updatePartialPolicy(
     @Body() updatePolicyUpdate: MotiPolicyPartialUpdate,


### PR DESCRIPTION
## PR 요약
- 기존 응답 dto에 관한 누락된 swagger 프로퍼티들 추가
- swagger에서 authorization header 설정하고 쉽게 테스트할 수 있도록 추가

##### 스크린샷
<img width="988" alt="image" src="https://github.com/boostcampwm2023/iOS02-moti/assets/34297340/05e45304-862f-4556-961d-eb9bb62d31a9">
Authorize 버튼을 누르면 access token을 입력할 수 있고,
access token이 필요한 요청인 경우 옆에 좌물쇠로 표현된다.

#### Linked Issue
close #196 
