### PR TITLE
삭제 버튼이 눌리면 홈 화면으로 이동하고, 데이터를 업데이트한다.

### DIFF
--- a/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementCoordinator.swift
@@ -10,10 +10,15 @@ import Core
 import Data
 import Domain
 
+protocol DetailAchievementCoordinatorDelegate: AnyObject {
+    func deleteButtonAction(achievementId: Int)
+}
+
 public final class DetailAchievementCoordinator: Coordinator {
     public var parentCoordinator: Coordinator?
     public var childCoordinators: [Coordinator] = []
     public var navigationController: UINavigationController
+    weak var delegate: DetailAchievementCoordinatorDelegate?
     
     public init(
         _ navigationController: UINavigationController,
@@ -48,5 +53,10 @@ public final class DetailAchievementCoordinator: Coordinator {
 extension DetailAchievementCoordinator: DetailAchievementViewControllerDelegate {
     func editButtonDidClicked(achievement: Achievement) {
         moveEditAchievementViewController(achievement: achievement)
+    }
+    
+    func deleteButtonDidClicked(achievementId: Int) {
+        finish(animated: true)
+        delegate?.deleteButtonAction(achievementId: achievementId)
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementViewController.swift
@@ -13,6 +13,7 @@ import Domain
 
 protocol DetailAchievementViewControllerDelegate: AnyObject {
     func editButtonDidClicked(achievement: Achievement)
+    func deleteButtonDidClicked(achievementId: Int)
 }
 
 final class DetailAchievementViewController: BaseViewController<DetailAchievementView> {
@@ -53,8 +54,11 @@ final class DetailAchievementViewController: BaseViewController<DetailAchievemen
     }
     
     @objc private func didClickedRemoveButton() {
-        showDestructiveTwoButtonAlert(title: "정말로 삭제하시겠습니까?", message: "삭제된 도전 기록은 되돌릴 수 없습니다.") {
-            Logger.debug("remove ..")
+        showDestructiveTwoButtonAlert(title: "정말로 삭제하시겠습니까?", message: "삭제된 도전 기록은 되돌릴 수 없습니다.") { [weak self] in
+            guard let self else { return }
+            
+            // TODO: viewModel에서 delete API 호출
+            self.delegate?.deleteButtonDidClicked(achievementId: viewModel.achievement.id)
         }
     }
     

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeCoordinator.swift
@@ -36,7 +36,16 @@ public final class HomeCoordinator: Coordinator {
     
     public func moveToDetailAchievementViewController(achievement: Achievement) {
         let detailAchievementCoordinator = DetailAchievementCoordinator(navigationController, self)
+        detailAchievementCoordinator.delegate = self
         childCoordinators.append(detailAchievementCoordinator)
         detailAchievementCoordinator.start(achievement: achievement)
+    }
+}
+
+extension HomeCoordinator: DetailAchievementCoordinatorDelegate {
+    func deleteButtonAction(achievementId: Int) {
+        // homeCoordinator에서 만든 homeVC를 따로 저장하고 있지 않기 때문에, naviVC에 접근하여 찾기
+        guard let homeVC = navigationController.viewControllers.compactMap({ $0 as? HomeViewController }).first else { return }
+        homeVC.delete(achievementId: achievementId)
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewController.swift
@@ -39,6 +39,10 @@ final class HomeViewController: BaseViewController<HomeView> {
     }
     
     // MARK: - Methods
+    func delete(achievementId: Int) {
+        viewModel.action(.delete(achievementId: achievementId))
+    }
+    
     private func bind() {
         viewModel.$achievementState
             .receive(on: DispatchQueue.main)

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewModel.swift
@@ -15,6 +15,7 @@ final class HomeViewModel {
         case addCategory(name: String)
         case fetchNextPage
         case fetchCategoryList(category: CategoryItem)
+        case delete(achievementId: Int)
     }
     
     enum CategoryState {
@@ -87,6 +88,8 @@ final class HomeViewModel {
             fetchNextAchievementList()
         case .fetchCategoryList(let category):
             fetchCategoryAchievementList(category: category)
+        case .delete(let achievementId):
+            delete(achievementId: achievementId)
         }
     }
     
@@ -105,6 +108,15 @@ final class HomeViewModel {
     
     func findCategory(at index: Int) -> CategoryItem {
         return categories[index]
+    }
+    
+    private func findIndexOfAchievement(with achievementId: Int) -> Int? {
+        return achievements.firstIndex { $0.id == achievementId }
+    }
+    
+    private func delete(achievementId: Int) {
+        guard let foundIndex = findIndexOfAchievement(with: achievementId) else { return }
+        achievements.remove(at: foundIndex)
     }
     
     private func fetchCategories() {


### PR DESCRIPTION
## PR 요약
- 삭제 API 연동 전 데이터 흐름 정립
- 삭제 버튼 액션 전달 흐름: detailVC -> detailCoordinator -> homeCoordinator -> homeVC -> homeVM

#### 주의 사항
- 삭제 API response로 id를 받았다는 전제

##### 스크린샷
<img width="50%" src="https://github.com/boostcampwm2023/iOS02-moti/assets/60506170/c231f933-5b27-497c-a5f2-3d7787205729">

#### Linked Issue
close #302 
