### PR TITLE
그룹 리스트 API 구현

### DIFF
--- a/BE/src/group/achievement/domain/group-achievement.domain.ts
+++ b/BE/src/group/achievement/domain/group-achievement.domain.ts
@@ -9,7 +9,7 @@ export class GroupAchievement {
   group: Group;
   groupCategory: GroupCategory;
   content: string;
-
+  createdAt: Date;
   constructor(
     title: string,
     user: User,

--- a/BE/src/group/achievement/entities/group-achievement.entity.ts
+++ b/BE/src/group/achievement/entities/group-achievement.entity.ts
@@ -43,6 +43,7 @@ export class GroupAchievementEntity extends BaseTimeEntity {
       this.content,
     );
     groupAchievement.id = this.id;
+    groupAchievement.createdAt = this.createdAt;
     return groupAchievement;
   }
 

--- a/BE/src/group/achievement/entities/group-achievement.repository.ts
+++ b/BE/src/group/achievement/entities/group-achievement.repository.ts
@@ -1,0 +1,13 @@
+import { TransactionalRepository } from '../../../config/transaction-manager/transactional-repository';
+import { CustomRepository } from '../../../config/typeorm/custom-repository.decorator';
+import { GroupAchievementEntity } from './group-achievement.entity';
+import { GroupAchievement } from '../domain/group-achievement.domain';
+
+@CustomRepository(GroupAchievementEntity)
+export class GroupAchievementRepository extends TransactionalRepository<GroupAchievementEntity> {
+  async saveGroupAchievement(groupAchievement: GroupAchievement) {
+    const newGroupAchievement = GroupAchievementEntity.from(groupAchievement);
+    await this.repository.save(newGroupAchievement);
+    return newGroupAchievement.toModel();
+  }
+}

--- a/BE/src/group/category/entities/group-category.repository.ts
+++ b/BE/src/group/category/entities/group-category.repository.ts
@@ -1,0 +1,13 @@
+import { TransactionalRepository } from '../../../config/transaction-manager/transactional-repository';
+import { CustomRepository } from '../../../config/typeorm/custom-repository.decorator';
+import { GroupCategoryEntity } from './group-category.entity';
+import { GroupCategory } from '../domain/group.category';
+
+@CustomRepository(GroupCategoryEntity)
+export class GroupCategoryRepository extends TransactionalRepository<GroupCategoryEntity> {
+  async saveGroupCategory(groupCategory: GroupCategory) {
+    const newGroupCategory = GroupCategoryEntity.from(groupCategory);
+    await this.repository.save(newGroupCategory);
+    return newGroupCategory.toModel();
+  }
+}

--- a/BE/src/group/group/application/group.service.spec.ts
+++ b/BE/src/group/group/application/group.service.spec.ts
@@ -14,11 +14,21 @@ import { GroupModule } from '../group.module';
 import { UserGroupRepository } from '../entities/user-group.repository';
 import { UserGroupGrade } from '../domain/user-group-grade';
 import { transactionTest } from '../../../../test/common/transaction-test';
+import { GroupFixture } from '../../../../test/group/group/group-fixture';
+import { GroupTestModule } from '../../../../test/group/group/group-test.module';
+import { GroupCategoryFixture } from '../../../../test/group/category/group-category-fixture';
+import { GroupAchievementFixture } from '../../../../test/group/achievement/group-achievement-fixture';
+import { GroupAchievementTestModule } from '../../../../test/group/achievement/group-achievement-test.module';
+import { GroupCategoryTestModule } from '../../../../test/group/category/group-category-test.module';
+import { dateFormat } from '../../../common/utils/date-formatter';
 
 describe('GroupSerivce Test', () => {
   let groupService: GroupService;
   let userGroupRepository: UserGroupRepository;
   let usersFixture: UsersFixture;
+  let groupFixture: GroupFixture;
+  let groupAchievementFixture: GroupAchievementFixture;
+  let groupCategoryFixture: GroupCategoryFixture;
   let dataSource: DataSource;
 
   beforeAll(async () => {
@@ -32,6 +42,9 @@ describe('GroupSerivce Test', () => {
         ]),
         GroupModule,
         UsersTestModule,
+        GroupTestModule,
+        GroupAchievementTestModule,
+        GroupCategoryTestModule,
       ],
       providers: [],
     }).compile();
@@ -39,6 +52,12 @@ describe('GroupSerivce Test', () => {
     groupService = module.get<GroupService>(GroupService);
     userGroupRepository = module.get<UserGroupRepository>(UserGroupRepository);
     usersFixture = module.get<UsersFixture>(UsersFixture);
+    groupFixture = module.get<GroupFixture>(GroupFixture);
+    groupAchievementFixture = module.get<GroupAchievementFixture>(
+      GroupAchievementFixture,
+    );
+    groupCategoryFixture =
+      module.get<GroupCategoryFixture>(GroupCategoryFixture);
     dataSource = module.get<DataSource>(DataSource);
   });
 
@@ -71,6 +90,60 @@ describe('GroupSerivce Test', () => {
       expect(userGroup.group.id).toEqual(groupResponse.id);
       expect(userGroup.user.id).toEqual(user.id);
       expect(userGroup.grade).toEqual(UserGroupGrade.LEADER);
+    });
+  });
+
+  test('내가 속한 그룹 리스트를 조회할 수 있다.', async () => {
+    // given
+    await transactionTest(dataSource, async () => {
+      // given
+      const user = await usersFixture.getUser('ABC');
+      const group1 = await groupFixture.createGroup('Test Group1', user);
+      const group2 = await groupFixture.createGroup('Test Group2', user);
+      const group1Category = await groupCategoryFixture.createCategory(
+        user,
+        group1,
+        'category1',
+      );
+      await groupAchievementFixture.createGroupAchievement(
+        user,
+        group1,
+        group1Category,
+        'achievement',
+      );
+      const lastChallenged =
+        await groupAchievementFixture.createGroupAchievement(
+          user,
+          group1,
+          group1Category,
+          'achievement2',
+        );
+
+      // when
+      const groupListResponse = await groupService.getGroups(user.id);
+
+      // then
+      expect(groupListResponse.data.length).toEqual(2);
+      expect(groupListResponse.data[0].name).toEqual('Test Group1');
+      expect(groupListResponse.data[0].continued).toEqual(2);
+      expect(groupListResponse.data[0].lastChallenged).toEqual(
+        dateFormat(lastChallenged.createdAt),
+      );
+      expect(groupListResponse.data[1].name).toEqual('Test Group2');
+      expect(groupListResponse.data[1].continued).toEqual(0);
+      expect(groupListResponse.data[1].lastChallenged).toEqual(null);
+    });
+  });
+
+  test('내가 속한 그룹 리스트가 없는 경우 빈 배열을 반환한다.', async () => {
+    // given
+    await transactionTest(dataSource, async () => {
+      // given
+      const user = await usersFixture.getUser('ABC');
+      // when
+      const groupListResponse = await groupService.getGroups(user.id);
+      // then
+      expect(groupListResponse.data.length).toEqual(0);
     });
   });
 });

--- a/BE/src/group/group/application/group.service.ts
+++ b/BE/src/group/group/application/group.service.ts
@@ -5,6 +5,7 @@ import { User } from '../../../users/domain/user.domain';
 import { UserGroupGrade } from '../domain/user-group-grade';
 import { Transactional } from '../../../config/transaction-manager';
 import { GroupResponse } from '../dto/group-response.dto';
+import { GroupListResponse } from '../dto/group-list-response';
 
 @Injectable()
 export class GroupService {
@@ -15,5 +16,10 @@ export class GroupService {
     const group = createGroupRequest.toModel();
     group.addMember(user, UserGroupGrade.LEADER);
     return GroupResponse.from(await this.groupRepository.saveGroup(group));
+  }
+
+  async getGroups(userId: number) {
+    const groups = await this.groupRepository.findByUserId(userId);
+    return new GroupListResponse(groups);
   }
 }

--- a/BE/src/group/group/controller/group.controller.spec.ts
+++ b/BE/src/group/group/controller/group.controller.spec.ts
@@ -2,7 +2,14 @@ import { GroupService } from '../application/group.service';
 import { Test, TestingModule } from '@nestjs/testing';
 import { AuthTestModule } from '../../../../test/auth/auth-test.module';
 import { AppModule } from '../../../app.module';
-import { anyOfClass, anything, instance, mock, when } from 'ts-mockito';
+import {
+  anyNumber,
+  anyOfClass,
+  anything,
+  instance,
+  mock,
+  when,
+} from 'ts-mockito';
 import { AuthFixture } from '../../../../test/auth/auth-fixture';
 import { INestApplication, ValidationPipe } from '@nestjs/common';
 import { validationPipeOptions } from '../../../config/validation';
@@ -12,6 +19,7 @@ import * as request from 'supertest';
 import { CreateGroupRequest } from '../dto/create-group-request.dto';
 import { User } from '../../../users/domain/user.domain';
 import { GroupResponse } from '../dto/group-response.dto';
+import { GroupListResponse } from '../dto/group-list-response';
 
 describe('GroupController', () => {
   let app: INestApplication;
@@ -83,16 +91,128 @@ describe('GroupController', () => {
     it('잘못된 인증시 401을 반환한다.', async () => {
       // given
       const accessToken = 'abcd.abcd.efgh';
+      const createGroupRequest = new CreateGroupRequest(
+        'Group Name',
+        'avatarUrl',
+      );
 
       // when
       // then
       return request(app.getHttpServer())
-        .get('/api/v1/achievements')
+        .post('/api/v1/groups')
+        .send(createGroupRequest)
         .set('Authorization', `Bearer ${accessToken}`)
         .expect(401)
         .expect((res: request.Response) => {
           expect(res.body.success).toBe(false);
           expect(res.body.message).toBe('잘못된 토큰입니다.');
+        });
+    });
+    it('만료된 인증정보에 401을 반환한다.', async () => {
+      // given
+      const { accessToken } =
+        await authFixture.getExpiredAccessTokenUser('ABC');
+      const createGroupRequest = new CreateGroupRequest(
+        'Group Name',
+        'avatarUrl',
+      );
+
+      // when
+      // then
+      return request(app.getHttpServer())
+        .post('/api/v1/groups')
+        .send(createGroupRequest)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(401)
+        .expect((res: request.Response) => {
+          expect(res.body.success).toBe(false);
+          expect(res.body.message).toBe('만료된 토큰입니다.');
+        });
+    });
+  });
+  describe('그룹 이름, 달성 기록 수, 최근 달성 기록 등록일자와 함께 그룹 리스트를 조회할수 있다.', () => {
+    it('성공 시 200을 반환한다.', async () => {
+      // given
+      const { accessToken } = await authFixture.getAuthenticatedUser('ABC');
+
+      const groupListResponse = new GroupListResponse([
+        {
+          id: 1,
+          name: 'Test Group1',
+          avatarUrl: 'avatarUrl1',
+          continued: 2,
+          lastChallenged: '2023-11-29T21:58:402Z',
+        },
+        {
+          id: 2,
+          name: 'Test Group2',
+          avatarUrl: 'avatarUrl2',
+          continued: 3,
+          lastChallenged: null,
+        },
+      ]);
+
+      when(mockGroupService.getGroups(anyNumber())).thenResolve(
+        groupListResponse,
+      );
+
+      // when
+      // then
+      return request(app.getHttpServer())
+        .get('/api/v1/groups')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(200)
+        .expect((res: request.Response) => {
+          expect(res.body.success).toEqual(true);
+          expect(res.body.data).toEqual({
+            data: [
+              {
+                avatarUrl: 'avatarUrl1',
+                continued: 2,
+                id: 1,
+                lastChallenged: '2023-11-29T21:58:402Z',
+                name: 'Test Group1',
+              },
+              {
+                avatarUrl: 'avatarUrl2',
+                continued: 3,
+                id: 2,
+                lastChallenged: null,
+                name: 'Test Group2',
+              },
+            ],
+          });
+        });
+    });
+    it('잘못된 인증시 401을 반환한다.', async () => {
+      // given
+      const accessToken = 'abcd.abcd.efgh';
+
+      // when
+      // then
+      return request(app.getHttpServer())
+        .get('/api/v1/groups')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(401)
+        .expect((res: request.Response) => {
+          expect(res.body.success).toBe(false);
+          expect(res.body.message).toBe('잘못된 토큰입니다.');
+        });
+    });
+    it('만료된 인증정보에 401을 반환한다.', async () => {
+      // given
+      const { accessToken } =
+        await authFixture.getExpiredAccessTokenUser('ABC');
+
+      // when
+      // then
+      return request(app.getHttpServer())
+        .get('/api/v1/groups')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(401)
+        .expect((res: request.Response) => {
+          expect(res.body.success).toBe(false);
+          expect(res.body.message).toBe('만료된 토큰입니다.');
         });
     });
   });

--- a/BE/src/group/group/controller/group.controller.ts
+++ b/BE/src/group/group/controller/group.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Get,
   HttpCode,
   HttpStatus,
   Post,
@@ -9,6 +10,7 @@ import {
 import {
   ApiBearerAuth,
   ApiCreatedResponse,
+  ApiOkResponse,
   ApiOperation,
   ApiTags,
 } from '@nestjs/swagger';
@@ -19,6 +21,7 @@ import { GroupResponse } from '../dto/group-response.dto';
 import { User } from '../../../users/domain/user.domain';
 import { CreateGroupRequest } from '../dto/create-group-request.dto';
 import { ApiData } from '../../../common/api/api-data';
+import { GroupListResponse } from '../dto/group-list-response';
 
 @Controller('/api/v1/groups')
 @ApiTags('그룹 API')
@@ -44,5 +47,21 @@ export class GroupController {
     return ApiData.success(
       await this.groupService.create(user, createGroupRequest),
     );
+  }
+
+  @ApiOperation({
+    summary: '그룹 리스트 API',
+    description: '유저가 속해 있는 그룹 리스트를 조회한다.',
+  })
+  @ApiOkResponse({
+    description: '그룹 리스트',
+    type: GroupListResponse,
+  })
+  @ApiBearerAuth('accessToken')
+  @Get()
+  @UseGuards(AccessTokenGuard)
+  @HttpCode(HttpStatus.OK)
+  async getGroups(@AuthenticatedUser() user: User) {
+    return ApiData.success(await this.groupService.getGroups(user.id));
   }
 }

--- a/BE/src/group/group/dto/group-list-response.ts
+++ b/BE/src/group/group/dto/group-list-response.ts
@@ -1,0 +1,9 @@
+import { GroupPreview } from './group-preview.dto';
+
+export class GroupListResponse {
+  data: GroupPreview[];
+
+  constructor(groupPreviews: GroupPreview[]) {
+    this.data = groupPreviews;
+  }
+}

--- a/BE/src/group/group/dto/group-list-response.ts
+++ b/BE/src/group/group/dto/group-list-response.ts
@@ -1,6 +1,8 @@
 import { GroupPreview } from './group-preview.dto';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class GroupListResponse {
+  @ApiProperty({ description: '그룹 목록', type: [GroupPreview] })
   data: GroupPreview[];
 
   constructor(groupPreviews: GroupPreview[]) {

--- a/BE/src/group/group/dto/group-preview.dto.ts
+++ b/BE/src/group/group/dto/group-preview.dto.ts
@@ -1,0 +1,18 @@
+import { IGroupPreview } from '../index';
+import { dateFormat } from '../../../common/utils/date-formatter';
+
+export class GroupPreview {
+  id: number;
+  name: string;
+  avatarUrl: string;
+  continued: number;
+  lastChallenged: string;
+
+  constructor(groupPreview: IGroupPreview) {
+    this.id = groupPreview.id;
+    this.name = groupPreview.name;
+    this.avatarUrl = groupPreview.avatarUrl;
+    this.continued = parseInt(groupPreview.continued);
+    this.lastChallenged = dateFormat(groupPreview.lastChallenged);
+  }
+}

--- a/BE/src/group/group/dto/group-preview.dto.ts
+++ b/BE/src/group/group/dto/group-preview.dto.ts
@@ -1,11 +1,17 @@
 import { IGroupPreview } from '../index';
 import { dateFormat } from '../../../common/utils/date-formatter';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class GroupPreview {
+  @ApiProperty({ description: '그룹 아이디' })
   id: number;
+  @ApiProperty({ description: '그룹 이름' })
   name: string;
+  @ApiProperty({ description: '그룹 로고 Url' })
   avatarUrl: string;
+  @ApiProperty({ description: '그룹 달성기록 총 회수' })
   continued: number;
+  @ApiProperty({ description: '그룹 달성기록 최근 등록 일자' })
   lastChallenged: string;
 
   constructor(groupPreview: IGroupPreview) {

--- a/BE/src/group/group/entities/group.repository.ts
+++ b/BE/src/group/group/entities/group.repository.ts
@@ -2,6 +2,8 @@ import { TransactionalRepository } from '../../../config/transaction-manager/tra
 import { GroupEntity } from './group.entity';
 import { CustomRepository } from '../../../config/typeorm/custom-repository.decorator';
 import { Group } from '../domain/group.domain';
+import { IGroupPreview } from '../index';
+import { GroupPreview } from '../dto/group-preview.dto';
 
 @CustomRepository(GroupEntity)
 export class GroupRepository extends TransactionalRepository<GroupEntity> {
@@ -9,5 +11,24 @@ export class GroupRepository extends TransactionalRepository<GroupEntity> {
     const newGroup = GroupEntity.from(group);
     await this.repository.save(newGroup);
     return newGroup.toModel();
+  }
+
+  async findByUserId(userId: number) {
+    const groupPreviews = await this.repository
+      .createQueryBuilder('group')
+      .leftJoin('group.userGroups', 'user_group')
+      .leftJoin('group.achievements', 'achievements')
+      .select([
+        'group.id as id',
+        'group.name as name',
+        'group.avatarUrl as avatarUrl',
+      ])
+      .addSelect('COUNT(achievements.id)', 'continued')
+      .addSelect('MAX(achievements.created_at)', 'lastChallenged')
+      .where('user_group.user_id = :userId', { userId })
+      .groupBy('group.id')
+      .getRawMany<IGroupPreview>();
+
+    return groupPreviews.map((groupPreview) => new GroupPreview(groupPreview));
   }
 }

--- a/BE/src/group/group/index.ts
+++ b/BE/src/group/group/index.ts
@@ -1,0 +1,7 @@
+export interface IGroupPreview {
+  id: number;
+  name: string;
+  avatarUrl: string;
+  continued: string;
+  lastChallenged: Date;
+}

--- a/BE/test/group/achievement/group-achievement-fixture.ts
+++ b/BE/test/group/achievement/group-achievement-fixture.ts
@@ -2,9 +2,32 @@ import { GroupAchievement } from '../../../src/group/achievement/domain/group-ac
 import { GroupCategory } from '../../../src/group/category/domain/group.category';
 import { Group } from '../../../src/group/group/domain/group.domain';
 import { User } from '../../../src/users/domain/user.domain';
+import { Injectable } from '@nestjs/common';
+import { GroupAchievementRepository } from '../../../src/group/achievement/entities/group-achievement.repository';
 
+@Injectable()
 export class GroupAchievementFixture {
   static id: number = 1;
+
+  constructor(
+    private readonly groupAchievementRepository: GroupAchievementRepository,
+  ) {}
+  async createGroupAchievement(
+    user: User,
+    group: Group,
+    groupCategory: GroupCategory,
+    name?: string,
+  ) {
+    const groupAchievement = GroupAchievementFixture.groupAchievement(
+      user,
+      group,
+      groupCategory,
+      name,
+    );
+    return await this.groupAchievementRepository.saveGroupAchievement(
+      groupAchievement,
+    );
+  }
 
   static groupAchievement(
     user: User,

--- a/BE/test/group/achievement/group-achievement-test.module.ts
+++ b/BE/test/group/achievement/group-achievement-test.module.ts
@@ -1,0 +1,13 @@
+import { CustomTypeOrmModule } from '../../../src/config/typeorm/custom-typeorm.module';
+import { Module } from '@nestjs/common';
+import { GroupAchievementRepository } from '../../../src/group/achievement/entities/group-achievement.repository';
+import { GroupAchievementFixture } from './group-achievement-fixture';
+
+@Module({
+  imports: [
+    CustomTypeOrmModule.forCustomRepository([GroupAchievementRepository]),
+  ],
+  providers: [GroupAchievementFixture],
+  exports: [GroupAchievementFixture],
+})
+export class GroupAchievementTestModule {}

--- a/BE/test/group/category/group-category-fixture.ts
+++ b/BE/test/group/category/group-category-fixture.ts
@@ -1,10 +1,21 @@
 import { GroupCategory } from '../../../src/group/category/domain/group.category';
 import { User } from '../../../src/users/domain/user.domain';
 import { Group } from '../../../src/group/group/domain/group.domain';
+import { GroupCategoryRepository } from '../../../src/group/category/entities/group-category.repository';
+import { Injectable } from '@nestjs/common';
 
+@Injectable()
 export class GroupCategoryFixture {
   static id: number = 0;
 
+  constructor(
+    private readonly groupCategoryRepository: GroupCategoryRepository,
+  ) {}
+
+  async createCategory(user: User, group: Group, name?: string) {
+    const groupCategory = GroupCategoryFixture.groupCategory(user, group, name);
+    return await this.groupCategoryRepository.saveGroupCategory(groupCategory);
+  }
   static groupCategory(user: User, group: Group, name?: string) {
     return new GroupCategory(
       user,

--- a/BE/test/group/category/group-category-test.module.ts
+++ b/BE/test/group/category/group-category-test.module.ts
@@ -1,0 +1,11 @@
+import { CustomTypeOrmModule } from '../../../src/config/typeorm/custom-typeorm.module';
+import { Module } from '@nestjs/common';
+import { GroupCategoryRepository } from '../../../src/group/category/entities/group-category.repository';
+import { GroupCategoryFixture } from './group-category-fixture';
+
+@Module({
+  imports: [CustomTypeOrmModule.forCustomRepository([GroupCategoryRepository])],
+  providers: [GroupCategoryFixture],
+  exports: [GroupCategoryFixture],
+})
+export class GroupCategoryTestModule {}

--- a/BE/test/group/group/group-fixture.ts
+++ b/BE/test/group/group/group-fixture.ts
@@ -1,7 +1,27 @@
+import { User } from '../../../src/users/domain/user.domain';
 import { Group } from '../../../src/group/group/domain/group.domain';
+import { GroupRepository } from '../../../src/group/group/entities/group.repository';
+import { UserGroupGrade } from '../../../src/group/group/domain/user-group-grade';
+import { Injectable } from '@nestjs/common';
 
+@Injectable()
 export class GroupFixture {
   static id: number = 0;
+
+  constructor(private readonly groupRepository: GroupRepository) {}
+
+  async createGroup(name: string, user?: User) {
+    const group = GroupFixture.group(name);
+    if (user) {
+      group.addMember(user, UserGroupGrade.LEADER);
+    }
+    return await this.groupRepository.saveGroup(group);
+  }
+
+  async addMember(group: Group, user: User, userGroupGrade: UserGroupGrade) {
+    group.addMember(user, userGroupGrade);
+    return await this.groupRepository.saveGroup(group);
+  }
 
   static group(name?: string) {
     return new Group(name || `group${++GroupFixture.id}`, 'file://avatarUrl');

--- a/BE/test/group/group/group-test.module.ts
+++ b/BE/test/group/group/group-test.module.ts
@@ -1,0 +1,11 @@
+import { GroupFixture } from './group-fixture';
+import { GroupRepository } from '../../../src/group/group/entities/group.repository';
+import { CustomTypeOrmModule } from '../../../src/config/typeorm/custom-typeorm.module';
+import { Module } from '@nestjs/common';
+
+@Module({
+  imports: [CustomTypeOrmModule.forCustomRepository([GroupRepository])],
+  providers: [GroupFixture],
+  exports: [GroupFixture],
+})
+export class GroupTestModule {}


### PR DESCRIPTION
## PR 요약
- 그룹 리스트 API를 구현
#### 변경 사항
- 그룹 리스트 API 기능 구현
- 테스트를 위한 group category repository, group achievement repository save 함수만 추가
- group category, achievement fixture 함수 추가

##### 스크린샷
<img width="877" alt="image" src="https://github.com/boostcampwm2023/iOS02-moti/assets/34297340/22fb3fd6-06ec-4b95-964f-583b9719febb">

#### Linked Issue
close #262 
close #263 
