### PR TITLE
달성 기록 등록 API 응답이 OK면 홈 화면으로 이동한다.

### DIFF
--- a/iOS/moti/moti/Data/Sources/Data/Network/DTO/AchievementListDTO.swift
+++ b/iOS/moti/moti/Data/Sources/Data/Network/DTO/AchievementListDTO.swift
@@ -30,6 +30,20 @@ struct AchievementSimpleDTO: Codable {
     let id: Int?
     let thumbnailUrl: URL?
     let title: String?
+    
+    init(id: Int?, thumbnailUrl: URL?, title: String?) {
+        self.id = id
+        self.thumbnailUrl = thumbnailUrl
+        self.title = title
+    }
+    
+    init(dto: DetailAchievementDTO) {
+        self.init(
+            id: dto.id,
+            thumbnailUrl: dto.imageUrl,
+            title: dto.title
+        )
+    }
 }
 
 extension Achievement {

--- a/iOS/moti/moti/Data/Sources/Data/Network/Endpoint/MotiAPI.swift
+++ b/iOS/moti/moti/Data/Sources/Data/Network/Endpoint/MotiAPI.swift
@@ -19,6 +19,7 @@ enum MotiAPI: EndpointProtocol {
     case saveImage(requestValue: SaveImageRequestValue)
     case deleteAchievement(requestValue: DeleteAchievementRequestValue)
     case updateAchievement(requestValue: UpdateAchievementRequestValue)
+    case postAchievement(requestValue: PostAchievementRequestValue)
 }
 
 extension MotiAPI {
@@ -42,6 +43,7 @@ extension MotiAPI {
         case .saveImage: return "/images"
         case .deleteAchievement(let requestValue): return "/achievements/\(requestValue.id)"
         case .updateAchievement(let requestValue): return "/achievements/\(requestValue.id)"
+        case .postAchievement: return "/achievements"
         }
     }
     
@@ -57,6 +59,7 @@ extension MotiAPI {
         case .saveImage: return .post
         case .deleteAchievement: return .delete
         case .updateAchievement: return .put
+        case .postAchievement: return .post
         }
     }
     
@@ -79,6 +82,8 @@ extension MotiAPI {
             return requestValue
         case .updateAchievement(let requestValue):
             return requestValue.body
+        case .postAchievement(let requestValue):
+            return requestValue
         default:
             return nil
         }

--- a/iOS/moti/moti/Data/Sources/Repository/AchievementRepository.swift
+++ b/iOS/moti/moti/Data/Sources/Repository/AchievementRepository.swift
@@ -62,4 +62,13 @@ public struct AchievementRepository: AchievementRepositoryProtocol {
         guard let isSuccess = responseDTO.success else { throw NetworkError.decode }
         return isSuccess
     }
+    
+    public func postAchievement(requestValue: PostAchievementRequestValue) async throws -> Achievement {
+        let endpoint = MotiAPI.postAchievement(requestValue: requestValue)
+        let responseDTO = try await provider.request(with: endpoint, type: DetailAchievementResponseDTO.self)
+
+        guard let detailAchievementDataDTO = responseDTO.data else { throw NetworkError.decode }
+        let achievementSimpleDTO = AchievementSimpleDTO(dto: detailAchievementDataDTO)
+        return Achievement(dto: achievementSimpleDTO)
+    }
 }

--- a/iOS/moti/moti/Domain/Sources/Domain/RepositoryProtocol/AchievementRepositoryProtocol.swift
+++ b/iOS/moti/moti/Domain/Sources/Domain/RepositoryProtocol/AchievementRepositoryProtocol.swift
@@ -23,4 +23,8 @@ public protocol AchievementRepositoryProtocol {
     func updateAchievement(
         requestValue: UpdateAchievementRequestValue
     ) async throws -> Bool
+    
+    func postAchievement(
+        requestValue: PostAchievementRequestValue
+    ) async throws -> Achievement
 }

--- a/iOS/moti/moti/Domain/Sources/Domain/UseCase/PostAchievementUseCase.swift
+++ b/iOS/moti/moti/Domain/Sources/Domain/UseCase/PostAchievementUseCase.swift
@@ -1,0 +1,34 @@
+//
+//  PostAchievementUseCase.swift
+//
+//
+//  Created by Kihyun Lee on 11/30/23.
+//
+
+import Foundation
+
+public struct PostAchievementRequestValue: RequestValue {
+    public let title: String
+    public let content: String
+    public let categoryId: Int
+    public let photoId: Int
+    
+    public init(title: String, content: String, categoryId: Int, photoId: Int) {
+        self.title = title
+        self.content = content
+        self.categoryId = categoryId
+        self.photoId = photoId
+    }
+}
+
+public struct PostAchievementUseCase {
+    private let repository: AchievementRepositoryProtocol
+    
+    public init(repository: AchievementRepositoryProtocol) {
+        self.repository = repository
+    }
+    
+    public func execute(requestValue: PostAchievementRequestValue) async throws -> Achievement {
+        return try await repository.postAchievement(requestValue: requestValue)
+    }
+}

--- a/iOS/moti/moti/Domain/Sources/Domain/UseCase/SaveImageUseCase.swift
+++ b/iOS/moti/moti/Domain/Sources/Domain/UseCase/SaveImageUseCase.swift
@@ -26,7 +26,7 @@ public struct SaveImageUseCase {
         self.repository = repository
     }
     
-    public func excute(requestValue: SaveImageRequestValue) async throws -> (Bool, Int) {
+    public func execute(requestValue: SaveImageRequestValue) async throws -> (Bool, Int) {
         return try await repository.saveImage(requestValue: requestValue)
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Capture/CaptureCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Capture/CaptureCoordinator.swift
@@ -9,11 +9,16 @@ import UIKit
 import Core
 import Domain
 
+protocol CaptureCoordinatorDelegate: AnyObject {
+    func postAchievement(newAchievement: Achievement)
+}
+
 final class CaptureCoordinator: Coordinator {
     var parentCoordinator: Coordinator?
     var childCoordinators: [Coordinator] = []
     var navigationController: UINavigationController
     private var currentNavigationController: UINavigationController?
+    weak var delegate: CaptureCoordinatorDelegate?
     
     init(
         _ navigationController: UINavigationController,
@@ -41,6 +46,7 @@ final class CaptureCoordinator: Coordinator {
     
     private func moveEditAchievementViewConrtoller(image: UIImage) {
         let editAchievementCoordinator = EditAchievementCoordinator(navigationController, self)
+        editAchievementCoordinator.delegate = self
         editAchievementCoordinator.startAfterCapture(image: image)
         childCoordinators.append(editAchievementCoordinator)
     }
@@ -54,5 +60,15 @@ final class CaptureCoordinator: Coordinator {
 extension CaptureCoordinator: CaptureViewControllerDelegate {
     func didCapture(image: UIImage) {
         moveEditAchievementViewConrtoller(image: image)
+    }
+}
+
+extension CaptureCoordinator: EditAchievementCoordinatorDelegate {
+    func doneButtonDidClickedFromDetail(updateAchievementRequestValue: UpdateAchievementRequestValue) {
+        
+    }
+    
+    func doneButtonDidClickedFromCapture(newAchievement: Achievement) {
+        delegate?.postAchievement(newAchievement: newAchievement)
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Capture/CaptureCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Capture/CaptureCoordinator.swift
@@ -10,7 +10,7 @@ import Core
 import Domain
 
 protocol CaptureCoordinatorDelegate: AnyObject {
-    func postAchievement(newAchievement: Achievement)
+    func achievementDidPosted(newAchievement: Achievement)
 }
 
 final class CaptureCoordinator: Coordinator {
@@ -69,6 +69,6 @@ extension CaptureCoordinator: EditAchievementCoordinatorDelegate {
     }
     
     func doneButtonDidClickedFromCapture(newAchievement: Achievement) {
-        delegate?.postAchievement(newAchievement: newAchievement)
+        delegate?.achievementDidPosted(newAchievement: newAchievement)
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementCoordinator.swift
@@ -13,7 +13,7 @@ import Domain
 protocol DetailAchievementCoordinatorDelegate: AnyObject {
     func deleteButtonAction(achievementId: Int)
     func updateAchievement(achievementId: Int, newCategoryId: Int)
-    func postAchievement(newAchievement: Achievement)
+    func achievementDidPosted(newAchievement: Achievement)
 }
 
 public final class DetailAchievementCoordinator: Coordinator {
@@ -75,6 +75,6 @@ extension DetailAchievementCoordinator: EditAchievementCoordinatorDelegate {
     }
     
     func doneButtonDidClickedFromCapture(newAchievement: Achievement) {
-        delegate?.postAchievement(newAchievement: newAchievement)
+        delegate?.achievementDidPosted(newAchievement: newAchievement)
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementCoordinator.swift
@@ -69,13 +69,12 @@ extension DetailAchievementCoordinator: DetailAchievementViewControllerDelegate 
 }
 
 extension DetailAchievementCoordinator: EditAchievementCoordinatorDelegate {
-    func doneButtonDidClicked(updateAchievementRequestValue: UpdateAchievementRequestValue) {
+    func doneButtonDidClickedFromDetail(updateAchievementRequestValue: UpdateAchievementRequestValue) {
         detailAchievementViewController?.update(updateAchievementRequestValue: updateAchievementRequestValue)
         delegate?.updateAchievement(achievementId: updateAchievementRequestValue.id, newCategoryId: updateAchievementRequestValue.body.categoryId)
     }
     
-    func postAchievement(newAchievement: Achievement) {
-        print("-3")
+    func doneButtonDidClickedFromCapture(newAchievement: Achievement) {
         delegate?.postAchievement(newAchievement: newAchievement)
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementCoordinator.swift
@@ -13,6 +13,7 @@ import Domain
 protocol DetailAchievementCoordinatorDelegate: AnyObject {
     func deleteButtonAction(achievementId: Int)
     func updateAchievement(achievementId: Int, newCategoryId: Int)
+    func postAchievement(newAchievement: Achievement)
 }
 
 public final class DetailAchievementCoordinator: Coordinator {
@@ -71,5 +72,10 @@ extension DetailAchievementCoordinator: EditAchievementCoordinatorDelegate {
     func doneButtonDidClicked(updateAchievementRequestValue: UpdateAchievementRequestValue) {
         detailAchievementViewController?.update(updateAchievementRequestValue: updateAchievementRequestValue)
         delegate?.updateAchievement(achievementId: updateAchievementRequestValue.id, newCategoryId: updateAchievementRequestValue.body.categoryId)
+    }
+    
+    func postAchievement(newAchievement: Achievement) {
+        print("-3")
+        delegate?.postAchievement(newAchievement: newAchievement)
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementCoordinator.swift
@@ -11,8 +11,8 @@ import Data
 import Domain
 
 protocol EditAchievementCoordinatorDelegate: AnyObject {
-    func doneButtonDidClicked(updateAchievementRequestValue: UpdateAchievementRequestValue)
-    func postAchievement(newAchievement: Achievement)
+    func doneButtonDidClickedFromDetail(updateAchievementRequestValue: UpdateAchievementRequestValue)
+    func doneButtonDidClickedFromCapture(newAchievement: Achievement)
 }
 
 final class EditAchievementCoordinator: Coordinator {
@@ -91,12 +91,11 @@ final class EditAchievementCoordinator: Coordinator {
 extension EditAchievementCoordinator: EditAchievementViewControllerDelegate {
     func doneButtonDidClickedFromDetailView(updateAchievementRequestValue: UpdateAchievementRequestValue) {
         parentCoordinator?.dismiss(child: self, animated: true)
-        delegate?.doneButtonDidClicked(updateAchievementRequestValue: updateAchievementRequestValue)
+        delegate?.doneButtonDidClickedFromDetail(updateAchievementRequestValue: updateAchievementRequestValue)
     }
     
     func doneButtonDidClickedFromCaptureView(newAchievement: Achievement) {
-        print("여기4", delegate)
-        delegate?.postAchievement(newAchievement: newAchievement)
+        delegate?.doneButtonDidClickedFromCapture(newAchievement: newAchievement)
         navigationController.setNavigationBarHidden(true, animated: false)
         finish(animated: false)
         parentCoordinator?.finish(animated: true)

--- a/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementCoordinator.swift
@@ -12,6 +12,7 @@ import Domain
 
 protocol EditAchievementCoordinatorDelegate: AnyObject {
     func doneButtonDidClicked(updateAchievementRequestValue: UpdateAchievementRequestValue)
+    func postAchievement(newAchievement: Achievement)
 }
 
 final class EditAchievementCoordinator: Coordinator {
@@ -36,7 +37,8 @@ final class EditAchievementCoordinator: Coordinator {
         let editAchievementVM = EditAchievementViewModel(
             saveImageUseCase: .init(repository: ImageRepository()),
             fetchCategoryListUseCase: .init(repository: CategoryListRepository()),
-            updateAchievementUseCase: .init(repository: AchievementRepository())
+            updateAchievementUseCase: .init(repository: AchievementRepository()), 
+            postAchievementUseCase: .init(repository: AchievementRepository())
         )
         let editAchievementVC = EditAchievementViewController(
             viewModel: editAchievementVM,
@@ -58,7 +60,8 @@ final class EditAchievementCoordinator: Coordinator {
         let editAchievementVM = EditAchievementViewModel(
             saveImageUseCase: .init(repository: ImageRepository()),
             fetchCategoryListUseCase: .init(repository: CategoryListRepository()),
-            updateAchievementUseCase: .init(repository: AchievementRepository())
+            updateAchievementUseCase: .init(repository: AchievementRepository()),
+            postAchievementUseCase: .init(repository: AchievementRepository())
         )
         let editAchievementVC = EditAchievementViewController(
             viewModel: editAchievementVM,
@@ -91,7 +94,9 @@ extension EditAchievementCoordinator: EditAchievementViewControllerDelegate {
         delegate?.doneButtonDidClicked(updateAchievementRequestValue: updateAchievementRequestValue)
     }
     
-    func doneButtonDidClickedFromCaptureView() {
+    func doneButtonDidClickedFromCaptureView(newAchievement: Achievement) {
+        print("여기4", delegate)
+        delegate?.postAchievement(newAchievement: newAchievement)
         navigationController.setNavigationBarHidden(true, animated: false)
         finish(animated: false)
         parentCoordinator?.finish(animated: true)

--- a/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementViewController.swift
@@ -186,9 +186,12 @@ final class EditAchievementViewController: BaseViewController<EditAchievementVie
             viewModel.action(.updateAchievement(updateAchievementRequestValue: updateAchievementRequestValue))
             
         } else { // 촬영 화면에서 넘어옴 => 생성 API
-            guard var title = layoutView.titleTextField.placeholder else { return }
+            var title = ""
             if let text = layoutView.titleTextField.text, !text.isEmpty {
                 title = text
+            } else {
+                guard let placeholder = layoutView.titleTextField.placeholder else { return }
+                title = placeholder
             }
             
             viewModel.action(.postAchievement(

--- a/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementViewController.swift
@@ -13,7 +13,7 @@ import Domain
 
 protocol EditAchievementViewControllerDelegate: AnyObject {
     func doneButtonDidClickedFromDetailView(updateAchievementRequestValue: UpdateAchievementRequestValue)
-    func doneButtonDidClickedFromCaptureView()
+    func doneButtonDidClickedFromCaptureView(newAchievement: Achievement)
 }
 
 final class EditAchievementViewController: BaseViewController<EditAchievementView> {
@@ -150,6 +150,20 @@ final class EditAchievementViewController: BaseViewController<EditAchievementVie
                 }
             }
             .store(in: &cancellables)
+        
+        viewModel.$postAchievementState
+            .receive(on: RunLoop.main)
+            .sink { [weak self] state in
+                guard let self else { return }
+                switch state {
+                case .none, .loading: break
+                case .finish(let newAchievement):
+                    delegate?.doneButtonDidClickedFromCaptureView(newAchievement: newAchievement)
+                case .error:
+                    Logger.error("Achievement Post Error")
+                }
+            }
+            .store(in: &cancellables)
 
     }
     
@@ -172,7 +186,16 @@ final class EditAchievementViewController: BaseViewController<EditAchievementVie
             viewModel.action(.updateAchievement(updateAchievementRequestValue: updateAchievementRequestValue))
             
         } else { // 촬영 화면에서 넘어옴 => 생성 API
-            delegate?.doneButtonDidClickedFromCaptureView()
+            guard var title = layoutView.titleTextField.placeholder else { return }
+            if let text = layoutView.titleTextField.text, !text.isEmpty {
+                title = text
+            }
+            
+            viewModel.action(.postAchievement(
+                title: title,
+                content: bottomSheet.text,
+                categoryId: findSelectedCategory().id)
+            )
         }
     }
     

--- a/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementViewModel.swift
@@ -53,6 +53,8 @@ final class EditAchievementViewModel {
     var firstCategory: CategoryItem? {
         return categories.first
     }
+    
+    /// 이미지 선저장으로 받아 놓은 사진 ID: post할 때 이 ID를 포함하여 post한다.
     private var photoId: Int?
     
     @Published private(set) var categoryState: CategoryState = .none

--- a/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementViewModel.swift
@@ -42,7 +42,7 @@ final class EditAchievementViewModel {
         case none
         case loading
         case finish(newAchievement: Achievement)
-        case error
+        case error(message: String)
     }
     
     private let saveImageUseCase: SaveImageUseCase
@@ -155,7 +155,10 @@ final class EditAchievementViewModel {
     private func postAchievement(title: String, content: String, categoryId: Int) {
         Task {
             do {
-                guard let photoId else { return }
+                guard let photoId else {
+                    postAchievementState = .error(message: "post achievement error: not exist photoId")
+                    return
+                }
                 let requestValue = PostAchievementRequestValue(
                     title: title,
                     content: content,
@@ -167,7 +170,7 @@ final class EditAchievementViewModel {
                 let newAchievement = try await postAchievementUseCase.execute(requestValue: requestValue)
                 postAchievementState = .finish(newAchievement: newAchievement)
             } catch {
-                postAchievementState = .error
+                postAchievementState = .error(message: "post achievement error")
             }
         }
     }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementViewModel.swift
@@ -15,6 +15,7 @@ final class EditAchievementViewModel {
         case saveImage(data: Data)
         case fetchCategories
         case updateAchievement(updateAchievementRequestValue: UpdateAchievementRequestValue)
+        case postAchievement(title: String, content: String, categoryId: Int)
     }
     
     enum CategoryState {
@@ -37,26 +38,38 @@ final class EditAchievementViewModel {
         case error
     }
     
+    enum PostAchievementState {
+        case none
+        case loading
+        case finish(newAchievement: Achievement)
+        case error
+    }
+    
     private let saveImageUseCase: SaveImageUseCase
     private let fetchCategoryListUseCase: FetchCategoryListUseCase
     private let updateAchievementUseCase: UpdateAchievementUseCase
+    private let postAchievementUseCase: PostAchievementUseCase
     private(set) var categories: [CategoryItem] = []
     var firstCategory: CategoryItem? {
         return categories.first
     }
+    private var photoId: Int?
     
     @Published private(set) var categoryState: CategoryState = .none
     @Published private(set) var saveImageState: SaveImageState = .none
     @Published private(set) var updateAchievementState: UpdateAchievementState = .none
+    @Published private(set) var postAchievementState: PostAchievementState = .none
     
     init(
         saveImageUseCase: SaveImageUseCase,
         fetchCategoryListUseCase: FetchCategoryListUseCase,
-        updateAchievementUseCase: UpdateAchievementUseCase
+        updateAchievementUseCase: UpdateAchievementUseCase,
+        postAchievementUseCase: PostAchievementUseCase
     ) {
         self.saveImageUseCase = saveImageUseCase
         self.fetchCategoryListUseCase = fetchCategoryListUseCase
         self.updateAchievementUseCase = updateAchievementUseCase
+        self.postAchievementUseCase = postAchievementUseCase
     }
 
     func action(_ action: Action) {
@@ -67,6 +80,8 @@ final class EditAchievementViewModel {
             fetchCategories()
         case .updateAchievement(let updateAchievementRequestValue):
             updateAchievement(updateAchievementRequestValue: updateAchievementRequestValue)
+        case .postAchievement(let title, let content, let categoryId):
+            postAchievement(title: title, content: content, categoryId: categoryId)
         }
     }
     
@@ -110,8 +125,9 @@ final class EditAchievementViewModel {
                     contentType: "jpeg", // heic로 테스트 해봤지만 전송되는 파일 데이터가 jpeg라서 의미 없음을 확인함. 따라서 jpeg로 통일해서 전송
                     imageData: data
                 )
-                let (isSuccess, imageId) = try await saveImageUseCase.excute(requestValue: requestValue)
-                Logger.debug("Upload: \(isSuccess) / id: \(imageId)")
+                let (isSuccess, photoId) = try await saveImageUseCase.execute(requestValue: requestValue)
+                Logger.debug("Upload: \(isSuccess) / id: \(photoId)")
+                self.photoId = photoId
                 saveImageState = .finish
             } catch {
                 saveImageState = .error
@@ -131,9 +147,28 @@ final class EditAchievementViewModel {
                     updateAchievementState = .error
                 }
             } catch {
-                saveImageState = .error
+                updateAchievementState = .error
             }
         }
-        
+    }
+    
+    private func postAchievement(title: String, content: String, categoryId: Int) {
+        Task {
+            do {
+                guard let photoId else { return }
+                let requestValue = PostAchievementRequestValue(
+                    title: title,
+                    content: content,
+                    categoryId: categoryId,
+                    photoId: photoId
+                )
+                
+                postAchievementState = .loading
+                let newAchievement = try await postAchievementUseCase.execute(requestValue: requestValue)
+                postAchievementState = .finish(newAchievement: newAchievement)
+            } catch {
+                postAchievementState = .error
+            }
+        }
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeActionState.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeActionState.swift
@@ -16,6 +16,7 @@ extension HomeViewModel {
         case fetchCategoryList(category: CategoryItem)
         case delete(achievementId: Int)
         case updateAchievement(id: Int, newCategoryId: Int)
+        case postAchievement(newAchievement: Achievement)
     }
     
     enum CategoryListState {

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeCoordinator.swift
@@ -54,7 +54,7 @@ extension HomeCoordinator: DetailAchievementCoordinatorDelegate {
         currentViewController?.updateAchievement(achievementId: achievementId, newCategoryId: newCategoryId)
     }
     
-    func postAchievement(newAchievement: Achievement) {
-        currentViewController?.postAchievement(newAchievement: newAchievement)
+    func achievementDidPosted(newAchievement: Achievement) {
+        currentViewController?.achievementDidPosted(newAchievement: newAchievement)
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeCoordinator.swift
@@ -86,7 +86,6 @@ extension HomeCoordinator: DetailAchievementCoordinatorDelegate {
     }
     
     func postAchievement(newAchievement: Achievement) {
-        print("-2")
         currentViewController?.postAchievement(newAchievement: newAchievement)
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeCoordinator.swift
@@ -84,4 +84,9 @@ extension HomeCoordinator: DetailAchievementCoordinatorDelegate {
     func updateAchievement(achievementId: Int, newCategoryId: Int) {
         currentViewController?.updateAchievement(achievementId: achievementId, newCategoryId: newCategoryId)
     }
+    
+    func postAchievement(newAchievement: Achievement) {
+        print("-2")
+        currentViewController?.postAchievement(newAchievement: newAchievement)
+    }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewController.swift
@@ -50,7 +50,6 @@ final class HomeViewController: BaseViewController<HomeView> {
     }
     
     func postAchievement(newAchievement: Achievement) {
-        print("막전")
         viewModel.action(.postAchievement(newAchievement: newAchievement))
     }
     

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewController.swift
@@ -9,6 +9,7 @@ import UIKit
 import Combine
 import Core
 import Data
+import Domain
 
 final class HomeViewController: BaseViewController<HomeView> {
 
@@ -46,6 +47,11 @@ final class HomeViewController: BaseViewController<HomeView> {
     
     func updateAchievement(achievementId: Int, newCategoryId: Int) {
         viewModel.action(.updateAchievement(id: achievementId, newCategoryId: newCategoryId))
+    }
+    
+    func postAchievement(newAchievement: Achievement) {
+        print("막전")
+        viewModel.action(.postAchievement(newAchievement: newAchievement))
     }
     
     private func bind() {

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewController.swift
@@ -51,7 +51,7 @@ final class HomeViewController: BaseViewController<HomeView> {
         viewModel.action(.updateAchievement(id: achievementId, newCategoryId: newCategoryId))
     }
     
-    func postAchievement(newAchievement: Achievement) {
+    func achievementDidPosted(newAchievement: Achievement) {
         viewModel.action(.postAchievement(newAchievement: newAchievement))
     }
     

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewModel.swift
@@ -98,6 +98,8 @@ final class HomeViewModel {
             deleteOfDataSource(achievementId: achievementId)
         case .updateAchievement(let id, let newCategoryId):
             updateAchievementCategory(achievementId: id, newCategoryId: newCategoryId)
+        case .postAchievement(let newAchievement):
+            postAchievement(newAchievement: newAchievement)
         }
     }
 }
@@ -174,6 +176,12 @@ private extension HomeViewModel {
         if currentCategory.id != newCategoryId {
             deleteOfDataSource(achievementId: achievementId)
         }
+    }
+    
+    /// 새로 생성된 도전 기록을 추가하는 액션
+    func postAchievement(newAchievement: Achievement) {
+        print("최종")
+        achievements.insert(newAchievement, at: 0)
     }
 }
 

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewModel.swift
@@ -180,7 +180,6 @@ private extension HomeViewModel {
     
     /// 새로 생성된 도전 기록을 추가하는 액션
     func postAchievement(newAchievement: Achievement) {
-        print("최종")
         achievements.insert(newAchievement, at: 0)
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/TabBar/TabBarCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/TabBar/TabBarCoordinator.swift
@@ -9,6 +9,7 @@ import UIKit
 import Design
 import Core
 import Data
+import Domain
 
 public final class TabBarCoordinator: Coordinator {
     enum TabItemType: CaseIterable {
@@ -55,6 +56,7 @@ public final class TabBarCoordinator: Coordinator {
   
     private func moveCaptureViewController() {
         let captureCoordinator = CaptureCoordinator(navigationController, self)
+        captureCoordinator.delegate = self
         captureCoordinator.start()
         childCoordinators.append(captureCoordinator)
     }
@@ -88,5 +90,15 @@ private extension TabBarCoordinator {
 extension TabBarCoordinator: TabBarViewControllerDelegate {
     func captureButtonDidClicked() {
         moveCaptureViewController()
+    }
+}
+
+extension TabBarCoordinator: CaptureCoordinatorDelegate {
+    func postAchievement(newAchievement: Achievement) {
+        guard let naviVC = tabBarController.viewControllers?.first as? UINavigationController else { return }
+        
+        guard let homeVC = naviVC.viewControllers.compactMap({ $0 as? HomeViewController}).first else { return }
+        
+        homeVC.postAchievement(newAchievement: newAchievement)
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/TabBar/TabBarCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/TabBar/TabBarCoordinator.swift
@@ -94,11 +94,11 @@ extension TabBarCoordinator: TabBarViewControllerDelegate {
 }
 
 extension TabBarCoordinator: CaptureCoordinatorDelegate {
-    func postAchievement(newAchievement: Achievement) {
+    func achievementDidPosted(newAchievement: Achievement) {
         guard let naviVC = tabBarController.viewControllers?.first as? UINavigationController else { return }
         
         guard let homeVC = naviVC.viewControllers.compactMap({ $0 as? HomeViewController}).first else { return }
         
-        homeVC.postAchievement(newAchievement: newAchievement)
+        homeVC.achievementDidPosted(newAchievement: newAchievement)
     }
 }

--- a/iOS/moti/moti/Resource/Info.plist
+++ b/iOS/moti/moti/Resource/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>BASE_URL</key>
 	<string>$(BASE_URL)</string>
 	<key>UIApplicationSceneManifest</key>

--- a/iOS/moti/moti/Resource/Info.plist
+++ b/iOS/moti/moti/Resource/Info.plist
@@ -2,11 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSAppTransportSecurity</key>
-	<dict>
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
-	</dict>
 	<key>BASE_URL</key>
 	<string>$(BASE_URL)</string>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
## PR 요약
- 달성기록 생성 API 연동
- 홈 뷰에서 업데이트

#### 스크린샷
<img width="40%" src="https://github.com/boostcampwm2023/iOS02-moti/assets/60506170/fdadea4a-fd2e-43ff-9482-99ca2d116efe">

#### 주의 사항
- delegate + naviVC.viewcontrollers 로 일단은 되게 함
- NotificationCenter 로 변경 고려중

#### Linked Issue
close #344
close #345 
