### PR TITLE
달성기록 편집 시 홈 화면의 헤더뷰를 업데이트한다. / HomeViewModel 가독성 개선

### DIFF
--- a/iOS/moti/moti/Data/Sources/Storage/CategoryStorage.swift
+++ b/iOS/moti/moti/Data/Sources/Storage/CategoryStorage.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Domain
+import Core
 
 public final class CategoryStorage: CategoryStorageProtocol {
     public static let shared = CategoryStorage()
@@ -53,11 +54,13 @@ public final class CategoryStorage: CategoryStorageProtocol {
     }
     
     public func decrease(categoryId: Int) {
+        Logger.debug("Decrease Continued \(categoryId)")
         storage[categoryId]?.continued -= 1
         wholeCategory?.continued -= 1
     }
     
     public func increase(categoryId: Int) {
+        Logger.debug("Increase Continued \(categoryId)")
         storage[categoryId]?.continued += 1
         wholeCategory?.continued += 1
     }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementCoordinator.swift
@@ -12,7 +12,7 @@ import Domain
 
 protocol DetailAchievementCoordinatorDelegate: AnyObject {
     func deleteButtonAction(achievementId: Int)
-    func updateAchievement(id: Int, newCategoryId: Int)
+    func updateAchievement(achievementId: Int, newCategoryId: Int)
 }
 
 public final class DetailAchievementCoordinator: Coordinator {
@@ -70,6 +70,6 @@ extension DetailAchievementCoordinator: DetailAchievementViewControllerDelegate 
 extension DetailAchievementCoordinator: EditAchievementCoordinatorDelegate {
     func doneButtonDidClicked(updateAchievementRequestValue: UpdateAchievementRequestValue) {
         detailAchievementViewController?.update(updateAchievementRequestValue: updateAchievementRequestValue)
-        delegate?.updateAchievement(id: updateAchievementRequestValue.id, newCategoryId: updateAchievementRequestValue.body.categoryId)
+        delegate?.updateAchievement(achievementId: updateAchievementRequestValue.id, newCategoryId: updateAchievementRequestValue.body.categoryId)
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementCoordinator.swift
@@ -68,7 +68,7 @@ extension DetailAchievementCoordinator: DetailAchievementViewControllerDelegate 
 }
 
 extension DetailAchievementCoordinator: EditAchievementCoordinatorDelegate {
-    func doneButtonAction(updateAchievementRequestValue: UpdateAchievementRequestValue) {
+    func doneButtonDidClicked(updateAchievementRequestValue: UpdateAchievementRequestValue) {
         detailAchievementViewController?.update(updateAchievementRequestValue: updateAchievementRequestValue)
         delegate?.updateAchievement(id: updateAchievementRequestValue.id, newCategoryId: updateAchievementRequestValue.body.categoryId)
     }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementCoordinator.swift
@@ -11,7 +11,7 @@ import Data
 import Domain
 
 protocol EditAchievementCoordinatorDelegate: AnyObject {
-    func doneButtonAction(updateAchievementRequestValue: UpdateAchievementRequestValue)
+    func doneButtonDidClicked(updateAchievementRequestValue: UpdateAchievementRequestValue)
 }
 
 final class EditAchievementCoordinator: Coordinator {
@@ -86,12 +86,12 @@ final class EditAchievementCoordinator: Coordinator {
 }
 
 extension EditAchievementCoordinator: EditAchievementViewControllerDelegate {
-    func doneButtonDidClickedFromEditMode(updateAchievementRequestValue: UpdateAchievementRequestValue) {
+    func doneButtonDidClickedFromDetailView(updateAchievementRequestValue: UpdateAchievementRequestValue) {
         parentCoordinator?.dismiss(child: self, animated: true)
-        delegate?.doneButtonAction(updateAchievementRequestValue: updateAchievementRequestValue)
+        delegate?.doneButtonDidClicked(updateAchievementRequestValue: updateAchievementRequestValue)
     }
     
-    func doneButtonDidClickedFromCaptureMode() {
+    func doneButtonDidClickedFromCaptureView() {
         navigationController.setNavigationBarHidden(true, animated: false)
         finish(animated: false)
         parentCoordinator?.finish(animated: true)

--- a/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementViewController.swift
@@ -12,8 +12,8 @@ import Combine
 import Domain
 
 protocol EditAchievementViewControllerDelegate: AnyObject {
-    func doneButtonDidClickedFromEditMode(updateAchievementRequestValue: UpdateAchievementRequestValue)
-    func doneButtonDidClickedFromCaptureMode()
+    func doneButtonDidClickedFromDetailView(updateAchievementRequestValue: UpdateAchievementRequestValue)
+    func doneButtonDidClickedFromCaptureView()
 }
 
 final class EditAchievementViewController: BaseViewController<EditAchievementView> {
@@ -66,7 +66,7 @@ final class EditAchievementViewController: BaseViewController<EditAchievementVie
         navigationItem.rightBarButtonItem = UIBarButtonItem(
             barButtonSystemItem: .done,
             target: self,
-            action: #selector(doneButtonAction)
+            action: #selector(doneButtonDidClicked)
         )
         
         viewModel.action(.fetchCategories)
@@ -144,7 +144,7 @@ final class EditAchievementViewController: BaseViewController<EditAchievementVie
                 switch state {
                 case .none, .loading: break
                 case .finish(let updateAchievementRequestValue):
-                    delegate?.doneButtonDidClickedFromEditMode(updateAchievementRequestValue: updateAchievementRequestValue)
+                    delegate?.doneButtonDidClickedFromDetailView(updateAchievementRequestValue: updateAchievementRequestValue)
                 case .error:
                     Logger.error("Achievement Update Error")
                 }
@@ -158,7 +158,7 @@ final class EditAchievementViewController: BaseViewController<EditAchievementVie
         layoutView.selectDoneButton.addTarget(self, action: #selector(donePicker), for: .touchUpInside)
     }
     
-    @objc func doneButtonAction() {
+    @objc func doneButtonDidClicked() {
         if let achievement { // 상세 화면에서 넘어옴 => 수정 API
             let updateAchievementRequestValue = UpdateAchievementRequestValue(
                 id: achievement.id,
@@ -172,7 +172,7 @@ final class EditAchievementViewController: BaseViewController<EditAchievementVie
             viewModel.action(.updateAchievement(updateAchievementRequestValue: updateAchievementRequestValue))
             
         } else { // 촬영 화면에서 넘어옴 => 생성 API
-            delegate?.doneButtonDidClickedFromCaptureMode()
+            delegate?.doneButtonDidClickedFromCaptureView()
         }
     }
     

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeActionState.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeActionState.swift
@@ -1,0 +1,45 @@
+//
+//  HomeActionState.swift
+//  
+//
+//  Created by 유정주 on 11/30/23.
+//
+
+import Foundation
+import Domain
+
+extension HomeViewModel {
+    enum HomeViewModelAction {
+        case launch
+        case addCategory(name: String)
+        case fetchNextPage
+        case fetchCategoryList(category: CategoryItem)
+        case delete(achievementId: Int)
+        case updateAchievement(id: Int, newCategoryId: Int)
+    }
+    
+    enum CategoryListState {
+        case initial
+        case finish
+        case error(message: String)
+    }
+    
+    enum CategoryState {
+        case initial
+        case updated(category: CategoryItem)
+    }
+    
+    enum AddCategoryState {
+        case none
+        case loading
+        case finish
+        case error(message: String)
+    }
+    
+    enum AchievementState {
+        case initial
+        case loading
+        case finish
+        case error(message: String)
+    }
+}

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeCoordinator.swift
@@ -81,7 +81,7 @@ extension HomeCoordinator: DetailAchievementCoordinatorDelegate {
         currentViewController?.delete(achievementId: achievementId)
     }
     
-    func updateAchievement(id: Int, newCategoryId: Int) {
-        currentViewController?.updateAchievement(id: id, newCategoryId: newCategoryId)
+    func updateAchievement(achievementId: Int, newCategoryId: Int) {
+        currentViewController?.updateAchievement(achievementId: achievementId, newCategoryId: newCategoryId)
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewController.swift
@@ -108,6 +108,7 @@ final class HomeViewController: BaseViewController<HomeView> {
                 switch state {
                 case .initial: break
                 case .updated(let category):
+                    Logger.debug("Updated: \(category)")
                     layoutView.updateAchievementHeader(with: category)
                 }
             }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewController.swift
@@ -44,8 +44,8 @@ final class HomeViewController: BaseViewController<HomeView> {
         viewModel.action(.delete(achievementId: achievementId))
     }
     
-    func updateAchievement(id: Int, newCategoryId: Int) {
-        viewModel.action(.updateAchievement(id: id, newCategoryId: newCategoryId))
+    func updateAchievement(achievementId: Int, newCategoryId: Int) {
+        viewModel.action(.updateAchievement(id: achievementId, newCategoryId: newCategoryId))
     }
     
     private func bind() {

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewModel.swift
@@ -142,6 +142,8 @@ final class HomeViewModel {
     private func updateAchievement(id: Int, newCategoryId: Int) {
         guard let currentCategory, currentCategory.id != 0 else { return }
         if currentCategory.id != newCategoryId {
+            CategoryStorage.shared.decrease(categoryId: id)
+            CategoryStorage.shared.increase(categoryId: newCategoryId)
             delete(achievementId: id)
         }
     }


### PR DESCRIPTION
## PR 요약
- 달성기록 편집 시 홈 화면의 헤더뷰를 업데이트한다.
- HomeViewModel 가독성 개선

#### 변경 사항
- ViewModel 작성하실 때 이번 수정내용 참고해서 작성해 주세요!

##### 스크린샷
<img src="https://github.com/boostcampwm2023/iOS02-moti/assets/89075274/38bbb88a-9466-4bac-b41e-f825e120ab99" width="50%">


#### Linked Issue
close #343 
