### PR TITLE
편집을 완료하면 카테고리, 제목, 내용의 읽기 모드로 변한다. 

### DIFF
--- a/iOS/moti/moti/Domain/Sources/Domain/Entity/Achievement.swift
+++ b/iOS/moti/moti/Domain/Sources/Domain/Entity/Achievement.swift
@@ -9,10 +9,10 @@ import Foundation
 
 public struct Achievement: Hashable {
     public let id: Int
-    public let category: CategoryItem?
-    public let title: String
+    public var category: CategoryItem?
+    public var title: String
     public let imageURL: URL?
-    public let body: String?
+    public var body: String?
     public let date: Date?
     
     public init(

--- a/iOS/moti/moti/Domain/Sources/Domain/UseCase/UpdateAchievementUseCase.swift
+++ b/iOS/moti/moti/Domain/Sources/Domain/UseCase/UpdateAchievementUseCase.swift
@@ -1,0 +1,20 @@
+//
+//  UpdateAchievementUseCase.swift
+//
+//
+//  Created by Kihyun Lee on 11/29/23.
+//
+
+import Foundation
+
+public struct UpdateAchievementRequestValue: RequestValue {
+    public let title: String
+    public let content: String
+    public let categoryId: Int
+    
+    public init(title: String, content: String, categoryId: Int) {
+        self.title = title
+        self.content = content
+        self.categoryId = categoryId
+    }
+}

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Common/TextViewBottomSheet.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Common/TextViewBottomSheet.swift
@@ -10,7 +10,7 @@ import Combine
 
 final class TextViewBottomSheet: UIViewController {
 
-    private let textView = {
+    let textView = {
         let textView = UITextView()
         textView.font = .medium
         return textView

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Common/TextViewBottomSheet.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Common/TextViewBottomSheet.swift
@@ -10,7 +10,7 @@ import Combine
 
 final class TextViewBottomSheet: UIViewController {
 
-    let textView = {
+    private let textView = {
         let textView = UITextView()
         textView.font = .medium
         return textView

--- a/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementCoordinator.swift
@@ -19,6 +19,7 @@ public final class DetailAchievementCoordinator: Coordinator {
     public var childCoordinators: [Coordinator] = []
     public var navigationController: UINavigationController
     weak var delegate: DetailAchievementCoordinatorDelegate?
+    private var detailAchievementViewController: DetailAchievementViewController?
     
     public init(
         _ navigationController: UINavigationController,
@@ -42,11 +43,13 @@ public final class DetailAchievementCoordinator: Coordinator {
         )
         detailAchievementVC.coordinator = self
         detailAchievementVC.delegate = self
+        detailAchievementViewController = detailAchievementVC
         navigationController.pushViewController(detailAchievementVC, animated: true)
     }
     
     private func moveEditAchievementViewController(achievement: Achievement) {
         let editAchievementCoordinator = EditAchievementCoordinator(navigationController, self)
+        editAchievementCoordinator.delegate = self
         editAchievementCoordinator.start(achievement: achievement)
         childCoordinators.append(editAchievementCoordinator)
     }
@@ -60,5 +63,11 @@ extension DetailAchievementCoordinator: DetailAchievementViewControllerDelegate 
     func deleteButtonDidClicked(achievementId: Int) {
         finish(animated: true)
         delegate?.deleteButtonAction(achievementId: achievementId)
+    }
+}
+
+extension DetailAchievementCoordinator: EditAchievementCoordinatorDelegate {
+    func doneAction(updateAchievementRequestValue: UpdateAchievementRequestValue) {
+        detailAchievementViewController?.update(updateAchievementRequestValue: updateAchievementRequestValue)
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementCoordinator.swift
@@ -67,7 +67,7 @@ extension DetailAchievementCoordinator: DetailAchievementViewControllerDelegate 
 }
 
 extension DetailAchievementCoordinator: EditAchievementCoordinatorDelegate {
-    func doneAction(updateAchievementRequestValue: UpdateAchievementRequestValue) {
+    func doneButtonAction(updateAchievementRequestValue: UpdateAchievementRequestValue) {
         detailAchievementViewController?.update(updateAchievementRequestValue: updateAchievementRequestValue)
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementView.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementView.swift
@@ -125,6 +125,13 @@ final class DetailAchievementView: UIView {
         titleLabel.text = title
     }
     
+    func update(updateAchievementRequestValue: UpdateAchievementRequestValue) {
+        // TODO: 카테고리 이름으로 수정
+        categoryLabel.text = "id가 \(updateAchievementRequestValue.categoryId)인 카테고리 이름"
+        titleLabel.text = updateAchievementRequestValue.title
+        bodyTextView.text = updateAchievementRequestValue.content
+    }
+    
     func cancelDownloadImage() {
         imageView.jf.cancelDownloadImage()
     }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementViewController.swift
@@ -46,6 +46,10 @@ final class DetailAchievementViewController: BaseViewController<DetailAchievemen
         layoutView.cancelDownloadImage()
     }
     
+    func update(updateAchievementRequestValue: UpdateAchievementRequestValue) {
+        viewModel.action(.update(updateAchievementRequestValue: updateAchievementRequestValue))
+    }
+    
     private func setupUI() {
         let removeButton = UIBarButtonItem(title: "삭제", style: .plain, target: self, action: #selector(didClickedRemoveButton))
         removeButton.tintColor = .red
@@ -92,6 +96,19 @@ final class DetailAchievementViewController: BaseViewController<DetailAchievemen
                     delegate?.deleteButtonDidClicked(achievementId: achievementId)
                 case .failed(let message):
                     Logger.error("delete achievement error: \(message)")
+                }
+            }
+            .store(in: &cancellables)
+        
+        viewModel.$updateState
+            .receive(on: RunLoop.main)
+            .sink { [weak self] state in
+                guard let self else { return }
+                switch state {
+                case .initial:
+                    break
+                case .success(let updateAchievementRequestValue):
+                    layoutView.update(updateAchievementRequestValue: updateAchievementRequestValue)
                 }
             }
             .store(in: &cancellables)

--- a/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementViewController.swift
@@ -48,6 +48,7 @@ final class DetailAchievementViewController: BaseViewController<DetailAchievemen
     
     func update(updateAchievementRequestValue: UpdateAchievementRequestValue) {
         viewModel.action(.update(updateAchievementRequestValue: updateAchievementRequestValue))
+        layoutView.update(updateAchievementRequestValue: updateAchievementRequestValue)
     }
     
     private func setupUI() {
@@ -96,19 +97,6 @@ final class DetailAchievementViewController: BaseViewController<DetailAchievemen
                     delegate?.deleteButtonDidClicked(achievementId: achievementId)
                 case .failed(let message):
                     Logger.error("delete achievement error: \(message)")
-                }
-            }
-            .store(in: &cancellables)
-        
-        viewModel.$updateState
-            .receive(on: RunLoop.main)
-            .sink { [weak self] state in
-                guard let self else { return }
-                switch state {
-                case .initial:
-                    break
-                case .success(let updateAchievementRequestValue):
-                    layoutView.update(updateAchievementRequestValue: updateAchievementRequestValue)
                 }
             }
             .store(in: &cancellables)

--- a/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementViewModel.swift
@@ -29,17 +29,11 @@ final class DetailAchievementViewModel {
         case failed(message: String)
     }
     
-    enum UpdateState { // API연동이 아닌 achievement 수정이므로 loading, fail이 없다.
-        case initial
-        case success(updateAchievementRequestValue: UpdateAchievementRequestValue)
-    }
-    
     private let fetchDetailAchievementUseCase: FetchDetailAchievementUseCase
     private let deleteAchievementUseCase: DeleteAchievementUseCase
     
     @Published private(set) var launchState: LaunchState = .none
     @Published private(set) var deleteState: DeleteState = .initial
-    @Published private(set) var updateState: UpdateState = .initial
     
     private(set) var achievement: Achievement
     
@@ -104,6 +98,5 @@ final class DetailAchievementViewModel {
 //        achievement.category = updateAchievementRequestValue.categoryId
         achievement.title = updateAchievementRequestValue.title
         achievement.body = updateAchievementRequestValue.content
-        updateState = .success(updateAchievementRequestValue: updateAchievementRequestValue)
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementViewModel.swift
@@ -13,6 +13,7 @@ final class DetailAchievementViewModel {
     enum DetailAchievementViewModelAction {
         case launch
         case delete
+        case update(updateAchievementRequestValue: UpdateAchievementRequestValue)
     }
     
     enum LaunchState {
@@ -28,11 +29,17 @@ final class DetailAchievementViewModel {
         case failed(message: String)
     }
     
+    enum UpdateState { // API연동이 아닌 achievement 수정이므로 loading, fail이 없다.
+        case initial
+        case success(updateAchievementRequestValue: UpdateAchievementRequestValue)
+    }
+    
     private let fetchDetailAchievementUseCase: FetchDetailAchievementUseCase
     private let deleteAchievementUseCase: DeleteAchievementUseCase
     
     @Published private(set) var launchState: LaunchState = .none
     @Published private(set) var deleteState: DeleteState = .initial
+    @Published private(set) var updateState: UpdateState = .initial
     
     private(set) var achievement: Achievement
     
@@ -53,6 +60,8 @@ final class DetailAchievementViewModel {
             fetchDetailAchievement()
         case .delete:
             deleteAchievement()
+        case .update(let updateAchievementRequestValue):
+            updateAchievement(updateAchievementRequestValue: updateAchievementRequestValue)
         }
     }
     
@@ -88,5 +97,13 @@ final class DetailAchievementViewModel {
                 deleteState = .failed(message: error.localizedDescription)
             }
         }
+    }
+    
+    private func updateAchievement(updateAchievementRequestValue: UpdateAchievementRequestValue) {
+        // TODO: 카테고리 아이템 수정
+//        achievement.category = updateAchievementRequestValue.categoryId
+        achievement.title = updateAchievementRequestValue.title
+        achievement.body = updateAchievementRequestValue.content
+        updateState = .success(updateAchievementRequestValue: updateAchievementRequestValue)
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementCoordinator.swift
@@ -80,13 +80,18 @@ final class EditAchievementCoordinator: Coordinator {
 }
 
 extension EditAchievementCoordinator: EditAchievementViewControllerDelegate {
-    func doneButtonDidClicked(isFromCaptureMode: Bool) {
-        if isFromCaptureMode {
-            navigationController.setNavigationBarHidden(true, animated: false)
-            finish(animated: false)
-            parentCoordinator?.finish(animated: true)
-        } else {
-            finish(animated: false)
-        }
+    func doneButtonDidClickedFromEditMode(updateAchievementRequestValue: UpdateAchievementRequestValue) {
+        finish(animated: false)
+        
+        guard let detailAchievementVC = navigationController.viewControllers
+            .compactMap({ $0 as? DetailAchievementViewController }).first else { return }
+        
+        detailAchievementVC.update(updateAchievementRequestValue: updateAchievementRequestValue)
+    }
+    
+    func doneButtonDidClickedFromCaptureMode() {
+        navigationController.setNavigationBarHidden(true, animated: false)
+        finish(animated: false)
+        parentCoordinator?.finish(animated: true)
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementCoordinator.swift
@@ -10,10 +10,15 @@ import Core
 import Data
 import Domain
 
+protocol EditAchievementCoordinatorDelegate: AnyObject {
+    func doneAction(updateAchievementRequestValue: UpdateAchievementRequestValue)
+}
+
 final class EditAchievementCoordinator: Coordinator {
     var parentCoordinator: Coordinator?
     var childCoordinators: [Coordinator] = []
     var navigationController: UINavigationController
+    weak var delegate: EditAchievementCoordinatorDelegate?
     
     init(
         _ navigationController: UINavigationController,
@@ -82,11 +87,7 @@ final class EditAchievementCoordinator: Coordinator {
 extension EditAchievementCoordinator: EditAchievementViewControllerDelegate {
     func doneButtonDidClickedFromEditMode(updateAchievementRequestValue: UpdateAchievementRequestValue) {
         finish(animated: false)
-        
-        guard let detailAchievementVC = navigationController.viewControllers
-            .compactMap({ $0 as? DetailAchievementViewController }).first else { return }
-        
-        detailAchievementVC.update(updateAchievementRequestValue: updateAchievementRequestValue)
+        delegate?.doneAction(updateAchievementRequestValue: updateAchievementRequestValue)
     }
     
     func doneButtonDidClickedFromCaptureMode() {

--- a/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementCoordinator.swift
@@ -11,7 +11,7 @@ import Data
 import Domain
 
 protocol EditAchievementCoordinatorDelegate: AnyObject {
-    func doneAction(updateAchievementRequestValue: UpdateAchievementRequestValue)
+    func doneButtonAction(updateAchievementRequestValue: UpdateAchievementRequestValue)
 }
 
 final class EditAchievementCoordinator: Coordinator {
@@ -87,7 +87,7 @@ final class EditAchievementCoordinator: Coordinator {
 extension EditAchievementCoordinator: EditAchievementViewControllerDelegate {
     func doneButtonDidClickedFromEditMode(updateAchievementRequestValue: UpdateAchievementRequestValue) {
         finish(animated: false)
-        delegate?.doneAction(updateAchievementRequestValue: updateAchievementRequestValue)
+        delegate?.doneButtonAction(updateAchievementRequestValue: updateAchievementRequestValue)
     }
     
     func doneButtonDidClickedFromCaptureMode() {

--- a/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementView.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementView.swift
@@ -20,7 +20,7 @@ final class EditAchievementView: UIView {
         return imageView
     }()
     
-    private let titleTextField = {
+    let titleTextField = {
         let textField = UITextField()
         textField.font = .largeBold
         textField.placeholder = "도전 성공"

--- a/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementViewController.swift
@@ -148,7 +148,7 @@ final class EditAchievementViewController: BaseViewController<EditAchievementVie
         if let achievement { // 상세 화면에서 넘어옴 => 수정 API
             let updateAchievementRequestValue = UpdateAchievementRequestValue(
                 title: layoutView.titleTextField.text ?? "",
-                content: bottomSheet.textView.text ?? "",
+                content: bottomSheet.text,
                 categoryId: findSelectedCategory().id
             )
             

--- a/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementViewController.swift
@@ -12,7 +12,8 @@ import Combine
 import Domain
 
 protocol EditAchievementViewControllerDelegate: AnyObject {
-    func doneButtonDidClicked(isFromCaptureMode: Bool)
+    func doneButtonDidClickedFromEditMode(updateAchievementRequestValue: UpdateAchievementRequestValue)
+    func doneButtonDidClickedFromCaptureMode()
 }
 
 final class EditAchievementViewController: BaseViewController<EditAchievementView> {
@@ -144,14 +145,23 @@ final class EditAchievementViewController: BaseViewController<EditAchievementVie
     }
     
     @objc func doneButtonAction() {
-        if let achievement {
-            // 상세 화면에서 넘어옴 => 수정 API
-            delegate?.doneButtonDidClicked(isFromCaptureMode: false)
+        if let achievement { // 상세 화면에서 넘어옴 => 수정 API
+            let updateAchievementRequestValue = UpdateAchievementRequestValue(
+                title: layoutView.titleTextField.text ?? "",
+                content: bottomSheet.textView.text ?? "",
+                categoryId: findSelectedCategory().id
+            )
             
-        } else {
-            // 촬영 화면에서 넘어옴 => 생성 API
-            delegate?.doneButtonDidClicked(isFromCaptureMode: true)
+            delegate?.doneButtonDidClickedFromEditMode(updateAchievementRequestValue: updateAchievementRequestValue)
+            
+        } else { // 촬영 화면에서 넘어옴 => 생성 API
+            delegate?.doneButtonDidClickedFromCaptureMode()
         }
+    }
+    
+    private func findSelectedCategory() -> CategoryItem {
+        let selectedRow = layoutView.categoryPickerView.selectedRow(inComponent: 0)
+        return viewModel.findCategory(at: selectedRow)
     }
 }
 

--- a/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementViewModel.swift
@@ -14,6 +14,7 @@ final class EditAchievementViewModel {
     enum Action {
         case saveImage(data: Data, imageExtension: ImageExtension)
         case fetchCategories
+        case updateAchievement
     }
     
     enum CategoryState {
@@ -23,6 +24,13 @@ final class EditAchievementViewModel {
     }
     
     enum SaveImageState {
+        case none
+        case loading
+        case finish
+        case error
+    }
+    
+    enum UpdateAchievementState {
         case none
         case loading
         case finish
@@ -53,6 +61,8 @@ final class EditAchievementViewModel {
             saveImageData(data, imageExtension)
         case .fetchCategories:
             fetchCategories()
+        case .updateAchievement:
+            break
         }
     }
     

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeCoordinator.swift
@@ -10,10 +10,15 @@ import Core
 import Data
 import Domain
 
+protocol HomeCoordinatorDelegate: AnyObject {
+    func deleteAction(achievementId: Int)
+}
+
 public final class HomeCoordinator: Coordinator {
     public let parentCoordinator: Coordinator?
     public var childCoordinators: [Core.Coordinator] = []
     public let navigationController: UINavigationController
+    weak var delegate: HomeCoordinatorDelegate?
     
     public init(
         _ navigationController: UINavigationController,
@@ -44,8 +49,6 @@ public final class HomeCoordinator: Coordinator {
 
 extension HomeCoordinator: DetailAchievementCoordinatorDelegate {
     func deleteButtonAction(achievementId: Int) {
-        // homeCoordinator에서 만든 homeVC를 따로 저장하고 있지 않기 때문에, naviVC에 접근하여 찾기
-        guard let homeVC = navigationController.viewControllers.compactMap({ $0 as? HomeViewController }).first else { return }
-        homeVC.delete(achievementId: achievementId)
+        delegate?.deleteAction(achievementId: achievementId)
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/TabBar/TabBarCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/TabBar/TabBarCoordinator.swift
@@ -27,6 +27,7 @@ public final class TabBarCoordinator: Coordinator {
     public var childCoordinators: [Coordinator] = []
     public let navigationController: UINavigationController
     private let tabBarController: TabBarViewController
+    private var homeViewController: HomeViewController?
     
     public init(
         _ navigationController: UINavigationController,
@@ -68,6 +69,7 @@ private extension TabBarCoordinator {
             addCategoryUseCase: .init(repository: CategoryListRepository())
         )
         let homeVC = HomeViewController(viewModel: homeVM)
+        homeViewController = homeVC
         
         homeVC.tabBarItem.image = SymbolImage.individualTabItem
         homeVC.tabBarItem.title = TabItemType.individual.title
@@ -76,6 +78,7 @@ private extension TabBarCoordinator {
         let navVC = UINavigationController(rootViewController: homeVC)
         
         let homeCoordinator = HomeCoordinator(navVC, self)
+        homeCoordinator.delegate = self
         homeVC.coordinator = homeCoordinator
         childCoordinators.append(homeCoordinator)
         return navVC
@@ -125,5 +128,11 @@ private extension TabBarCoordinator {
 extension TabBarCoordinator: TabBarViewControllerDelegate {
     func captureButtonDidClicked() {
         moveCaptureViewController()
+    }
+}
+
+extension TabBarCoordinator: HomeCoordinatorDelegate {
+    func deleteAction(achievementId: Int) {
+        homeViewController?.delete(achievementId: achievementId)
     }
 }


### PR DESCRIPTION
## PR 요약
- 편집 done 클릭시 상세뷰 업데이트
- 수정 완료 동작 흐름: editVC->editVM->editVC->editCoordinator->detailVC->detailVM->detailVC

#### 주의 사항
- 수정 완료 API가 success임을 가정

##### 스크린샷
<img width="50%" src="https://github.com/boostcampwm2023/iOS02-moti/assets/60506170/af37e35f-ba40-44ee-b4f9-85b1b05f0c7b">

#### Linked Issue
close #308
