### PR TITLE
currentCategory가 전체 카테고리일 때 헤더뷰 업데이트 버그 수정

### DIFF
--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewModel.swift
@@ -167,13 +167,13 @@ private extension HomeViewModel {
     
     /// 도전 기록의 카테고리를 변경하는 액션
     func updateAchievementCategory(achievementId: Int, newCategoryId: Int) {
-        guard let currentCategory, currentCategory.id != 0 else { return }
+        guard let currentCategory else { return }
         
         CategoryStorage.shared.decrease(categoryId: currentCategory.id)
         CategoryStorage.shared.increase(categoryId: newCategoryId)
         syncCurrentCategoryWithStorage()
         
-        if currentCategory.id != newCategoryId {
+        if currentCategory.id != 0 && currentCategory.id != newCategoryId {
             deleteOfDataSource(achievementId: achievementId)
         }
     }


### PR DESCRIPTION
## PR 요약
- homeVM의 currentCategory가 "전체"일 때 headerView가 업데이트 안 되는 버그 수정

#### Linked Issue
close #351 
