### PR TITLE
로그아웃을 구현한다. / status code 401일 때 로그인 화면으로 이동 구현

### DIFF
--- a/iOS/moti/moti/Application/AppCoordinator.swift
+++ b/iOS/moti/moti/Application/AppCoordinator.swift
@@ -27,6 +27,14 @@ final class AppCoordinator: Coordinator {
         moveLaunchViewController()
     }
     
+    func startWhenExpiredAccessToken() {
+        moveLoginViewControllerWhenExpiredAccessToken()
+    }
+    
+    func startWhenLogout() {
+        moveLoginViewController()
+    }
+    
     private func moveLaunchViewController() {
         let launchCoordinator = LaunchCoodinator(navigationController, self)
         launchCoordinator.delegate = self
@@ -37,6 +45,13 @@ final class AppCoordinator: Coordinator {
         let loginCoordinator = LoginCoordinator(navigationController, self)
         loginCoordinator.delegate = self
         start(coordinator: loginCoordinator)
+    }
+    
+    private func moveLoginViewControllerWhenExpiredAccessToken() {
+        let loginCoordinator = LoginCoordinator(navigationController, self)
+        loginCoordinator.delegate = self
+        loginCoordinator.startWithAlert(message: "토큰이 만료되었습니다.\n다시 로그인 해주세요.")
+        childCoordinators.append(loginCoordinator)
     }
     
     private func moveHomeViewController() {

--- a/iOS/moti/moti/Core/Sources/Core/Notification+Extension.swift
+++ b/iOS/moti/moti/Core/Sources/Core/Notification+Extension.swift
@@ -1,0 +1,13 @@
+//
+//  Notification+Extension.swift
+//
+//
+//  Created by 유정주 on 12/3/23.
+//
+
+import Foundation
+
+public extension Notification.Name {
+    static let accessTokenDidExpired = Notification.Name("accessTokenDidExpired")
+    static let logout = Notification.Name("logout")
+}

--- a/iOS/moti/moti/Data/Sources/Data/Network/Provider/Provider.swift
+++ b/iOS/moti/moti/Data/Sources/Data/Network/Provider/Provider.swift
@@ -80,6 +80,9 @@ public struct Provider: ProviderProtocol {
         switch statusCode {
         case 200..<300:
             return body
+        case 401:
+            NotificationCenter.default.post(name: .accessTokenDidExpired, object: nil)
+            throw NetworkError.statusCode(code: response.statusCode, message: "유효하지 않은 토큰입니다.")
         default:
             throw NetworkError.statusCode(code: response.statusCode, message: body.message ?? "nil")
         }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Common/BaseViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Common/BaseViewController.swift
@@ -47,17 +47,14 @@ extension BaseViewController {
         title: String? = nil,
         message: String? = nil,
         okTitle: String? = "확인",
-        okAction: (() -> Void)? = nil,
-        cancelTitle: String? = "취소",
-        cancelAction: (() -> Void)? = nil
+        okAction: (() -> Void)? = nil
     ) {
         let alertVC = AlertFactory.makeTwoButtonAlert(
             title: title,
             message: message,
             okTitle: okTitle,
             okAction: okAction,
-            cancelTitle: cancelTitle,
-            cancelAction: cancelAction
+            cancelTitle: "취소"
         )
         present(alertVC, animated: true)
     }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeActionState.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeActionState.swift
@@ -19,6 +19,7 @@ extension HomeViewModel {
         case postAchievement(newAchievement: Achievement)
         case deleteAchievement(achievementId: Int, categoryId: Int)
         case fetchDetailAchievement(achievementId: Int)
+        case logout
     }
     
     enum CategoryListState {

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewController.swift
@@ -162,13 +162,27 @@ private extension HomeViewController {
         let appInfoAction = UIAction(title: "앱 정보", handler: { _ in
             self.moveToAppInfoViewController()
         })
-        moreItem.menu = UIMenu(children: [appInfoAction])
+        let logoutAction = UIAction(title: "로그아웃", handler: { _ in
+            self.logout()
+        })
+        moreItem.menu = UIMenu(children: [appInfoAction, logoutAction])
         
         navigationItem.rightBarButtonItems = [profileItem, moreItem]
     }
     
     func moveToAppInfoViewController() {
         coordinator?.moveToAppInfoViewController()
+    }
+    
+    func logout() {
+        showTwoButtonAlert(
+            title: "로그아웃",
+            message: "정말 로그아웃을 하시겠습니까?",
+            okTitle: "로그아웃", 
+            okAction: {
+                self.viewModel.action(.logout)
+            }
+        )
     }
 }
 

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewModel.swift
@@ -114,6 +114,10 @@ final class HomeViewModel {
             deleteAchievement(achievementId: achievementId, categoryId: categoryId)
         case .fetchDetailAchievement(let achievementId):
             fetchDetailAchievement(id: achievementId)
+        case .logout:
+            NotificationCenter.default.post(name: .logout, object: nil)
+            KeychainStorage.shared.remove(key: .accessToken)
+            KeychainStorage.shared.remove(key: .refreshToken)
         }
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Login/LoginCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Login/LoginCoordinator.swift
@@ -38,6 +38,16 @@ public final class LoginCoordinator: Coordinator {
         
         navigationController.viewControllers = [loginVC]
     }
+    
+    public func startWithAlert(message: String) {
+        let loginUseCase = LoginUseCase(repository: LoginRepository(), keychainStorage: KeychainStorage.shared)
+        let loginVM = LoginViewModel(loginUseCase: loginUseCase)
+        let loginVC = LoginViewController(viewModel: loginVM, alertMessage: message)
+        loginVC.coordinator = self
+        loginVC.delegate = self
+        
+        navigationController.viewControllers = [loginVC]
+    }
 }
 
 extension LoginCoordinator: LoginViewControllerDelegate {

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Login/LoginViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Login/LoginViewController.swift
@@ -23,9 +23,18 @@ final class LoginViewController: BaseViewController<LoginView> {
     private let viewModel: LoginViewModel
     private var cancellables: Set<AnyCancellable> = []
     
+    private let alertMessage: String?
+    
     // MARK: - Init
     init(viewModel: LoginViewModel) {
         self.viewModel = viewModel
+        self.alertMessage = nil
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    init(viewModel: LoginViewModel, alertMessage: String) {
+        self.viewModel = viewModel
+        self.alertMessage = alertMessage
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -48,6 +57,10 @@ final class LoginViewController: BaseViewController<LoginView> {
         // view.window가 필요하므로 viewDidAppear에서 setup
         // viewDidLayoutSubviews부터 window가 생기지만, 한 번만 호출하기 위해 viewDidAppear에서 호출
         setupAppleLoginRequester()
+        
+        if let alertMessage = alertMessage {
+            showOneButtonAlert(message: alertMessage)
+        }
     }
     
     private func bind() {


### PR DESCRIPTION
## PR 요약
- 로그아웃을 누르면 로그인 화면으로 이동
- API 응답 status code가 401이면 로그인 화면으로 이동, Alert 표시

##### 스크린샷
- 로그아웃
<img src = "https://github.com/boostcampwm2023/iOS02-moti/assets/89075274/c75a4879-3992-468f-a7fe-43c71939ef31" width = "50%">

- 토큰 만료 시 로그인 화면으로 이동
<img src = "https://github.com/boostcampwm2023/iOS02-moti/assets/89075274/51f6893d-dd64-4d11-b864-b657c2c89f6d" width = "50%">

#### Linked Issue
close #382 
close #383 
