### PR TITLE
달성기록 편집을 완료하면 수정 API를 호출한다.

### DIFF
--- a/iOS/moti/moti/Data/Sources/Data/Network/DTO/UpdateAchievementDTO.swift
+++ b/iOS/moti/moti/Data/Sources/Data/Network/DTO/UpdateAchievementDTO.swift
@@ -1,0 +1,20 @@
+//
+//  UpdateAchievementDTO.swift
+//
+//
+//  Created by Kihyun Lee on 11/30/23.
+//
+
+import Foundation
+import Domain
+
+struct UpdateAchievementResponseDTO: ResponseDTO {
+    let success: Bool?
+    let message: String?
+    let data: UpdateAchievementDataDTO?
+}
+
+struct UpdateAchievementDataDTO: Codable {
+    let id: Int
+}
+

--- a/iOS/moti/moti/Data/Sources/Data/Network/Endpoint/MotiAPI.swift
+++ b/iOS/moti/moti/Data/Sources/Data/Network/Endpoint/MotiAPI.swift
@@ -18,6 +18,7 @@ enum MotiAPI: EndpointProtocol {
     case fetchDetailAchievement(requestValue: FetchDetailAchievementRequestValue)
     case saveImage(requestValue: SaveImageRequestValue)
     case deleteAchievement(requestValue: DeleteAchievementRequestValue)
+    case updateAchievement(requestValue: UpdateAchievementRequestValue)
 }
 
 extension MotiAPI {
@@ -40,6 +41,7 @@ extension MotiAPI {
         case .fetchDetailAchievement(let requestValue): return "/achievements/\(requestValue.id)"
         case .saveImage: return "/images"
         case .deleteAchievement(let requestValue): return "/achievements/\(requestValue.id)"
+        case .updateAchievement(let requestValue): return "/achievements/\(requestValue.id)"
         }
     }
     
@@ -54,6 +56,7 @@ extension MotiAPI {
         case .fetchDetailAchievement: return .get
         case .saveImage: return .post
         case .deleteAchievement: return .delete
+        case .updateAchievement: return .put
         }
     }
     
@@ -74,6 +77,8 @@ extension MotiAPI {
             return requestValue
         case .addCategory(let requestValue):
             return requestValue
+        case .updateAchievement(let requestValue):
+            return requestValue.body
         default:
             return nil
         }

--- a/iOS/moti/moti/Data/Sources/Repository/UpdateAchievementRepository.swift
+++ b/iOS/moti/moti/Data/Sources/Repository/UpdateAchievementRepository.swift
@@ -1,0 +1,25 @@
+//
+//  UpdateAchievementRepository.swift
+//
+//
+//  Created by Kihyun Lee on 11/30/23.
+//
+
+import Foundation
+import Domain
+
+public struct UpdateAchievementRepository: UpdateAchievementRepositoryProtocol {
+    private let provider: ProviderProtocol
+    
+    public init(provider: ProviderProtocol = Provider()) {
+        self.provider = provider
+    }
+    
+    public func updateAchievement(requestValue: UpdateAchievementRequestValue) async throws -> Bool {
+        let endpoint = MotiAPI.updateAchievement(requestValue: requestValue)
+        let responseDTO = try await provider.request(with: endpoint, type: UpdateAchievementResponseDTO.self)
+        
+        guard let isSuccess = responseDTO.success else { throw NetworkError.decode }
+        return isSuccess
+    }
+}

--- a/iOS/moti/moti/Domain/Sources/Domain/RepositoryProtocol/UpdateAchievementRepositoryProtocol.swift
+++ b/iOS/moti/moti/Domain/Sources/Domain/RepositoryProtocol/UpdateAchievementRepositoryProtocol.swift
@@ -1,0 +1,12 @@
+//
+//  UpdateAchievementRepositoryProtocol.swift
+//
+//
+//  Created by Kihyun Lee on 11/30/23.
+//
+
+import Foundation
+
+public protocol UpdateAchievementRepositoryProtocol {
+    func updateAchievement(requestValue: UpdateAchievementRequestValue) async throws -> Bool
+}

--- a/iOS/moti/moti/Domain/Sources/Domain/UseCase/UpdateAchievementUseCase.swift
+++ b/iOS/moti/moti/Domain/Sources/Domain/UseCase/UpdateAchievementUseCase.swift
@@ -8,6 +8,16 @@
 import Foundation
 
 public struct UpdateAchievementRequestValue: RequestValue {
+    public let id: Int
+    public let body: UpdateAchievementRequestBody
+    
+    public init(id: Int, body: UpdateAchievementRequestBody) {
+        self.id = id
+        self.body = body
+    }
+}
+
+public struct UpdateAchievementRequestBody: RequestValue {
     public let title: String
     public let content: String
     public let categoryId: Int
@@ -16,5 +26,17 @@ public struct UpdateAchievementRequestValue: RequestValue {
         self.title = title
         self.content = content
         self.categoryId = categoryId
+    }
+}
+
+public struct UpdateAchievementUseCase {
+    private let repository: UpdateAchievementRepositoryProtocol
+    
+    public init(repository: UpdateAchievementRepositoryProtocol) {
+        self.repository = repository
+    }
+    
+    public func execute(requestValue: UpdateAchievementRequestValue) async throws -> Bool {
+        return try await repository.updateAchievement(requestValue: requestValue)
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementCoordinator.swift
@@ -12,6 +12,7 @@ import Domain
 
 protocol DetailAchievementCoordinatorDelegate: AnyObject {
     func deleteButtonAction(achievementId: Int)
+    func updateAchievement(id: Int, newCategoryId: Int)
 }
 
 public final class DetailAchievementCoordinator: Coordinator {
@@ -69,5 +70,6 @@ extension DetailAchievementCoordinator: DetailAchievementViewControllerDelegate 
 extension DetailAchievementCoordinator: EditAchievementCoordinatorDelegate {
     func doneButtonAction(updateAchievementRequestValue: UpdateAchievementRequestValue) {
         detailAchievementViewController?.update(updateAchievementRequestValue: updateAchievementRequestValue)
+        delegate?.updateAchievement(id: updateAchievementRequestValue.id, newCategoryId: updateAchievementRequestValue.body.categoryId)
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementView.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementView.swift
@@ -8,6 +8,7 @@
 import UIKit
 import Design
 import Domain
+import Data
 
 final class DetailAchievementView: UIView {
     
@@ -126,8 +127,8 @@ final class DetailAchievementView: UIView {
     }
     
     func update(updateAchievementRequestValue: UpdateAchievementRequestValue) {
-        // TODO: 카테고리 이름으로 수정
-        categoryLabel.text = "id가 \(updateAchievementRequestValue.categoryId)인 카테고리 이름"
+        let category = CategoryStorage.shared.find(categoryId: updateAchievementRequestValue.categoryId)
+        categoryLabel.text = category?.name
         titleLabel.text = updateAchievementRequestValue.title
         bodyTextView.text = updateAchievementRequestValue.content
     }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementView.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementView.swift
@@ -127,10 +127,12 @@ final class DetailAchievementView: UIView {
     }
     
     func update(updateAchievementRequestValue: UpdateAchievementRequestValue) {
-        let category = CategoryStorage.shared.find(categoryId: updateAchievementRequestValue.categoryId)
+        let category = CategoryStorage.shared.find(
+            categoryId: updateAchievementRequestValue.body.categoryId
+        )
         categoryLabel.text = category?.name
-        titleLabel.text = updateAchievementRequestValue.title
-        bodyTextView.text = updateAchievementRequestValue.content
+        titleLabel.text = updateAchievementRequestValue.body.title
+        bodyTextView.text = updateAchievementRequestValue.body.content
     }
     
     func cancelDownloadImage() {

--- a/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementViewModel.swift
@@ -95,9 +95,9 @@ final class DetailAchievementViewModel {
     }
     
     private func updateAchievement(updateAchievementRequestValue: UpdateAchievementRequestValue) {
-        let category = CategoryStorage.shared.find(categoryId: updateAchievementRequestValue.categoryId)
+        let category = CategoryStorage.shared.find(categoryId: updateAchievementRequestValue.body.categoryId)
         achievement.category = category
-        achievement.title = updateAchievementRequestValue.title
-        achievement.body = updateAchievementRequestValue.content
+        achievement.title = updateAchievementRequestValue.body.title
+        achievement.body = updateAchievementRequestValue.body.content
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementViewModel.swift
@@ -8,6 +8,7 @@
 import Foundation
 import Domain
 import Core
+import Data
 
 final class DetailAchievementViewModel {
     enum DetailAchievementViewModelAction {
@@ -94,8 +95,8 @@ final class DetailAchievementViewModel {
     }
     
     private func updateAchievement(updateAchievementRequestValue: UpdateAchievementRequestValue) {
-        // TODO: 카테고리 아이템 수정
-//        achievement.category = updateAchievementRequestValue.categoryId
+        let category = CategoryStorage.shared.find(categoryId: updateAchievementRequestValue.categoryId)
+        achievement.category = category
         achievement.title = updateAchievementRequestValue.title
         achievement.body = updateAchievementRequestValue.content
     }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementCoordinator.swift
@@ -35,7 +35,8 @@ final class EditAchievementCoordinator: Coordinator {
     func start(achievement: Achievement) {
         let editAchievementVM = EditAchievementViewModel(
             saveImageUseCase: .init(repository: ImageRepository()),
-            fetchCategoryListUseCase: .init(repository: CategoryListRepository())
+            fetchCategoryListUseCase: .init(repository: CategoryListRepository()),
+            updateAchievementUseCase: .init(repository: UpdateAchievementRepository())
         )
         let editAchievementVC = EditAchievementViewController(
             viewModel: editAchievementVM,
@@ -56,7 +57,8 @@ final class EditAchievementCoordinator: Coordinator {
     func startAfterCapture(image: UIImage, imageExtension: ImageExtension) {
         let editAchievementVM = EditAchievementViewModel(
             saveImageUseCase: .init(repository: ImageRepository()),
-            fetchCategoryListUseCase: .init(repository: CategoryListRepository())
+            fetchCategoryListUseCase: .init(repository: CategoryListRepository()),
+            updateAchievementUseCase: .init(repository: UpdateAchievementRepository())
         )
         let editAchievementVC = EditAchievementViewController(
             viewModel: editAchievementVM,

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeCoordinator.swift
@@ -12,6 +12,7 @@ import Domain
 
 protocol HomeCoordinatorDelegate: AnyObject {
     func deleteAction(achievementId: Int)
+    func updateAchievement(id: Int, newCategoryId: Int)
 }
 
 public final class HomeCoordinator: Coordinator {
@@ -50,5 +51,9 @@ public final class HomeCoordinator: Coordinator {
 extension HomeCoordinator: DetailAchievementCoordinatorDelegate {
     func deleteButtonAction(achievementId: Int) {
         delegate?.deleteAction(achievementId: achievementId)
+    }
+    
+    func updateAchievement(id: Int, newCategoryId: Int) {
+        delegate?.updateAchievement(id: id, newCategoryId: newCategoryId)
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewController.swift
@@ -43,6 +43,10 @@ final class HomeViewController: BaseViewController<HomeView> {
         viewModel.action(.delete(achievementId: achievementId))
     }
     
+    func updateAchievement(id: Int, newCategoryId: Int) {
+        viewModel.action(.updateAchievement(id: id, newCategoryId: newCategoryId))
+    }
+    
     private func bind() {
         viewModel.$achievementState
             .receive(on: DispatchQueue.main)

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewModel.swift
@@ -16,6 +16,7 @@ final class HomeViewModel {
         case fetchNextPage
         case fetchCategoryList(category: CategoryItem)
         case delete(achievementId: Int)
+        case updateAchievement(id: Int, newCategoryId: Int)
     }
     
     enum CategoryState {
@@ -91,6 +92,8 @@ final class HomeViewModel {
             fetchCategoryAchievementList(category: category)
         case .delete(let achievementId):
             delete(achievementId: achievementId)
+        case .updateAchievement(let id, let newCategoryId):
+            updateAchievement(id: id, newCategoryId: newCategoryId)
         }
     }
     
@@ -118,6 +121,13 @@ final class HomeViewModel {
     private func delete(achievementId: Int) {
         guard let foundIndex = findIndexOfAchievement(with: achievementId) else { return }
         achievements.remove(at: foundIndex)
+    }
+    
+    private func updateAchievement(id: Int, newCategoryId: Int) {
+        guard let currentCategory, currentCategory.id != 0 else { return }
+        if currentCategory.id != newCategoryId {
+            delete(achievementId: id)
+        }
     }
     
     private func fetchCategories() {

--- a/iOS/moti/moti/Presentation/Sources/Presentation/TabBar/TabBarCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/TabBar/TabBarCoordinator.swift
@@ -135,4 +135,8 @@ extension TabBarCoordinator: HomeCoordinatorDelegate {
     func deleteAction(achievementId: Int) {
         homeViewController?.delete(achievementId: achievementId)
     }
+    
+    func updateAchievement(id: Int, newCategoryId: Int) {
+        homeViewController?.updateAchievement(id: id, newCategoryId: newCategoryId)
+    }
 }


### PR DESCRIPTION
## PR 요약
- 달성기록의 제목, 내용 수정은 문제 없으나
- 카테고리 수정시 home에서 위치 반영이 필요
- 새로 바뀐 newCategory가 기존의 currentCategory와 달라진다면 홈뷰에서 삭제
- 달라지지 않고 그대로라면 냅두기
- 혹은 currentCategoryId == 0 이어도 전체 카테고리이므로 삭제할 필요 없음

##### 스크린샷
<img width="50%" src="https://github.com/boostcampwm2023/iOS02-moti/assets/60506170/24326049-7357-4453-98ea-e46aa16daa99">

#### Linked Issue
close #307
