### PR TITLE
달성기록 조회 페이징 디폴트 개수 변경

### DIFF
--- a/BE/src/achievement/dto/paginate-achievement-request.ts
+++ b/BE/src/achievement/dto/paginate-achievement-request.ts
@@ -19,7 +19,7 @@ export class PaginateAchievementRequest {
 
   constructor(
     categoryId?: number,
-    take: number = 12,
+    take: number = 30,
     whereIdLessThan?: number,
   ) {
     this.categoryId = categoryId;

--- a/BE/src/achievement/entities/achievement.repository.spec.ts
+++ b/BE/src/achievement/entities/achievement.repository.spec.ts
@@ -146,12 +146,12 @@ describe('AchievementRepository test', () => {
       const category_2 = await categoryFixture.getCategory(user, 'DEF');
 
       const achievements = [];
-      for (let i = 0; i < 10; i++) {
+      for (let i = 0; i < 30; i++) {
         achievements.push(
           await achievementFixture.getAchievement(user, category_1),
         );
       }
-      for (let i = 0; i < 10; i++) {
+      for (let i = 0; i < 30; i++) {
         achievements.push(
           await achievementFixture.getAchievement(user, category_2),
         );
@@ -166,7 +166,7 @@ describe('AchievementRepository test', () => {
       );
 
       // then
-      expect(findAll.length).toEqual(12);
+      expect(findAll.length).toEqual(30);
     });
   });
 


### PR DESCRIPTION
## PR 요약
달성기록 조회 페이징 디폴트 개수 30개로 변경

#### 변경 사항
- 달성기록 조회 페이징 디폴트 개수 30개로 변경
- 관련 테스트 코드 수정


#### Linked Issue
close #304
