### PR TITLE
그룹 기본 로고 설정로직을 추가한다.

### DIFF
--- a/.github/workflows/be.cd.yml
+++ b/.github/workflows/be.cd.yml
@@ -65,6 +65,7 @@ jobs:
           FILESTORE_PREFIX: ${{ secrets.FILESTORE_PREFIX }}
           FILESTORE_IMAGE_PREFIX: ${{ secrets.FILESTORE_IMAGE_PREFIX }}
           FILESTORE_THUMBNAIL_PREFIX: ${{ secrets.FILESTORE_THUMBNAIL_PREFIX }}
+          GROUP_AVATAR_URLS: ${{ secrets.GROUP_AVATAR_URLS }}
           EOF
 
       - name: Install dependencies

--- a/.github/workflows/be.ci.yml
+++ b/.github/workflows/be.ci.yml
@@ -69,6 +69,7 @@ jobs:
           FILESTORE_PREFIX: ${{ secrets.FILESTORE_PREFIX }}
           FILESTORE_IMAGE_PREFIX: ${{ secrets.FILESTORE_IMAGE_PREFIX }}
           FILESTORE_THUMBNAIL_PREFIX: ${{ secrets.FILESTORE_THUMBNAIL_PREFIX }}
+          GROUP_AVATAR_URLS: ${{ secrets.GROUP_AVATAR_URLS }}
           EOF
       - name: Install dependencies
         run: npm ci

--- a/BE/src/group/group/application/group-avatar.holder.spec.ts
+++ b/BE/src/group/group/application/group-avatar.holder.spec.ts
@@ -1,0 +1,25 @@
+import { ConfigService } from '@nestjs/config';
+import { GroupAvatarHolder } from './group-avatar.holder';
+
+describe('GroupAvatarHolder Test', () => {
+  test('기본 group avatarUrl을 환경변수로 부터 가져온다.', () => {
+    //given
+    //when
+    const configService = new ConfigService({
+      GROUP_AVATAR_URLS: 'url1,url2,url3,url4,url5',
+    });
+    const groupAvatarHolder: GroupAvatarHolder = new GroupAvatarHolder(
+      configService,
+    );
+
+    //then
+    expect(groupAvatarHolder.getUrls()).toEqual([
+      'url1',
+      'url2',
+      'url3',
+      'url4',
+      'url5',
+    ]);
+    expect(groupAvatarHolder.getUrls()).toContain(groupAvatarHolder.getUrl());
+  });
+});

--- a/BE/src/group/group/application/group-avatar.holder.ts
+++ b/BE/src/group/group/application/group-avatar.holder.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class GroupAvatarHolder {
+  private readonly defaultAvatarUrls: string[];
+  constructor(configService: ConfigService) {
+    const rawAvatarUrls = configService.get<string>('GROUP_AVATAR_URLS');
+    this.defaultAvatarUrls = rawAvatarUrls.split(',');
+  }
+
+  getUrls() {
+    return this.defaultAvatarUrls;
+  }
+
+  getUrl() {
+    const idx = Math.floor(Math.random() * this.defaultAvatarUrls.length);
+    return this.defaultAvatarUrls[idx];
+  }
+}

--- a/BE/src/group/group/application/group.service.spec.ts
+++ b/BE/src/group/group/application/group.service.spec.ts
@@ -93,6 +93,31 @@ describe('GroupSerivce Test', () => {
     });
   });
 
+  test('avatarUrl 없이 그룹을 생성할 수 있다.', async () => {
+    // given
+    await transactionTest(dataSource, async () => {
+      const user = await usersFixture.getUser('ABC');
+      const createGroupRequest = new CreateGroupRequest('Group Name');
+
+      // when
+      const groupResponse = await groupService.create(user, createGroupRequest);
+      const userGroup = await userGroupRepository.repository.findOne({
+        where: { group: { id: groupResponse.id }, user: { id: user.id } },
+        relations: {
+          group: true,
+          user: true,
+        },
+      });
+
+      // then
+      expect(groupResponse.name).toEqual('Group Name');
+      expect(groupResponse.avatarUrl).not.toBeNull();
+      expect(userGroup.group.id).toEqual(groupResponse.id);
+      expect(userGroup.user.id).toEqual(user.id);
+      expect(userGroup.grade).toEqual(UserGroupGrade.LEADER);
+    });
+  });
+
   test('내가 속한 그룹 리스트를 조회할 수 있다.', async () => {
     // given
     await transactionTest(dataSource, async () => {

--- a/BE/src/group/group/application/group.service.ts
+++ b/BE/src/group/group/application/group.service.ts
@@ -6,15 +6,21 @@ import { UserGroupGrade } from '../domain/user-group-grade';
 import { Transactional } from '../../../config/transaction-manager';
 import { GroupResponse } from '../dto/group-response.dto';
 import { GroupListResponse } from '../dto/group-list-response';
+import { GroupAvatarHolder } from './group-avatar.holder';
 
 @Injectable()
 export class GroupService {
-  constructor(private readonly groupRepository: GroupRepository) {}
+  constructor(
+    private readonly groupRepository: GroupRepository,
+    private readonly groupAvatarHolder: GroupAvatarHolder,
+  ) {}
 
   @Transactional()
   async create(user: User, createGroupRequest: CreateGroupRequest) {
     const group = createGroupRequest.toModel();
     group.addMember(user, UserGroupGrade.LEADER);
+    if (!group.avatarUrl)
+      group.assignAvatarUrl(this.groupAvatarHolder.getUrl());
     return GroupResponse.from(await this.groupRepository.saveGroup(group));
   }
 

--- a/BE/src/group/group/domain/group.domain.spec.ts
+++ b/BE/src/group/group/domain/group.domain.spec.ts
@@ -4,12 +4,25 @@ import { UserGroupGrade } from './user-group-grade';
 
 describe('Group Domain Test', () => {
   test('유저를 추가할 수 있다.', () => {
+    //given
+    //when
     const group = new Group('Test Group', 'avatarUrl');
     const user = new User();
     group.addMember(user, UserGroupGrade.PARTICIPANT);
 
+    //then
     expect(group.userGroups.length).toEqual(1);
     expect(group.userGroups[0].grade).toEqual(UserGroupGrade.PARTICIPANT);
     expect(group.userGroups[0].user).toEqual(user);
+  });
+
+  test('그룹 로고를 설정할 수 있다.', () => {
+    //given
+    //when
+    const group = new Group('Test Group', null);
+    group.assignAvatarUrl('https://image.site/image/group-1.jpg');
+
+    //then
+    expect(group.avatarUrl).toEqual('https://image.site/image/group-1.jpg');
   });
 });

--- a/BE/src/group/group/domain/group.domain.ts
+++ b/BE/src/group/group/domain/group.domain.ts
@@ -17,4 +17,8 @@ export class Group {
   addMember(user: User, userGrade: UserGroupGrade) {
     this.userGroups.push(new UserGroup(user, this, userGrade));
   }
+
+  assignAvatarUrl(url: string) {
+    this.avatarUrl = url;
+  }
 }

--- a/BE/src/group/group/dto/create-group-request.dto.ts
+++ b/BE/src/group/group/dto/create-group-request.dto.ts
@@ -12,7 +12,7 @@ export class CreateGroupRequest {
   @ApiProperty({ description: '그룹 로고 이미지 url', required: false })
   avatarUrl: string;
 
-  constructor(name: string, avatarUrl: string) {
+  constructor(name: string, avatarUrl?: string) {
     this.name = name;
     this.avatarUrl = avatarUrl;
   }

--- a/BE/src/group/group/group.module.ts
+++ b/BE/src/group/group/group.module.ts
@@ -4,6 +4,7 @@ import { CustomTypeOrmModule } from '../../config/typeorm/custom-typeorm.module'
 import { GroupRepository } from './entities/group.repository';
 import { GroupService } from './application/group.service';
 import { UserGroupRepository } from './entities/user-group.repository';
+import { GroupAvatarHolder } from './application/group-avatar.holder';
 
 @Module({
   imports: [
@@ -13,6 +14,6 @@ import { UserGroupRepository } from './entities/user-group.repository';
     ]),
   ],
   controllers: [GroupController],
-  providers: [GroupService],
+  providers: [GroupService, GroupAvatarHolder],
 })
 export class GroupModule {}


### PR DESCRIPTION
## PR 요약
- 그룹 생성시 avatar url 없이 요청시에 기본 그룹 이미지를 설정하도록 로직 추가
#### 변경 사항
- group avatar holder 추가
- 도메인 및 서비스에 관련 로직, 테스트 코드 추가

##### 스크린샷
<img width="755" alt="image" src="https://github.com/boostcampwm2023/iOS02-moti/assets/34297340/c93966ed-d4d8-4b35-8c80-cff45de14bf6">

<img width="773" alt="image" src="https://github.com/boostcampwm2023/iOS02-moti/assets/34297340/30470a21-547f-46dc-9c32-f4f9a034cbe9">


#### Linked Issue
close #340 
