### PR TITLE
키체인 적용 (로그인, 자동로그인, Access Token 헤더)

### DIFF
--- a/iOS/moti/moti/Application/AppCoordinator.swift
+++ b/iOS/moti/moti/Application/AppCoordinator.swift
@@ -61,7 +61,7 @@ extension AppCoordinator: LaunchCoodinatorDelegate {
 }
 
 extension AppCoordinator: LoginCoordinatorDelegate {
-    func finishLogin(token: UserToken) {
+    func finishLogin() {
         Logger.info("Success Login. 홈 화면으로 이동")
         moveHomeViewController()
     }

--- a/iOS/moti/moti/Data/Sources/Data/Network/Endpoint/MotiAPI.swift
+++ b/iOS/moti/moti/Data/Sources/Data/Network/Endpoint/MotiAPI.swift
@@ -109,7 +109,8 @@ extension MotiAPI {
         case .version, .login:
             break
         default:
-            if let accessToken = keychainStorage.read(key: .accessToken) {
+            if let accessTokenData = keychainStorage.read(key: .accessToken),
+               let accessToken = String(data: accessTokenData, encoding: .utf8) {
                 header["Authorization"] = "Bearer \(accessToken)"
             }
         }

--- a/iOS/moti/moti/Data/Sources/Data/Network/Endpoint/MotiAPI.swift
+++ b/iOS/moti/moti/Data/Sources/Data/Network/Endpoint/MotiAPI.swift
@@ -20,6 +20,10 @@ enum MotiAPI: EndpointProtocol {
     case deleteAchievement(requestValue: DeleteAchievementRequestValue)
     case updateAchievement(requestValue: UpdateAchievementRequestValue)
     case postAchievement(requestValue: PostAchievementRequestValue)
+    
+    private var keychainStorage: KeychainStorageProtocol {
+        return KeychainStorage.shared
+    }
 }
 
 extension MotiAPI {
@@ -105,8 +109,7 @@ extension MotiAPI {
         case .version, .login:
             break
         default:
-            // TODO: Keychain Storage로 변경
-            if let accessToken = UserDefaults.standard.string(forKey: "accessToken") {
+            if let accessToken = keychainStorage.read(key: .accessToken) {
                 header["Authorization"] = "Bearer \(accessToken)"
             }
         }

--- a/iOS/moti/moti/Data/Sources/Storage/KeychainStorage.swift
+++ b/iOS/moti/moti/Data/Sources/Storage/KeychainStorage.swift
@@ -8,8 +8,12 @@
 import Foundation
 import Domain
 
-final class KeychainStorage: KeychainStorageProtocol {
-    func read(key: KeychainKey) -> Data? {
+public final class KeychainStorage: KeychainStorageProtocol {
+    public static let shared = KeychainStorage()
+    
+    private init() { }
+    
+    public func read(key: KeychainKey) -> Data? {
         let query = NSDictionary(dictionary: [
             kSecClass: kSecClassGenericPassword,
             kSecAttrAccount: key.rawValue,
@@ -23,7 +27,7 @@ final class KeychainStorage: KeychainStorageProtocol {
         return data as? Data
     }
     
-    func write(key: KeychainKey, data: Data) {
+    public func write(key: KeychainKey, data: Data) {
         let query = NSDictionary(dictionary: [
             kSecClass: kSecClassGenericPassword,
             kSecAttrAccount: key.rawValue,
@@ -33,7 +37,7 @@ final class KeychainStorage: KeychainStorageProtocol {
         SecItemAdd(query, nil)
     }
     
-    func remove(key: KeychainKey) {
+    public func remove(key: KeychainKey) {
         guard let data = read(key: key) else { return }
         let query = NSDictionary(dictionary: [
             kSecClass: kSecClassGenericPassword,

--- a/iOS/moti/moti/Data/Sources/Storage/KeychainStorage.swift
+++ b/iOS/moti/moti/Data/Sources/Storage/KeychainStorage.swift
@@ -1,0 +1,45 @@
+//
+//  KeychainStorage.swift
+//
+//
+//  Created by 유정주 on 12/2/23.
+//
+
+import Foundation
+import Domain
+
+final class KeychainStorage: KeychainStorageProtocol {
+    func read(key: KeychainKey) -> Data? {
+        let query = NSDictionary(dictionary: [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccount: key.rawValue,
+            kSecReturnData: true,
+            kSecMatchLimit: kSecMatchLimitOne
+        ])
+        var data: AnyObject?
+        _ = withUnsafeMutablePointer(to: &data) {
+            SecItemCopyMatching(query, UnsafeMutablePointer($0))
+        }
+        return data as? Data
+    }
+    
+    func write(key: KeychainKey, data: Data) {
+        let query = NSDictionary(dictionary: [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccount: key.rawValue,
+            kSecValueData: data
+        ])
+        SecItemDelete(query)
+        SecItemAdd(query, nil)
+    }
+    
+    func remove(key: KeychainKey) {
+        guard let data = read(key: key) else { return }
+        let query = NSDictionary(dictionary: [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccount: key.rawValue,
+            kSecValueData: data
+        ])
+        SecItemDelete(query)
+    }
+}

--- a/iOS/moti/moti/Domain/Sources/Domain/StorageProtocol/KeychainStorageProtocol.swift
+++ b/iOS/moti/moti/Domain/Sources/Domain/StorageProtocol/KeychainStorageProtocol.swift
@@ -1,0 +1,19 @@
+//
+//  KeychainStorageProtocol.swift
+//
+//
+//  Created by 유정주 on 12/2/23.
+//
+
+import Foundation
+
+public enum KeychainKey: String {
+    case accessToken
+    case refreshToken
+}
+
+public protocol KeychainStorageProtocol {
+    func read(key: KeychainKey) -> Data?
+    func write(key: KeychainKey, data: Data)
+    func remove(key: KeychainKey)
+}

--- a/iOS/moti/moti/Domain/Sources/Domain/UseCase/AutoLoginUseCase.swift
+++ b/iOS/moti/moti/Domain/Sources/Domain/UseCase/AutoLoginUseCase.swift
@@ -17,12 +17,39 @@ public struct AutoLoginRequestValue: RequestValue {
 
 public struct AutoLoginUseCase {
     private let repository: LoginRepositoryProtocol
+    private let keychainStorage: KeychainStorageProtocol
     
-    public init(repository: LoginRepositoryProtocol) {
+    public init(
+        repository: LoginRepositoryProtocol,
+        keychainStorage: KeychainStorageProtocol
+    ) {
         self.repository = repository
+        self.keychainStorage = keychainStorage
     }
     
-    public func excute(requestValue: AutoLoginRequestValue) async throws -> UserToken {
-        return try await repository.autoLogin(requestValue: requestValue)
+    public func excute() async throws -> Bool {
+        guard let refreshTokenData = keychainStorage.read(key: .refreshToken),
+              let refreshToken = String(data: refreshTokenData, encoding: .utf8) else {
+            resetUserToken()
+            return false
+        }
+        
+        let requestValue = AutoLoginRequestValue(refreshToken: refreshToken)
+        let userToken = try await repository.autoLogin(requestValue: requestValue)
+        saveUserToken(userToken)
+        
+        return true
+    }
+    
+    private func saveUserToken(_ userToken: UserToken) {
+        guard let accessToken = userToken.accessToken.data(using: .utf8),
+              let refreshToken = userToken.refreshToken.data(using: .utf8) else { return }
+        keychainStorage.write(key: .accessToken, data: accessToken)
+        keychainStorage.write(key: .refreshToken, data: refreshToken)
+    }
+    
+    private func resetUserToken() {
+        keychainStorage.remove(key: .accessToken)
+        keychainStorage.remove(key: .refreshToken)
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Launch/LaunchCoodinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Launch/LaunchCoodinator.swift
@@ -8,6 +8,7 @@
 import UIKit
 import Core
 import Data
+import Domain
 
 public protocol LaunchCoodinatorDelegate: AnyObject {
     func successAutoLogin(_ coordinator: LaunchCoodinator)
@@ -29,9 +30,13 @@ public final class LaunchCoodinator: Coordinator {
     }
     
     public func start() {
+        let autoLoginUseCase = AutoLoginUseCase(
+            repository: LoginRepository(),
+            keychainStorage: KeychainStorage.shared
+        )
         let launchVM = LaunchViewModel(
             fetchVersionUseCase: .init(repository: VersionRepository()),
-            autoLoginUseCase: .init(repository: LoginRepository())
+            autoLoginUseCase: autoLoginUseCase
         )
         let launchVC = LaunchViewController(viewModel: launchVM)
         launchVC.coordinator = self

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Launch/LaunchViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Launch/LaunchViewModel.swift
@@ -70,14 +70,9 @@ final class LaunchViewModel {
     
     private func requestAutoLogin() {
         Task {
-            do {
-                autoLoginState = .loading
-                let isSuccess = try await autoLoginUseCase.excute()
-                autoLoginState = isSuccess ? .success : .failed(message: "최초 로그인")
-            } catch {
-                Logger.error(error)
-                autoLoginState = .failed(message: error.localizedDescription)
-            }
+            autoLoginState = .loading
+            let isSuccess = await autoLoginUseCase.excute()
+            autoLoginState = isSuccess ? .success : .failed(message: "최초 로그인")
         }
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Launch/LaunchViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Launch/LaunchViewModel.swift
@@ -48,14 +48,7 @@ final class LaunchViewModel {
         case .launch:
             fetchVersion()
         case .autoLogin:
-            if let refreshToken = fetchRefreshToken() {
-                Logger.debug("refreshToken으로 자동 로그인 시도")
-                requestAutoLogin(using: refreshToken)
-            } else {
-                Logger.debug("자동 로그인 실패")
-                resetToken()
-                autoLoginState = .failed(message: "최초 로그인")
-            }
+            requestAutoLogin()
         }
     }
     
@@ -75,35 +68,16 @@ final class LaunchViewModel {
         }
     }
     
-    private func fetchRefreshToken() -> String? {
-        // Keychain 저장소로 변경
-        return UserDefaults.standard.string(forKey: "refreshToken")
-    }
-    
-    private func requestAutoLogin(using refreshToken: String) {
+    private func requestAutoLogin() {
         Task {
             do {
                 autoLoginState = .loading
-                
-                let requestValue = AutoLoginRequestValue(refreshToken: refreshToken)
-                let token = try await autoLoginUseCase.excute(requestValue: requestValue)
-                saveAccessToken(token.accessToken)
-                
-                autoLoginState = .success
+                let isSuccess = try await autoLoginUseCase.excute()
+                autoLoginState = isSuccess ? .success : .failed(message: "최초 로그인")
             } catch {
                 Logger.error(error)
                 autoLoginState = .failed(message: error.localizedDescription)
             }
         }
-    }
-    
-    // TODO: UserDefaultsStorage로 변경해서 UseCase로 사용하기
-    private func saveAccessToken(_ accessToken: String) {
-        UserDefaults.standard.setValue(accessToken, forKey: "accessToken")
-    }
-    
-    private func resetToken() {
-        UserDefaults.standard.removeObject(forKey: "refreshToken")
-        UserDefaults.standard.removeObject(forKey: "accessToken")
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Login/LoginCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Login/LoginCoordinator.swift
@@ -11,7 +11,7 @@ import Data
 import Domain
 
 public protocol LoginCoordinatorDelegate: AnyObject {
-    func finishLogin(token: UserToken)
+    func finishLogin()
 }
 
 public final class LoginCoordinator: Coordinator {
@@ -30,7 +30,7 @@ public final class LoginCoordinator: Coordinator {
     }
     
     public func start() {
-        let loginUseCase = LoginUseCase(repository: LoginRepository())
+        let loginUseCase = LoginUseCase(repository: LoginRepository(), keychainStorage: KeychainStorage.shared)
         let loginVM = LoginViewModel(loginUseCase: loginUseCase)
         let loginVC = LoginViewController(viewModel: loginVM)
         loginVC.coordinator = self
@@ -41,7 +41,7 @@ public final class LoginCoordinator: Coordinator {
 }
 
 extension LoginCoordinator: LoginViewControllerDelegate {
-    func didLogin(token: UserToken) {
-        delegate?.finishLogin(token: token)
+    func didLogin() {
+        delegate?.finishLogin()
     }
 }


### PR DESCRIPTION
## PR 요약
- 키체인 적용
- 로그인, 자동로그인 시 키체인에 저장
- MotiAPI에서 access token을 키체인에서 읽음

#### 변경 사항
- 토큰을 KeyChain으로 변경했습니다. KeyChainStorage를 확인해 주세요.
- 로그인, 자동로그인 UseCase 안에서 토큰을 저장합니다.

#### Linked Issue
close #88 
