### PR TITLE
썸네일 저장 API 작성하기

### DIFF
--- a/BE/src/auth/guard/admin-token.guard.ts
+++ b/BE/src/auth/guard/admin-token.guard.ts
@@ -2,13 +2,17 @@ import { ExecutionContext, Injectable } from '@nestjs/common';
 import { AccessTokenGuard } from './access-token.guard';
 import { UserRole } from '../../users/domain/user-role';
 import { User } from '../../users/domain/user.domain';
+import { MotimateException } from '../../common/exception/motimate.excpetion';
+import { ERROR_INFO } from '../../common/exception/error-code';
 
 @Injectable()
 export class AdminTokenGuard extends AccessTokenGuard {
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const req = context.switchToHttp().getRequest();
     if (!(await super.canActivate(context))) return false;
-    return this.validateAdminUser(req.user);
+    if (!this.validateAdminUser(req.user))
+      throw new MotimateException(ERROR_INFO.RESTRICT_ACEESS_TO_ADMIN);
+    return true;
   }
 
   validateAdminUser(user: User): boolean {

--- a/BE/src/common/exception/error-code.ts
+++ b/BE/src/common/exception/error-code.ts
@@ -43,4 +43,16 @@ export const ERROR_INFO = {
     statusCode: 500,
     message: '파일 요청 작업에 실패했습니다.',
   },
+  IMAGE_NOT_FOUND: {
+    statusCode: 400,
+    message: '존재하지 않는 이미지 입니다.',
+  },
+  IMAGE_ALREADY_EXISTS_THUMBNAIL: {
+    statusCode: 400,
+    message: '이미 썸네일이 생성된 이미지 입니다.',
+  },
+  RESTRICT_ACEESS_TO_ADMIN: {
+    statusCode: 403,
+    message: '제한된 요청입니다.',
+  },
 } as const;

--- a/BE/src/image/application/image.service.ts
+++ b/BE/src/image/application/image.service.ts
@@ -4,6 +4,9 @@ import { File, FileStore } from '../../common/application/file-store';
 import { User } from '../../users/domain/user.domain';
 import { Image } from '../domain/image.domain';
 import { ConfigService } from '@nestjs/config';
+import { Transactional } from '../../config/transaction-manager';
+import { ImageNotFoundException } from '../exception/image-not-found.exception';
+import { ImageAlreadyExistsThumbnailException } from '../exception/image-already-exists-thumbnail.exception';
 
 @Injectable()
 export class ImageService {
@@ -16,9 +19,21 @@ export class ImageService {
     this.imagePrefix = configService.get<string>('FILESTORE_IMAGE_PREFIX');
   }
 
+  @Transactional()
   async saveImage(file: File, user: User): Promise<Image> {
     const image = new Image(user);
     await image.uploadOriginalImage(file, this.fileStore, this.imagePrefix);
     return await this.imageRepository.saveImage(image);
+  }
+
+  @Transactional()
+  async saveThumbnail(imageId: number, thumbnailPath: string): Promise<Image> {
+    const findImage = await this.imageRepository.findById(imageId);
+    if (!findImage) throw new ImageNotFoundException();
+    if (findImage.thumbnailUrl)
+      throw new ImageAlreadyExistsThumbnailException();
+
+    findImage.updateThumbnail(thumbnailPath);
+    return await this.imageRepository.saveImage(findImage);
   }
 }

--- a/BE/src/image/controller/image.controller.spec.ts
+++ b/BE/src/image/controller/image.controller.spec.ts
@@ -1,13 +1,14 @@
 import { ImageService } from '../application/image.service';
 import {
   anyNumber,
-  anyOfClass, anyString,
+  anyOfClass,
+  anyString,
   anything,
   instance,
   mock,
   objectContaining,
-  when
-} from "ts-mockito";
+  when,
+} from 'ts-mockito';
 import { Image } from '../domain/image.domain';
 import { User } from '../../users/domain/user.domain';
 import { Test, TestingModule } from '@nestjs/testing';

--- a/BE/src/image/domain/image.domain.ts
+++ b/BE/src/image/domain/image.domain.ts
@@ -25,6 +25,10 @@ export class Image {
     return uploadFile;
   }
 
+  updateThumbnail(thumbnailUrl: string) {
+    this.thumbnailUrl = thumbnailUrl;
+  }
+
   constructor(user: User) {
     this.user = user;
   }

--- a/BE/src/image/dto/thumbnail-request.ts
+++ b/BE/src/image/dto/thumbnail-request.ts
@@ -1,0 +1,8 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmptyString } from '../../config/config/validation-decorator';
+
+export class ThumbnailRequest {
+  @IsNotEmptyString({ message: '잘못된 썸네일 경로입니다.' })
+  @ApiProperty({ description: '저장된 썸네일 경로' })
+  thumbnailUrl: string;
+}

--- a/BE/src/image/entities/image.repository.ts
+++ b/BE/src/image/entities/image.repository.ts
@@ -10,4 +10,12 @@ export class ImageRepository extends TransactionalRepository<ImageEntity> {
     const savedImage = await this.repository.save(imageEntity);
     return savedImage.toModel();
   }
+
+  async findById(id: number): Promise<Image> {
+    const imageEntity = await this.repository.findOneBy({
+      id: id,
+    });
+
+    return imageEntity?.toModel();
+  }
 }

--- a/BE/src/image/exception/image-already-exists-thumbnail.exception.ts
+++ b/BE/src/image/exception/image-already-exists-thumbnail.exception.ts
@@ -1,0 +1,8 @@
+import { MotimateException } from '../../common/exception/motimate.excpetion';
+import { ERROR_INFO } from '../../common/exception/error-code';
+
+export class ImageAlreadyExistsThumbnailException extends MotimateException {
+  constructor() {
+    super(ERROR_INFO.IMAGE_ALREADY_EXISTS_THUMBNAIL);
+  }
+}

--- a/BE/src/image/exception/image-not-found.exception.ts
+++ b/BE/src/image/exception/image-not-found.exception.ts
@@ -1,0 +1,8 @@
+import { MotimateException } from '../../common/exception/motimate.excpetion';
+import { ERROR_INFO } from '../../common/exception/error-code';
+
+export class ImageNotFoundException extends MotimateException {
+  constructor() {
+    super(ERROR_INFO.IMAGE_NOT_FOUND);
+  }
+}

--- a/BE/test/auth/auth-fixture.ts
+++ b/BE/test/auth/auth-fixture.ts
@@ -1,15 +1,32 @@
 import { Injectable } from '@nestjs/common';
 import { UsersFixture } from '../user/users-fixture';
 import { JwtUtils } from '../../src/auth/application/jwt-utils';
-import { UserFixtureData } from './index';
+import { AdminFixtureData, UserFixtureData } from './index';
 import { JwtRolePayloads } from '../../src/auth';
+import { AdminFixture } from '../admin/admin-fixture';
 
 @Injectable()
 export class AuthFixture {
   constructor(
     private readonly userFixture: UsersFixture,
     private readonly jwtUtils: JwtUtils,
+    private readonly adminFixture: AdminFixture,
   ) {}
+
+  async getAuthenticatedAdmin(id: number | string): Promise<AdminFixtureData> {
+    const admin = await this.adminFixture.getAdmin(id);
+    const claim: JwtRolePayloads = {
+      userCode: admin.user.userCode,
+      roles: admin.user.roles,
+    };
+
+    const accessToken = this.jwtUtils.createToken(claim, new Date());
+    return {
+      user: admin.user,
+      admin,
+      accessToken,
+    };
+  }
 
   async getAuthenticatedUser(id: number | string): Promise<UserFixtureData> {
     const user = await this.userFixture.getUser(id);

--- a/BE/test/auth/auth-test.module.ts
+++ b/BE/test/auth/auth-test.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { UsersTestModule } from '../user/users-test.module';
 import { AuthModule } from '../../src/auth/auth.module';
 import { AuthFixture } from './auth-fixture';
+import { AdminTestModule } from '../admin/admin-test.module';
 
 @Module({
-  imports: [UsersTestModule, AuthModule],
+  imports: [UsersTestModule, AuthModule, AdminTestModule],
   exports: [AuthFixture],
   providers: [AuthFixture],
 })

--- a/BE/test/auth/index.ts
+++ b/BE/test/auth/index.ts
@@ -1,6 +1,11 @@
+import { Admin } from 'src/admin/domain/admin.domain';
 import { User } from '../../src/users/domain/user.domain';
 
 export interface UserFixtureData {
   user: User;
   accessToken: string;
+}
+
+export interface AdminFixtureData extends UserFixtureData {
+  admin: Admin;
 }

--- a/BE/test/image/image-fixture.ts
+++ b/BE/test/image/image-fixture.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@nestjs/common';
+import { User } from '../../src/users/domain/user.domain';
+import { ImageRepository } from '../../src/image/entities/image.repository';
+import { Image } from '../../src/image/domain/image.domain';
+import { FileFixture } from '../common/file-store/file-fixture';
+import { FileStore } from '../../src/common/application/file-store';
+
+@Injectable()
+export class ImageFixture {
+  static id = 0;
+
+  constructor(
+    private readonly imageRepository: ImageRepository,
+    private readonly fileStore: FileStore,
+  ) {}
+
+  async getImage(user: User): Promise<Image> {
+    const image = ImageFixture.image(user);
+    return this.imageRepository.saveImage(image);
+  }
+
+  async getImageWithRealFile(user: User, imagePrefix: string): Promise<Image> {
+    const image = ImageFixture.image(user);
+    const file = FileFixture.file(`test${++ImageFixture.id}`, 'jpg');
+    await image.uploadOriginalImage(file, this.fileStore, imagePrefix);
+    return this.imageRepository.saveImage(image);
+  }
+
+  static image(user: User): Image {
+    const image = new Image(user);
+    const file = FileFixture.file(`test${++ImageFixture.id}`, 'jpg');
+    image.originalName = file.originalname;
+    image.imageUrl = file.path;
+    return image;
+  }
+}

--- a/BE/test/image/image-test.module.ts
+++ b/BE/test/image/image-test.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { CustomTypeOrmModule } from '../../src/config/typeorm/custom-typeorm.module';
+import { ImageRepository } from '../../src/image/entities/image.repository';
+import { ImageModule } from '../../src/image/image.module';
+import { ImageFixture } from './image-fixture';
+import { FileStoreModule } from '../../src/common/application/file-store/file-store.module';
+
+@Module({
+  imports: [
+    CustomTypeOrmModule.forCustomRepository([ImageRepository]),
+    ImageModule,
+    FileStoreModule,
+  ],
+  providers: [ImageFixture],
+  exports: [ImageFixture],
+})
+export class ImageTestModule {}


### PR DESCRIPTION
## PR 요약
썸네일 저장 API 작성하기

#### 변경 사항
- 썸네일 저장 API 작성하기
- 썸네일 관련 테스트 코드
- 관련 E2E 테스트
- 어드민 사용자로 가드

#### Linked Issue
close #252 
