### PR TITLE
헤더뷰 업데이트 버그 수정

### DIFF
--- a/iOS/moti/moti/Data/Sources/Repository/AchievementRepository.swift
+++ b/iOS/moti/moti/Data/Sources/Repository/AchievementRepository.swift
@@ -68,7 +68,6 @@ public struct AchievementRepository: AchievementRepositoryProtocol {
         let responseDTO = try await provider.request(with: endpoint, type: DetailAchievementResponseDTO.self)
 
         guard let detailAchievementDataDTO = responseDTO.data else { throw NetworkError.decode }
-        let achievementSimpleDTO = AchievementSimpleDTO(dto: detailAchievementDataDTO)
-        return Achievement(dto: achievementSimpleDTO)
+        return Achievement(dto: detailAchievementDataDTO)
     }
 }

--- a/iOS/moti/moti/Domain/Sources/Domain/UseCase/PostAchievementUseCase.swift
+++ b/iOS/moti/moti/Domain/Sources/Domain/UseCase/PostAchievementUseCase.swift
@@ -23,12 +23,22 @@ public struct PostAchievementRequestValue: RequestValue {
 
 public struct PostAchievementUseCase {
     private let repository: AchievementRepositoryProtocol
+    private let categoryStorage: CategoryStorageProtocol
     
-    public init(repository: AchievementRepositoryProtocol) {
+    public init(
+        repository: AchievementRepositoryProtocol,
+        categoryStorage: CategoryStorageProtocol
+    ) {
         self.repository = repository
+        self.categoryStorage = categoryStorage
     }
     
     public func execute(requestValue: PostAchievementRequestValue) async throws -> Achievement {
-        return try await repository.postAchievement(requestValue: requestValue)
+        let newAchievement = try await repository.postAchievement(requestValue: requestValue)
+        if let category = newAchievement.category {
+            categoryStorage.increase(categoryId: category.id)
+        }
+        
+        return newAchievement
     }
 }

--- a/iOS/moti/moti/Domain/Sources/Domain/UseCase/UpdateAchievementUseCase.swift
+++ b/iOS/moti/moti/Domain/Sources/Domain/UseCase/UpdateAchievementUseCase.swift
@@ -31,12 +31,46 @@ public struct UpdateAchievementRequestBody: RequestValue {
 
 public struct UpdateAchievementUseCase {
     private let repository: AchievementRepositoryProtocol
+    private let categoryStorage: CategoryStorageProtocol
     
-    public init(repository: AchievementRepositoryProtocol) {
+    public init(
+        repository: AchievementRepositoryProtocol,
+        categoryStorage: CategoryStorageProtocol
+    ) {
         self.repository = repository
+        self.categoryStorage = categoryStorage
     }
     
-    public func execute(requestValue: UpdateAchievementRequestValue) async throws -> Bool {
-        return try await repository.updateAchievement(requestValue: requestValue)
+    /// 도전 기록 정보를 업데이트 합니다
+    /// 카테고리 변경에 따라 CategoryStorage의 카운팅도 진행됩니다.
+    public func execute(
+        oldAchievement: Achievement,
+        requestValue: UpdateAchievementRequestValue
+    ) async throws -> (isSuccess: Bool, updatedAchievement: Achievement?) {
+        let isSuccess = try await repository.updateAchievement(requestValue: requestValue)
+        guard isSuccess else { return (false, nil) }
+        
+        let newData = requestValue.body
+        let toCategoryId = newData.categoryId
+        
+        guard let fromCategoryId = oldAchievement.category?.id,
+              let toCategory = categoryStorage.find(categoryId: toCategoryId),
+              let achievementDate = oldAchievement.date else {
+            // TODO: 요청 정보가 잘못 됐다는 Error로 변경 예정
+            return (false, nil)
+        }
+        
+        categoryStorage.decrease(categoryId: fromCategoryId)
+        categoryStorage.increase(categoryId: toCategoryId)
+        
+        let updatedAchievement = Achievement(
+            id: oldAchievement.id,
+            category: toCategory,
+            title: newData.title,
+            imageURL: oldAchievement.imageURL, 
+            body: newData.content,
+            date: achievementDate
+        )
+        return (true, updatedAchievement)
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Capture/CaptureCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Capture/CaptureCoordinator.swift
@@ -64,7 +64,7 @@ extension CaptureCoordinator: CaptureViewControllerDelegate {
 }
 
 extension CaptureCoordinator: EditAchievementCoordinatorDelegate {
-    func doneButtonDidClickedFromDetail(updateAchievementRequestValue: UpdateAchievementRequestValue) {
+    func doneButtonDidClickedFromDetail(updatedAchievement: Achievement) {
         
     }
     

--- a/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementCoordinator.swift
@@ -11,7 +11,7 @@ import Data
 import Domain
 
 protocol DetailAchievementCoordinatorDelegate: AnyObject {
-    func deleteButtonAction(achievementId: Int)
+    func deleteButtonDidClicked(achievementId: Int)
     func updateAchievement(updatedAchievement: Achievement)
     func achievementDidPosted(newAchievement: Achievement)
 }
@@ -64,7 +64,7 @@ extension DetailAchievementCoordinator: DetailAchievementViewControllerDelegate 
     
     func deleteButtonDidClicked(achievementId: Int) {
         finish(animated: true)
-        delegate?.deleteButtonAction(achievementId: achievementId)
+        delegate?.deleteButtonDidClicked(achievementId: achievementId)
     }
 }
 

--- a/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementCoordinator.swift
@@ -12,7 +12,7 @@ import Domain
 
 protocol DetailAchievementCoordinatorDelegate: AnyObject {
     func deleteButtonAction(achievementId: Int)
-    func updateAchievement(achievementId: Int, newCategoryId: Int)
+    func updateAchievement(updatedAchievement: Achievement)
     func achievementDidPosted(newAchievement: Achievement)
 }
 
@@ -69,12 +69,12 @@ extension DetailAchievementCoordinator: DetailAchievementViewControllerDelegate 
 }
 
 extension DetailAchievementCoordinator: EditAchievementCoordinatorDelegate {
-    func doneButtonDidClickedFromDetail(updateAchievementRequestValue: UpdateAchievementRequestValue) {
-        detailAchievementViewController?.update(updateAchievementRequestValue: updateAchievementRequestValue)
-        delegate?.updateAchievement(achievementId: updateAchievementRequestValue.id, newCategoryId: updateAchievementRequestValue.body.categoryId)
+    func doneButtonDidClickedFromDetail(updatedAchievement: Achievement) {
+        detailAchievementViewController?.update(updatedAchievement: updatedAchievement)
+        delegate?.updateAchievement(updatedAchievement: updatedAchievement)
     }
     
     func doneButtonDidClickedFromCapture(newAchievement: Achievement) {
-        delegate?.achievementDidPosted(newAchievement: newAchievement)
+
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementView.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementView.swift
@@ -126,13 +126,10 @@ final class DetailAchievementView: UIView {
         titleLabel.text = title
     }
     
-    func update(updateAchievementRequestValue: UpdateAchievementRequestValue) {
-        let category = CategoryStorage.shared.find(
-            categoryId: updateAchievementRequestValue.body.categoryId
-        )
-        categoryLabel.text = category?.name
-        titleLabel.text = updateAchievementRequestValue.body.title
-        bodyTextView.text = updateAchievementRequestValue.body.content
+    func update(updatedAchievement: Achievement) {
+        categoryLabel.text = updatedAchievement.category?.name
+        titleLabel.text = updatedAchievement.title
+        bodyTextView.text = updatedAchievement.body
     }
     
     func cancelDownloadImage() {

--- a/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementViewController.swift
@@ -60,9 +60,9 @@ final class DetailAchievementViewController: BaseViewController<DetailAchievemen
         layoutView.cancelDownloadImage()
     }
     
-    func update(updateAchievementRequestValue: UpdateAchievementRequestValue) {
-        viewModel.action(.update(updateAchievementRequestValue: updateAchievementRequestValue))
-        layoutView.update(updateAchievementRequestValue: updateAchievementRequestValue)
+    func update(updatedAchievement: Achievement) {
+        viewModel.action(.update(updatedAchievement: updatedAchievement))
+        layoutView.update(updatedAchievement: updatedAchievement)
     }
     
     private func setupUI() {

--- a/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementViewModel.swift
@@ -14,7 +14,7 @@ final class DetailAchievementViewModel {
     enum DetailAchievementViewModelAction {
         case launch
         case delete
-        case update(updateAchievementRequestValue: UpdateAchievementRequestValue)
+        case update(updatedAchievement: Achievement)
     }
     
     enum LaunchState {
@@ -55,8 +55,8 @@ final class DetailAchievementViewModel {
             fetchDetailAchievement()
         case .delete:
             deleteAchievement()
-        case .update(let updateAchievementRequestValue):
-            updateAchievement(updateAchievementRequestValue: updateAchievementRequestValue)
+        case .update(let updatedAchievement):
+            self.achievement = updatedAchievement
         }
     }
     
@@ -97,12 +97,5 @@ final class DetailAchievementViewModel {
                 deleteState = .failed(message: error.localizedDescription)
             }
         }
-    }
-    
-    private func updateAchievement(updateAchievementRequestValue: UpdateAchievementRequestValue) {
-        let category = CategoryStorage.shared.find(categoryId: updateAchievementRequestValue.body.categoryId)
-        achievement.category = category
-        achievement.title = updateAchievementRequestValue.body.title
-        achievement.body = updateAchievementRequestValue.body.content
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementCoordinator.swift
@@ -38,7 +38,7 @@ final class EditAchievementCoordinator: Coordinator {
             saveImageUseCase: .init(repository: ImageRepository()),
             fetchCategoryListUseCase: .init(repository: CategoryListRepository()),
             updateAchievementUseCase: .init(repository: AchievementRepository(), categoryStorage: CategoryStorage.shared),
-            postAchievementUseCase: .init(repository: AchievementRepository())
+            postAchievementUseCase: .init(repository: AchievementRepository(), categoryStorage: CategoryStorage.shared)
         )
         let editAchievementVC = EditAchievementViewController(
             viewModel: editAchievementVM,
@@ -61,7 +61,7 @@ final class EditAchievementCoordinator: Coordinator {
             saveImageUseCase: .init(repository: ImageRepository()),
             fetchCategoryListUseCase: .init(repository: CategoryListRepository()),
             updateAchievementUseCase: .init(repository: AchievementRepository(), categoryStorage: CategoryStorage.shared),
-            postAchievementUseCase: .init(repository: AchievementRepository())
+            postAchievementUseCase: .init(repository: AchievementRepository(), categoryStorage: CategoryStorage.shared)
         )
         let editAchievementVC = EditAchievementViewController(
             viewModel: editAchievementVM,

--- a/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementCoordinator.swift
@@ -11,7 +11,7 @@ import Data
 import Domain
 
 protocol EditAchievementCoordinatorDelegate: AnyObject {
-    func doneButtonDidClickedFromDetail(updateAchievementRequestValue: UpdateAchievementRequestValue)
+    func doneButtonDidClickedFromDetail(updatedAchievement: Achievement)
     func doneButtonDidClickedFromCapture(newAchievement: Achievement)
 }
 
@@ -37,7 +37,7 @@ final class EditAchievementCoordinator: Coordinator {
         let editAchievementVM = EditAchievementViewModel(
             saveImageUseCase: .init(repository: ImageRepository()),
             fetchCategoryListUseCase: .init(repository: CategoryListRepository()),
-            updateAchievementUseCase: .init(repository: AchievementRepository()), 
+            updateAchievementUseCase: .init(repository: AchievementRepository(), categoryStorage: CategoryStorage.shared),
             postAchievementUseCase: .init(repository: AchievementRepository())
         )
         let editAchievementVC = EditAchievementViewController(
@@ -60,7 +60,7 @@ final class EditAchievementCoordinator: Coordinator {
         let editAchievementVM = EditAchievementViewModel(
             saveImageUseCase: .init(repository: ImageRepository()),
             fetchCategoryListUseCase: .init(repository: CategoryListRepository()),
-            updateAchievementUseCase: .init(repository: AchievementRepository()),
+            updateAchievementUseCase: .init(repository: AchievementRepository(), categoryStorage: CategoryStorage.shared),
             postAchievementUseCase: .init(repository: AchievementRepository())
         )
         let editAchievementVC = EditAchievementViewController(
@@ -89,9 +89,9 @@ final class EditAchievementCoordinator: Coordinator {
 }
 
 extension EditAchievementCoordinator: EditAchievementViewControllerDelegate {
-    func doneButtonDidClickedFromDetailView(updateAchievementRequestValue: UpdateAchievementRequestValue) {
+    func doneButtonDidClickedFromDetailView(updatedAchievement: Achievement) {
         parentCoordinator?.dismiss(child: self, animated: true)
-        delegate?.doneButtonDidClickedFromDetail(updateAchievementRequestValue: updateAchievementRequestValue)
+        delegate?.doneButtonDidClickedFromDetail(updatedAchievement: updatedAchievement)
     }
     
     func doneButtonDidClickedFromCaptureView(newAchievement: Achievement) {

--- a/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementViewController.swift
@@ -12,7 +12,7 @@ import Combine
 import Domain
 
 protocol EditAchievementViewControllerDelegate: AnyObject {
-    func doneButtonDidClickedFromDetailView(updateAchievementRequestValue: UpdateAchievementRequestValue)
+    func doneButtonDidClickedFromDetailView(updatedAchievement: Achievement)
     func doneButtonDidClickedFromCaptureView(newAchievement: Achievement)
 }
 
@@ -143,8 +143,8 @@ final class EditAchievementViewController: BaseViewController<EditAchievementVie
                 guard let self else { return }
                 switch state {
                 case .none, .loading: break
-                case .finish(let updateAchievementRequestValue):
-                    delegate?.doneButtonDidClickedFromDetailView(updateAchievementRequestValue: updateAchievementRequestValue)
+                case .finish(let updatedAchievement):
+                    delegate?.doneButtonDidClickedFromDetailView(updatedAchievement: updatedAchievement)
                 case .error:
                     Logger.error("Achievement Update Error")
                 }
@@ -173,18 +173,13 @@ final class EditAchievementViewController: BaseViewController<EditAchievementVie
     }
     
     @objc func doneButtonDidClicked() {
-        if let achievement { // 상세 화면에서 넘어옴 => 수정 API
-            let updateAchievementRequestValue = UpdateAchievementRequestValue(
-                id: achievement.id,
-                body: UpdateAchievementRequestBody(
-                    title: layoutView.titleTextField.text ?? "",
-                    content: bottomSheet.text,
-                    categoryId: findSelectedCategory().id
-                )
+        if let achievement = achievement { // 상세 화면에서 넘어옴 => 수정 API
+            let updatedData = UpdateAchievementRequestBody(
+                title: layoutView.titleTextField.text ?? "",
+                content: bottomSheet.text,
+                categoryId: findSelectedCategory().id
             )
-            
-            viewModel.action(.updateAchievement(updateAchievementRequestValue: updateAchievementRequestValue))
-            
+            viewModel.action(.updateAchievement(achievement: achievement, updateData: updatedData))
         } else { // 촬영 화면에서 넘어옴 => 생성 API
             var title = ""
             if let text = layoutView.titleTextField.text, !text.isEmpty {

--- a/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementViewModel.swift
@@ -14,7 +14,7 @@ final class EditAchievementViewModel {
     enum Action {
         case saveImage(data: Data)
         case fetchCategories
-        case updateAchievement(updateAchievementRequestValue: UpdateAchievementRequestValue)
+        case updateAchievement(achievement: Achievement, updateData: UpdateAchievementRequestBody)
         case postAchievement(title: String, content: String, categoryId: Int)
     }
     
@@ -34,7 +34,7 @@ final class EditAchievementViewModel {
     enum UpdateAchievementState {
         case none
         case loading
-        case finish(updateAchievementRequestValue: UpdateAchievementRequestValue)
+        case finish(updatedAchievement: Achievement)
         case error
     }
     
@@ -80,8 +80,8 @@ final class EditAchievementViewModel {
             saveImageData(data)
         case .fetchCategories:
             fetchCategories()
-        case .updateAchievement(let updateAchievementRequestValue):
-            updateAchievement(updateAchievementRequestValue: updateAchievementRequestValue)
+        case .updateAchievement(let achievement, let updateData):
+            updateAchievement(achievement: achievement, updateData: updateData)
         case .postAchievement(let title, let content, let categoryId):
             postAchievement(title: title, content: content, categoryId: categoryId)
         }
@@ -138,13 +138,21 @@ final class EditAchievementViewModel {
         
     }
     
-    private func updateAchievement(updateAchievementRequestValue: UpdateAchievementRequestValue) {
+    private func updateAchievement(achievement: Achievement, updateData: UpdateAchievementRequestBody) {
         Task {
             do {
                 updateAchievementState = .loading
-                let isSuccess = try await updateAchievementUseCase.execute(requestValue: updateAchievementRequestValue)
-                if isSuccess {
-                    updateAchievementState = .finish(updateAchievementRequestValue: updateAchievementRequestValue)
+                let updateAchievementRequestValue = UpdateAchievementRequestValue(
+                    id: achievement.id,
+                    body: updateData
+                )
+                
+                let (isSuccess, updatedAchievement) = try await updateAchievementUseCase.execute(
+                    oldAchievement: achievement,
+                    requestValue: updateAchievementRequestValue
+                )
+                if isSuccess, let updatedAchievement = updatedAchievement {
+                    updateAchievementState = .finish(updatedAchievement: updatedAchievement)
                 } else {
                     updateAchievementState = .error
                 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeActionState.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeActionState.swift
@@ -14,8 +14,8 @@ extension HomeViewModel {
         case addCategory(name: String)
         case fetchNextPage
         case fetchAchievementList(category: CategoryItem)
-        case delete(achievementId: Int)
-        case updateAchievement(id: Int, newCategoryId: Int)
+        case deleteAchievementDataSourceItem(achievementId: Int)
+        case updateAchievement(updatedAchievement: Achievement)
         case postAchievement(newAchievement: Achievement)
     }
     

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeCoordinator.swift
@@ -46,7 +46,7 @@ public final class HomeCoordinator: Coordinator {
 }
 
 extension HomeCoordinator: DetailAchievementCoordinatorDelegate {
-    func deleteButtonAction(achievementId: Int) {
+    func deleteButtonDidClicked(achievementId: Int) {
         currentViewController?.deleteAchievementDataSourceItem(achievementId: achievementId)
     }
     

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeCoordinator.swift
@@ -47,11 +47,11 @@ public final class HomeCoordinator: Coordinator {
 
 extension HomeCoordinator: DetailAchievementCoordinatorDelegate {
     func deleteButtonAction(achievementId: Int) {
-        currentViewController?.delete(achievementId: achievementId)
+        currentViewController?.deleteAchievementDataSourceItem(achievementId: achievementId)
     }
     
-    func updateAchievement(achievementId: Int, newCategoryId: Int) {
-        currentViewController?.updateAchievement(achievementId: achievementId, newCategoryId: newCategoryId)
+    func updateAchievement(updatedAchievement: Achievement) {
+        currentViewController?.updateAchievement(updatedAchievement: updatedAchievement)
     }
     
     func achievementDidPosted(newAchievement: Achievement) {

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewController.swift
@@ -43,12 +43,12 @@ final class HomeViewController: BaseViewController<HomeView> {
     }
     
     // MARK: - Methods
-    func delete(achievementId: Int) {
-        viewModel.action(.delete(achievementId: achievementId))
+    func deleteAchievementDataSourceItem(achievementId: Int) {
+        viewModel.action(.deleteAchievementDataSourceItem(achievementId: achievementId))
     }
     
-    func updateAchievement(achievementId: Int, newCategoryId: Int) {
-        viewModel.action(.updateAchievement(id: achievementId, newCategoryId: newCategoryId))
+    func updateAchievement(updatedAchievement: Achievement) {
+        viewModel.action(.updateAchievement(updatedAchievement: updatedAchievement))
     }
     
     func achievementDidPosted(newAchievement: Achievement) {
@@ -114,9 +114,8 @@ final class HomeViewController: BaseViewController<HomeView> {
                 guard let self else { return }
                 switch state {
                 case .initial: break
-                case .updated(let category):
-                    Logger.debug("Updated: \(category)")
-                    layoutView.updateAchievementHeader(with: category)
+                case .updated(let updatedCategory):
+                    layoutView.updateAchievementHeader(with: updatedCategory)
                 }
             }
             .store(in: &cancellables)

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewModel.swift
@@ -94,10 +94,10 @@ final class HomeViewModel {
             fetchNextAchievementList()
         case .fetchAchievementList(let category):
             fetchCategoryAchievementList(category: category)
-        case .delete(let achievementId):
+        case .deleteAchievementDataSourceItem(let achievementId):
             deleteOfDataSource(achievementId: achievementId)
-        case .updateAchievement(let id, let newCategoryId):
-            updateAchievementCategory(achievementId: id, newCategoryId: newCategoryId)
+        case .updateAchievement(let updatedAchievement):
+            updateAchievementCategory(updatedAchievement: updatedAchievement)
         case .postAchievement(let newAchievement):
             postAchievement(newAchievement: newAchievement)
         }
@@ -161,20 +161,16 @@ private extension HomeViewModel {
     func deleteOfDataSource(achievementId: Int) {
         guard let foundIndex = firstIndexOf(achievementId: achievementId) else { return }
         achievements.remove(at: foundIndex)
-        
-        syncCurrentCategoryWithStorage()
     }
     
     /// 도전 기록의 카테고리를 변경하는 액션
-    func updateAchievementCategory(achievementId: Int, newCategoryId: Int) {
-        guard let currentCategory else { return }
-        
-        CategoryStorage.shared.decrease(categoryId: currentCategory.id)
-        CategoryStorage.shared.increase(categoryId: newCategoryId)
+    func updateAchievementCategory(updatedAchievement: Achievement) {
+        guard let currentCategory,
+              let updatedCategory = updatedAchievement.category else { return }
         syncCurrentCategoryWithStorage()
         
-        if currentCategory.id != 0 && currentCategory.id != newCategoryId {
-            deleteOfDataSource(achievementId: achievementId)
+        if currentCategory.id != 0 && currentCategory.id != updatedCategory.id {
+            deleteOfDataSource(achievementId: updatedAchievement.id)
         }
     }
     

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewModel.swift
@@ -40,6 +40,7 @@ final class HomeViewModel {
     private var achievements: [Achievement] = [] {
         didSet {
             achievementDataSource?.update(data: achievements)
+            syncCurrentCategoryWithStorage()
         }
     }
     


### PR DESCRIPTION
## PR 요약
- 헤더뷰 업데이트 버그 수정

#### 변경 사항
- Achievement Create, Update, Delete UseCase에서 CategoryStorage를 업데이트합니다.
- Update 후 updatedAchievement를 반환합니다. (기존에는 id, requestValue였음)

#### 주의사항
- 일단은 CategoryStorage 업데이트는 UseCase에서만 하는거로 해봐요!
- 코드 변경사항이 많지만 꼭!! 숙지해 주세요!

#### Linked Issue
close #351 
