### PR TITLE
달성기록 리스트 API 수정

### DIFF
--- a/BE/src/achievement/dto/achievement-response.ts
+++ b/BE/src/achievement/dto/achievement-response.ts
@@ -1,18 +1,27 @@
 import { Achievement } from '../domain/achievement.domain';
 import { ApiProperty } from '@nestjs/swagger';
+import { Category } from '../../category/domain/category.domain';
 
 export class AchievementResponse {
   @ApiProperty({ description: 'id' })
   id: number;
-  @ApiProperty({ description: 'string' })
+  @ApiProperty({ description: 'thumbnailUrl' })
   thumbnailUrl: string;
-  @ApiProperty({ description: 'string' })
+  @ApiProperty({ description: 'title' })
   title: string;
+  @ApiProperty({ description: 'categoryId' })
+  categoryId: number;
 
-  constructor(id: number, thumbnailUrl: string, title: string) {
+  constructor(
+    id: number,
+    thumbnailUrl: string,
+    title: string,
+    category?: Category,
+  ) {
     this.id = id;
     this.thumbnailUrl = thumbnailUrl;
     this.title = title;
+    this.categoryId = category?.id;
   }
 
   static from(achievement: Achievement) {
@@ -20,6 +29,7 @@ export class AchievementResponse {
       achievement.id,
       achievement.image?.thumbnailUrl || achievement.image?.imageUrl || null,
       achievement.title,
+      achievement.category,
     );
   }
 }

--- a/BE/src/achievement/dto/achievement-response.ts
+++ b/BE/src/achievement/dto/achievement-response.ts
@@ -21,7 +21,7 @@ export class AchievementResponse {
     this.id = id;
     this.thumbnailUrl = thumbnailUrl;
     this.title = title;
-    this.categoryId = category?.id;
+    this.categoryId = category ? category.id : null;
   }
 
   static from(achievement: Achievement) {

--- a/BE/src/achievement/entities/achievement.repository.spec.ts
+++ b/BE/src/achievement/entities/achievement.repository.spec.ts
@@ -194,6 +194,32 @@ describe('AchievementRepository test', () => {
     });
   });
 
+  test('카테고리 ID가 -1인 경우에는 카테고리 미설정 달성 기록을 조회한다.', async () => {
+    await transactionTest(dataSource, async () => {
+      // given
+      const user = await usersFixture.getUser('ABC');
+
+      const achievements: Achievement[] =
+        await achievementFixture.getAchievements(10, user, null);
+      achievements.push(
+        ...(await achievementFixture.getAchievements(10, user, null)),
+      );
+
+      // when
+      const achievementPaginationOption: PaginateAchievementRequest = {
+        categoryId: -1,
+        take: 12,
+      };
+      const findAll = await achievementRepository.findAll(
+        user.id,
+        achievementPaginationOption,
+      );
+
+      // then
+      expect(findAll.length).toEqual(12);
+    });
+  });
+
   test('카테고리 ID를 넣지 않은 경우에도 모든 달성 기록을 조회한다.', async () => {
     await transactionTest(dataSource, async () => {
       // given

--- a/BE/src/achievement/entities/achievement.repository.spec.ts
+++ b/BE/src/achievement/entities/achievement.repository.spec.ts
@@ -162,6 +162,7 @@ describe('AchievementRepository test', () => {
 
       // then
       expect(findAll.length).toEqual(10);
+      expect(findAll[0].category.id).toEqual(category.id);
     });
   });
 

--- a/BE/src/achievement/entities/achievement.repository.ts
+++ b/BE/src/achievement/entities/achievement.repository.ts
@@ -26,6 +26,9 @@ export class AchievementRepository extends TransactionalRepository<AchievementEn
       where,
       order: { createdAt: 'DESC' },
       take: achievementPaginationOption.take,
+      relations: {
+        category: true,
+      },
     });
     return achievementEntities.map((achievementEntity) =>
       achievementEntity.toModel(),

--- a/BE/src/achievement/entities/achievement.repository.ts
+++ b/BE/src/achievement/entities/achievement.repository.ts
@@ -2,7 +2,7 @@ import { CustomRepository } from '../../config/typeorm/custom-repository.decorat
 import { TransactionalRepository } from '../../config/transaction-manager/transactional-repository';
 import { AchievementEntity } from './achievement.entity';
 import { Achievement } from '../domain/achievement.domain';
-import { FindOptionsWhere, LessThan } from 'typeorm';
+import { FindOptionsWhere, IsNull, LessThan } from 'typeorm';
 import { PaginateAchievementRequest } from '../dto/paginate-achievement-request';
 import { AchievementDetailResponse } from '../dto/achievement-detail-response';
 import { IAchievementDetail } from '../index';
@@ -18,6 +18,9 @@ export class AchievementRepository extends TransactionalRepository<AchievementEn
     };
     if (achievementPaginationOption?.categoryId !== 0) {
       where.category = { id: achievementPaginationOption.categoryId };
+    }
+    if (achievementPaginationOption?.categoryId === -1) {
+      where.category = { id: IsNull() };
     }
     if (achievementPaginationOption.whereIdLessThan) {
       where.id = LessThan(achievementPaginationOption.whereIdLessThan);


### PR DESCRIPTION
## PR 요약
- categoryId -1로 필터링시 카테고리 미설정 기록 반환
- 응답본문에 categoryId를 추가한다
 

##### 스크린샷
<img width="762" alt="image" src="https://github.com/boostcampwm2023/iOS02-moti/assets/34297340/b92b0674-9cfa-49e8-8814-0237884b979c">

<img width="750" alt="image" src="https://github.com/boostcampwm2023/iOS02-moti/assets/34297340/c7adc366-3900-4ce2-8ef7-48ab7b9cf58b">

#### Linked Issue
close #373 
