### PR TITLE
카테고리, 제목, 내용의 편집 모드로 변한다.

### DIFF
--- a/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementCoordinator.swift
@@ -34,6 +34,19 @@ public final class DetailAchievementCoordinator: Coordinator {
                 achievement: achievement)
         )
         detailAchievementVC.coordinator = self
+        detailAchievementVC.delegate = self
         navigationController.pushViewController(detailAchievementVC, animated: true)
+    }
+    
+    private func moveEditAchievementViewController(achievement: Achievement) {
+        let editAchievementCoordinator = EditAchievementCoordinator(navigationController, self)
+        editAchievementCoordinator.start(achievement: achievement)
+        childCoordinators.append(editAchievementCoordinator)
+    }
+}
+
+extension DetailAchievementCoordinator: DetailAchievementViewControllerDelegate {
+    func editButtonDidClicked(achievement: Achievement) {
+        moveEditAchievementViewController(achievement: achievement)
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementViewController.swift
@@ -9,9 +9,15 @@ import UIKit
 import Design
 import Core
 import Combine
+import Domain
+
+protocol DetailAchievementViewControllerDelegate: AnyObject {
+    func editButtonDidClicked(achievement: Achievement)
+}
 
 final class DetailAchievementViewController: BaseViewController<DetailAchievementView> {
     weak var coordinator: DetailAchievementCoordinator?
+    weak var delegate: DetailAchievementViewControllerDelegate?
     
     private let viewModel: DetailAchievementViewModel
     private var cancellables: Set<AnyCancellable> = []
@@ -51,7 +57,7 @@ final class DetailAchievementViewController: BaseViewController<DetailAchievemen
     }
     
     @objc private func didClickedEditButton() {
-        Logger.debug("편집 버튼!")
+        delegate?.editButtonDidClicked(achievement: viewModel.achievement)
     }
     
     private func bind() {

--- a/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementViewModel.swift
@@ -25,7 +25,7 @@ final class DetailAchievementViewModel {
     
     @Published private(set) var launchState: LaunchState = .none
     
-    var achievement: Achievement
+    private(set) var achievement: Achievement
     
     init(
         fetchDetailAchievementUseCase: FetchDetailAchievementUseCase,

--- a/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementViewModel.swift
@@ -25,7 +25,7 @@ final class DetailAchievementViewModel {
     
     @Published private(set) var launchState: LaunchState = .none
     
-    private var achievement: Achievement
+    var achievement: Achievement
     
     init(
         fetchDetailAchievementUseCase: FetchDetailAchievementUseCase,

--- a/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementCoordinator.swift
@@ -78,7 +78,7 @@ extension EditAchievementCoordinator: EditAchievementViewControllerDelegate {
             finish(animated: false)
             parentCoordinator?.finish(animated: true)
         } else {
-            navigationController.popViewController(animated: false)
+            finish(animated: false)
         }
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementCoordinator.swift
@@ -72,8 +72,8 @@ final class EditAchievementCoordinator: Coordinator {
 }
 
 extension EditAchievementCoordinator: EditAchievementViewControllerDelegate {
-    func doneButtonDidClicked(isCaptureMode: Bool) {
-        if isCaptureMode {
+    func doneButtonDidClicked(isFromCaptureMode: Bool) {
+        if isFromCaptureMode {
             navigationController.setNavigationBarHidden(true, animated: false)
             finish(animated: false)
             parentCoordinator?.finish(animated: true)

--- a/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementCoordinator.swift
@@ -37,14 +37,10 @@ final class EditAchievementCoordinator: Coordinator {
             achievement: achievement
         )
         editAchievementVC.coordinator = self
+        editAchievementVC.delegate = self
+        editAchievementVC.navigationItem.hidesBackButton = true
         
-        editAchievementVC.navigationItem.rightBarButtonItem = UIBarButtonItem(
-            barButtonSystemItem: .done,
-            target: self,
-            action: #selector(doneButtonAction)
-        )
-        
-        navigationController.pushViewController(editAchievementVC, animated: true)
+        navigationController.pushViewController(editAchievementVC, animated: false)
         navigationController.setNavigationBarHidden(false, animated: false)
     }
     
@@ -59,16 +55,11 @@ final class EditAchievementCoordinator: Coordinator {
             imageExtension: imageExtension
         )
         editAchievementVC.coordinator = self
+        editAchievementVC.delegate = self
         
         editAchievementVC.navigationItem.leftBarButtonItem = UIBarButtonItem(
             title: "다시 촬영", style: .plain, target: self,
             action: #selector(recaptureButtonAction)
-        )
-        
-        editAchievementVC.navigationItem.rightBarButtonItem = UIBarButtonItem(
-            barButtonSystemItem: .done,
-            target: self,
-            action: #selector(doneButtonAction)
         )
         
         navigationController.pushViewController(editAchievementVC, animated: false)
@@ -78,10 +69,16 @@ final class EditAchievementCoordinator: Coordinator {
     @objc func recaptureButtonAction() {
         finish(animated: false)
     }
-    
-    @objc func doneButtonAction() {
-        navigationController.setNavigationBarHidden(true, animated: false)
-        finish(animated: false)
-        parentCoordinator?.finish(animated: true)
+}
+
+extension EditAchievementCoordinator: EditAchievementViewControllerDelegate {
+    func doneButtonDidClicked(isCaptureMode: Bool) {
+        if isCaptureMode {
+            navigationController.setNavigationBarHidden(true, animated: false)
+            finish(animated: false)
+            parentCoordinator?.finish(animated: true)
+        } else {
+            navigationController.popViewController(animated: false)
+        }
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementViewController.swift
@@ -119,9 +119,7 @@ final class EditAchievementViewController: BaseViewController<EditAchievementVie
                 
                 switch state {
                 case .none:
-                    if let doneButton = navigationItem.rightBarButtonItem {
-                        doneButton.isEnabled = true
-                    }
+                    break
                 case .loading:
                     // 완료 버튼 비활성화
                     if let doneButton = navigationItem.rightBarButtonItem {

--- a/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementViewController.swift
@@ -146,7 +146,7 @@ final class EditAchievementViewController: BaseViewController<EditAchievementVie
     }
     
     @objc func doneButtonAction() {
-        if viewModel.saveImageState == .none {
+        if let achievement {
             // 상세 화면에서 넘어옴
             delegate?.doneButtonDidClicked(isFromCaptureMode: false)
             

--- a/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementViewController.swift
@@ -11,10 +11,15 @@ import Design
 import Combine
 import Domain
 
+protocol EditAchievementViewControllerDelegate: AnyObject {
+    func doneButtonDidClicked(isCaptureMode: Bool)
+}
+
 final class EditAchievementViewController: BaseViewController<EditAchievementView> {
     
     // MARK: - Properties
     weak var coordinator: EditAchievementCoordinator?
+    weak var delegate: EditAchievementViewControllerDelegate?
     private let viewModel: EditAchievementViewModel
     private var cancellables: Set<AnyCancellable> = []
     
@@ -57,6 +62,12 @@ final class EditAchievementViewController: BaseViewController<EditAchievementVie
     // MARK: - Life Cycles
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        navigationItem.rightBarButtonItem = UIBarButtonItem(
+            barButtonSystemItem: .done,
+            target: self,
+            action: #selector(doneButtonAction)
+        )
         
         viewModel.action(.fetchCategories)
         addTarget()
@@ -107,6 +118,10 @@ final class EditAchievementViewController: BaseViewController<EditAchievementVie
                 guard let self else { return }
                 
                 switch state {
+                case .none:
+                    if let doneButton = navigationItem.rightBarButtonItem {
+                        doneButton.isEnabled = true
+                    }
                 case .loading:
                     // 완료 버튼 비활성화
                     if let doneButton = navigationItem.rightBarButtonItem {
@@ -128,6 +143,17 @@ final class EditAchievementViewController: BaseViewController<EditAchievementVie
     private func addTarget() {
         layoutView.categoryButton.addTarget(self, action: #selector(showPicker), for: .touchUpInside)
         layoutView.selectDoneButton.addTarget(self, action: #selector(donePicker), for: .touchUpInside)
+    }
+    
+    @objc func doneButtonAction() {
+        if viewModel.saveImageState == .none {
+            // 상세 화면에서 넘어옴
+            delegate?.doneButtonDidClicked(isCaptureMode: false)
+            
+        } else {
+            // 촬영 화면에서 넘어옴
+            delegate?.doneButtonDidClicked(isCaptureMode: true)
+        }
     }
 }
 

--- a/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementViewController.swift
@@ -12,7 +12,7 @@ import Combine
 import Domain
 
 protocol EditAchievementViewControllerDelegate: AnyObject {
-    func doneButtonDidClicked(isCaptureMode: Bool)
+    func doneButtonDidClicked(isFromCaptureMode: Bool)
 }
 
 final class EditAchievementViewController: BaseViewController<EditAchievementView> {
@@ -148,11 +148,11 @@ final class EditAchievementViewController: BaseViewController<EditAchievementVie
     @objc func doneButtonAction() {
         if viewModel.saveImageState == .none {
             // 상세 화면에서 넘어옴
-            delegate?.doneButtonDidClicked(isCaptureMode: false)
+            delegate?.doneButtonDidClicked(isFromCaptureMode: false)
             
         } else {
             // 촬영 화면에서 넘어옴
-            delegate?.doneButtonDidClicked(isCaptureMode: true)
+            delegate?.doneButtonDidClicked(isFromCaptureMode: true)
         }
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementViewController.swift
@@ -147,11 +147,11 @@ final class EditAchievementViewController: BaseViewController<EditAchievementVie
     
     @objc func doneButtonAction() {
         if let achievement {
-            // 상세 화면에서 넘어옴
+            // 상세 화면에서 넘어옴 => 수정 API
             delegate?.doneButtonDidClicked(isFromCaptureMode: false)
             
         } else {
-            // 촬영 화면에서 넘어옴
+            // 촬영 화면에서 넘어옴 => 생성 API
             delegate?.doneButtonDidClicked(isFromCaptureMode: true)
         }
     }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementViewModel.swift
@@ -23,6 +23,7 @@ final class EditAchievementViewModel {
     }
     
     enum SaveImageState {
+        case none
         case loading
         case finish
         case error
@@ -36,7 +37,7 @@ final class EditAchievementViewModel {
     }
     
     @Published private(set) var categoryState: CategoryState = .none
-    @Published private(set) var saveImageState: SaveImageState = .loading
+    @Published private(set) var saveImageState: SaveImageState = .none
     
     init(
         saveImageUseCase: SaveImageUseCase,


### PR DESCRIPTION
## PR 요약
- 상세 화면에서 "편집" 버튼 클릭 시 EditVC로 achievement 전달하여 화면 이동
#### 변경 사항
- 기존에는 EditCoordinator에서 done버튼 액션을 처리
- done버튼 액션에 `navigationController.setNavigationBarHidden` 가 있었음
- 그런데 '촬영 화면'이 아니라 '상세 화면'에서 넘어간 편집 화면은 done버튼 액션이 동작이 다름
- setNavigationBarHidden이 불리면 naviBar 가 완전히 없어져 버리고 finish를 하면 홈 화면으로 가버리는 각종 문제 발생
- 그래서 done버튼이 눌렸을 때 편집 화면이 '촬영'에서 넘어온 건지 '상세'에서 넘어온 건지를 알아야 하기 때문에 SaveImageState로 구분

##### 스크린샷
<img width="50%" src="https://github.com/boostcampwm2023/iOS02-moti/assets/60506170/11e486ed-183f-409f-8b60-a706b37de840">

#### Linked Issue
close #294 
