### PR TITLE
그룹내 특정 달성 기록을 차단할 수 있다.

### DIFF
--- a/BE/src/app.module.ts
+++ b/BE/src/app.module.ts
@@ -16,6 +16,7 @@ import { UuidHolderModule } from './common/application/uuid-holder/uuid.module';
 import { ImageModule } from './image/image.module';
 import { GroupModule } from './group/group/group.module';
 import { GroupCategoryModule } from './group/category/group-category.module';
+import { GroupAchievementModule } from './group/achievement/group-achievement.module';
 
 @Module({
   imports: [
@@ -32,6 +33,7 @@ import { GroupCategoryModule } from './group/category/group-category.module';
     ImageModule,
     GroupModule,
     GroupCategoryModule,
+    GroupAchievementModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/BE/src/common/exception/error-code.ts
+++ b/BE/src/common/exception/error-code.ts
@@ -67,4 +67,12 @@ export const ERROR_INFO = {
     statusCode: 400,
     message: '그룹에 카테고리를 만들 수 없습니다.',
   },
+  NO_SUCH_GROUP_ACHIEVEMENT: {
+    statusCode: 400,
+    message: '존재하지 않는 그룹 달성기록 입니다.',
+  },
+  INVALID_REJECT_REQUEST: {
+    statusCode: 400,
+    message: '유효하지 않은 차단 요청입니다.',
+  },
 } as const;

--- a/BE/src/group/achievement/application/group-achievement.service.spec.ts
+++ b/BE/src/group/achievement/application/group-achievement.service.spec.ts
@@ -1,0 +1,136 @@
+import { UsersFixture } from '../../../../test/user/users-fixture';
+import { DataSource } from 'typeorm';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigModule } from '@nestjs/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { configServiceModuleOptions } from '../../../config/config';
+import { typeOrmModuleOptions } from '../../../config/typeorm';
+import { UsersTestModule } from '../../../../test/user/users-test.module';
+import { transactionTest } from '../../../../test/common/transaction-test';
+import { GroupFixture } from '../../../../test/group/group/group-fixture';
+import { GroupTestModule } from '../../../../test/group/group/group-test.module';
+import { GroupAchievementFixture } from '../../../../test/group/achievement/group-achievement-fixture';
+import { GroupAchievementTestModule } from '../../../../test/group/achievement/group-achievement-test.module';
+import { GroupCategoryTestModule } from '../../../../test/group/category/group-category-test.module';
+import { GroupAchievementService } from './group-achievement.service';
+import { GroupAchievementModule } from '../group-achievement.module';
+import { UserGroupGrade } from '../../group/domain/user-group-grade';
+import { NoSuchGroupAchievementException } from '../exception/no-such-group-achievement.exception';
+import { InvalidRejectRequestException } from '../exception/invalid-reject-request.exception';
+
+describe('GroupAchievementService Test', () => {
+  let groupAchievementService: GroupAchievementService;
+  let usersFixture: UsersFixture;
+  let groupFixture: GroupFixture;
+  let groupAchievementFixture: GroupAchievementFixture;
+  let dataSource: DataSource;
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot(configServiceModuleOptions),
+        TypeOrmModule.forRootAsync(typeOrmModuleOptions),
+        GroupAchievementModule,
+        UsersTestModule,
+        GroupTestModule,
+        GroupAchievementTestModule,
+        GroupCategoryTestModule,
+      ],
+      providers: [],
+    }).compile();
+
+    groupAchievementService = module.get<GroupAchievementService>(
+      GroupAchievementService,
+    );
+    usersFixture = module.get<UsersFixture>(UsersFixture);
+    groupFixture = module.get<GroupFixture>(GroupFixture);
+    groupAchievementFixture = module.get<GroupAchievementFixture>(
+      GroupAchievementFixture,
+    );
+    dataSource = module.get<DataSource>(DataSource);
+  });
+
+  afterAll(async () => {
+    await dataSource.destroy();
+  });
+
+  test('그룹내 특정 달성기록을 차단할 수 있다.', async () => {
+    await transactionTest(dataSource, async () => {
+      // given
+      const user1 = await usersFixture.getUser('ABC');
+      const user2 = await usersFixture.getUser('DEF');
+      const group = await groupFixture.createGroup('GROUP', user1);
+      await groupFixture.addMember(group, user2, UserGroupGrade.PARTICIPANT);
+      const groupAchievement =
+        await groupAchievementFixture.createGroupAchievement(
+          user2,
+          group,
+          null,
+          'title',
+        );
+
+      // when
+      const rejectGroupAchievementResponse =
+        await groupAchievementService.reject(
+          user1,
+          group.id,
+          groupAchievement.id,
+        );
+
+      // then
+      expect(rejectGroupAchievementResponse.userId).toEqual(user1.id);
+      expect(rejectGroupAchievementResponse.groupAchievementId).toEqual(
+        groupAchievement.id,
+      );
+    });
+  });
+
+  test('그룹내 존재하지 않는 달성기록을 차단하려고 하면 NoSuchGroupAchievementException를 던진다.', async () => {
+    await transactionTest(dataSource, async () => {
+      // given
+      const user1 = await usersFixture.getUser('ABC');
+      const user2 = await usersFixture.getUser('DEF');
+      const group = await groupFixture.createGroup('GROUP', user1);
+      await groupFixture.addMember(group, user2, UserGroupGrade.PARTICIPANT);
+      const groupAchievement =
+        await groupAchievementFixture.createGroupAchievement(
+          user2,
+          group,
+          null,
+          'title',
+        );
+
+      // when
+      // then
+      await expect(
+        groupAchievementService.reject(
+          user1,
+          group.id,
+          groupAchievement.id + 1,
+        ),
+      ).rejects.toThrow(NoSuchGroupAchievementException);
+    });
+  });
+  test('다른 그룹의 달성기록을 차단하려고 하면 NoSuchGroupAchievementException를 던진다.', async () => {
+    await transactionTest(dataSource, async () => {
+      // given
+      const user1 = await usersFixture.getUser('ABC');
+      const user2 = await usersFixture.getUser('DEF');
+      const group1 = await groupFixture.createGroup('GROUP1', user1);
+      const group2 = await groupFixture.createGroup('GROUP2', user2);
+      const group2Achievement =
+        await groupAchievementFixture.createGroupAchievement(
+          user2,
+          group2,
+          null,
+          'title',
+        );
+
+      // when
+      // then
+      await expect(
+        groupAchievementService.reject(user1, group1.id, group2Achievement.id),
+      ).rejects.toThrow(InvalidRejectRequestException);
+    });
+  });
+});

--- a/BE/src/group/achievement/application/group-achievement.service.ts
+++ b/BE/src/group/achievement/application/group-achievement.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@nestjs/common';
+import { GroupAchievementRepository } from '../entities/group-achievement.repository';
+import { UserBlockedGroupAchievementRepository } from '../entities/user-blocked-group-achievement.repository';
+import { UserBlockedGroupAchievement } from '../domain/user-blocked-group-achievement.domain';
+import { User } from '../../../users/domain/user.domain';
+import { RejectGroupAchievementResponse } from '../dto/reject-group-achievement-response.dto';
+import { NoSuchGroupAchievementException } from '../exception/no-such-group-achievement.exception';
+import { InvalidRejectRequestException } from '../exception/invalid-reject-request.exception';
+
+@Injectable()
+export class GroupAchievementService {
+  constructor(
+    private readonly groupAchievementRepository: GroupAchievementRepository,
+    private readonly userBlockedGroupAchievementRepository: UserBlockedGroupAchievementRepository,
+  ) {}
+  async reject(user: User, groupId: number, achievementId: number) {
+    const achievement =
+      await this.groupAchievementRepository.findById(achievementId);
+    if (!achievement) throw new NoSuchGroupAchievementException();
+    if (achievement.group.id !== groupId)
+      throw new InvalidRejectRequestException();
+
+    const userBlockedGroupAchievement =
+      await this.userBlockedGroupAchievementRepository.saveUserBlockedGroupAchievement(
+        new UserBlockedGroupAchievement(user, achievement),
+      );
+
+    return RejectGroupAchievementResponse.from(userBlockedGroupAchievement);
+  }
+}

--- a/BE/src/group/achievement/controller/group-achievement.controller.spec.ts
+++ b/BE/src/group/achievement/controller/group-achievement.controller.spec.ts
@@ -1,0 +1,167 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuthTestModule } from '../../../../test/auth/auth-test.module';
+import { AppModule } from '../../../app.module';
+import { anyNumber, anyOfClass, instance, mock, when } from 'ts-mockito';
+import { AuthFixture } from '../../../../test/auth/auth-fixture';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { validationPipeOptions } from '../../../config/validation';
+import { UnexpectedExceptionFilter } from '../../../common/filter/unexpected-exception.filter';
+import { MotimateExceptionFilter } from '../../../common/filter/exception.filter';
+import * as request from 'supertest';
+
+import { RejectGroupAchievementResponse } from '../dto/reject-group-achievement-response.dto';
+import { User } from '../../../users/domain/user.domain';
+import { InvalidRejectRequestException } from '../exception/invalid-reject-request.exception';
+import { NoSuchGroupAchievementException } from '../exception/no-such-group-achievement.exception';
+import { GroupAchievementService } from '../application/group-achievement.service';
+
+describe('GroupAchievementController', () => {
+  let app: INestApplication;
+  let authFixture: AuthFixture;
+  let mockGroupAchievementService: GroupAchievementService;
+
+  beforeAll(async () => {
+    mockGroupAchievementService = mock<GroupAchievementService>(
+      GroupAchievementService,
+    );
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule, AuthTestModule],
+      controllers: [],
+      providers: [],
+    })
+      .overrideProvider(GroupAchievementService)
+      .useValue(instance<GroupAchievementService>(mockGroupAchievementService))
+      .compile();
+
+    authFixture = moduleFixture.get<AuthFixture>(AuthFixture);
+    app = moduleFixture.createNestApplication();
+
+    app.useGlobalPipes(new ValidationPipe(validationPipeOptions));
+    app.useGlobalFilters(
+      new UnexpectedExceptionFilter(),
+      new MotimateExceptionFilter(),
+    );
+
+    await app.init();
+  });
+
+  describe('테스트 환경 확인', () => {
+    it('app가 정의되어 있어야 한다.', () => {
+      expect(app).toBeDefined();
+    });
+  });
+
+  describe('특정 그룹 달성 기록을 차단할 수 있다.', () => {
+    it('성공 시 200을 반환한다.', async () => {
+      // given
+      const { accessToken } = await authFixture.getAuthenticatedUser('ABC');
+
+      const rejectGroupAchievementResponse = new RejectGroupAchievementResponse(
+        1,
+        1,
+      );
+
+      when(
+        mockGroupAchievementService.reject(
+          anyOfClass(User),
+          anyNumber(),
+          anyNumber(),
+        ),
+      ).thenResolve(rejectGroupAchievementResponse);
+
+      // when
+      // then
+      return request(app.getHttpServer())
+        .post('/api/v1/groups/1/achievements/1/reject')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(200)
+        .expect((res: request.Response) => {
+          expect(res.body.success).toEqual(true);
+          expect(res.body.data).toEqual({
+            userId: 1,
+            groupAchievementId: 1,
+          });
+        });
+    });
+    it('그룹에 존재하지 않는 달성기록을 차단하려는 경우 400을 반환한다.', async () => {
+      // given
+      const { accessToken } = await authFixture.getAuthenticatedUser('ABC');
+
+      when(
+        mockGroupAchievementService.reject(
+          anyOfClass(User),
+          anyNumber(),
+          anyNumber(),
+        ),
+      ).thenThrow(new NoSuchGroupAchievementException());
+
+      // when
+      // then
+      return request(app.getHttpServer())
+        .post('/api/v1/groups/1/achievements/1/reject')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(400)
+        .expect((res: request.Response) => {
+          expect(res.body.success).toEqual(false);
+          expect(res.body.message).toEqual(
+            '존재하지 않는 그룹 달성기록 입니다.',
+          );
+        });
+    });
+    it('다른 그룹에 있는 달성기록을 차단하려는 경우 400을 반환한다.', async () => {
+      // given
+      const { accessToken } = await authFixture.getAuthenticatedUser('ABC');
+
+      when(
+        mockGroupAchievementService.reject(
+          anyOfClass(User),
+          anyNumber(),
+          anyNumber(),
+        ),
+      ).thenThrow(new InvalidRejectRequestException());
+
+      // when
+      // then
+      return request(app.getHttpServer())
+        .post('/api/v1/groups/1/achievements/1/reject')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(400)
+        .expect((res: request.Response) => {
+          expect(res.body.success).toEqual(false);
+          expect(res.body.message).toEqual('유효하지 않은 차단 요청입니다.');
+        });
+    });
+    it('잘못된 인증시 401을 반환한다.', async () => {
+      // given
+      const accessToken = 'abcd.abcd.efgh';
+
+      // when
+      // then
+      return request(app.getHttpServer())
+        .post('/api/v1/groups/1/achievements/1/reject')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(401)
+        .expect((res: request.Response) => {
+          expect(res.body.success).toBe(false);
+          expect(res.body.message).toBe('잘못된 토큰입니다.');
+        });
+    });
+    it('만료된 인증정보에 401을 반환한다.', async () => {
+      // given
+      const { accessToken } =
+        await authFixture.getExpiredAccessTokenUser('ABC');
+
+      // when
+      // then
+      return request(app.getHttpServer())
+        .post('/api/v1/groups/1/achievements/1/reject')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(401)
+        .expect((res: request.Response) => {
+          expect(res.body.success).toBe(false);
+          expect(res.body.message).toBe('만료된 토큰입니다.');
+        });
+    });
+  });
+});

--- a/BE/src/group/achievement/controller/group-achievement.controller.ts
+++ b/BE/src/group/achievement/controller/group-achievement.controller.ts
@@ -1,0 +1,51 @@
+import {
+  Controller,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { AccessTokenGuard } from '../../../auth/guard/access-token.guard';
+import { AuthenticatedUser } from '../../../auth/decorator/athenticated-user.decorator';
+import { User } from '../../../users/domain/user.domain';
+import { ApiData } from '../../../common/api/api-data';
+import { GroupAchievementService } from '../application/group-achievement.service';
+import { ParseIntPipe } from '../../../common/pipe/parse-int.pipe';
+import { RejectGroupAchievementResponse } from '../dto/reject-group-achievement-response.dto';
+
+@Controller('/api/v1/groups')
+@ApiTags('그룹 달성기록 API')
+export class GroupAchievementController {
+  constructor(
+    private readonly groupAchievementService: GroupAchievementService,
+  ) {}
+
+  @ApiOperation({
+    summary: '특정 달성기록 차단 API',
+    description: '특정 달성기록을 차단한다.',
+  })
+  @ApiResponse({
+    description: '달성기록 차단',
+    type: RejectGroupAchievementResponse,
+  })
+  @ApiBearerAuth('accessToken')
+  @Post(`/:groupId/achievements/:achievementId/reject`)
+  @UseGuards(AccessTokenGuard)
+  @HttpCode(HttpStatus.OK)
+  async rejectAchievement(
+    @AuthenticatedUser() user: User,
+    @Param('groupId', ParseIntPipe) groupId: number,
+    @Param('achievementId', ParseIntPipe) achievementId: number,
+  ) {
+    return ApiData.success(
+      await this.groupAchievementService.reject(user, groupId, achievementId),
+    );
+  }
+}

--- a/BE/src/group/achievement/dto/reject-group-achievement-response.dto.ts
+++ b/BE/src/group/achievement/dto/reject-group-achievement-response.dto.ts
@@ -1,0 +1,21 @@
+import { UserBlockedGroupAchievement } from '../domain/user-blocked-group-achievement.domain';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class RejectGroupAchievementResponse {
+  @ApiProperty({ description: '유저 아이디' })
+  userId: number;
+  @ApiProperty({ description: '달성기록 아이디' })
+  groupAchievementId: number;
+
+  constructor(userId: number, groupAchievementId: number) {
+    this.userId = userId;
+    this.groupAchievementId = groupAchievementId;
+  }
+
+  static from(userBlockedGroupAchievement: UserBlockedGroupAchievement) {
+    return new RejectGroupAchievementResponse(
+      userBlockedGroupAchievement.user.id,
+      userBlockedGroupAchievement.groupAchievement.id,
+    );
+  }
+}

--- a/BE/src/group/achievement/entities/group-achievement.repository.spec.ts
+++ b/BE/src/group/achievement/entities/group-achievement.repository.spec.ts
@@ -1,0 +1,113 @@
+import { DataSource } from 'typeorm';
+import { UsersFixture } from '../../../../test/user/users-fixture';
+import { typeOrmModuleOptions } from '../../../config/typeorm';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigModule } from '@nestjs/config';
+import { UsersTestModule } from '../../../../test/user/users-test.module';
+import { configServiceModuleOptions } from '../../../config/config';
+import { transactionTest } from '../../../../test/common/transaction-test';
+import { GroupFixture } from '../../../../test/group/group/group-fixture';
+import { CustomTypeOrmModule } from '../../../config/typeorm/custom-typeorm.module';
+import { GroupTestModule } from '../../../../test/group/group/group-test.module';
+import { GroupAchievementRepository } from './group-achievement.repository';
+import { GroupRepository } from '../../group/entities/group.repository';
+import { UserGroupRepository } from '../../group/entities/user-group.repository';
+import { GroupAchievementFixture } from '../../../../test/group/achievement/group-achievement-fixture';
+import { GroupAchievementTestModule } from '../../../../test/group/achievement/group-achievement-test.module';
+import { GroupAchievement } from '../domain/group-achievement.domain';
+
+describe('GroupRepository Test', () => {
+  let groupAchievementRepository: GroupAchievementRepository;
+  let groupFixture: GroupFixture;
+  let usersFixture: UsersFixture;
+  let groupAchievementFixture: GroupAchievementFixture;
+  let dataSource: DataSource;
+
+  beforeAll(async () => {
+    const app: TestingModule = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot(configServiceModuleOptions),
+        TypeOrmModule.forRootAsync(typeOrmModuleOptions),
+        CustomTypeOrmModule.forCustomRepository([
+          GroupRepository,
+          UserGroupRepository,
+          GroupAchievementRepository,
+        ]),
+        UsersTestModule,
+        GroupTestModule,
+        GroupAchievementTestModule,
+      ],
+      controllers: [],
+      providers: [],
+    }).compile();
+
+    groupAchievementRepository = app.get<GroupAchievementRepository>(
+      GroupAchievementRepository,
+    );
+    usersFixture = app.get<UsersFixture>(UsersFixture);
+    groupFixture = app.get<GroupFixture>(GroupFixture);
+    groupAchievementFixture = app.get<GroupAchievementFixture>(
+      GroupAchievementFixture,
+    );
+    dataSource = app.get<DataSource>(DataSource);
+  });
+
+  afterAll(async () => {
+    await dataSource.destroy();
+  });
+
+  test('그룹 달성 기록을 저장할 수 있다.', async () => {
+    await transactionTest(dataSource, async () => {
+      // given
+      const user = await usersFixture.getUser('ABC');
+      const group = await groupFixture.createGroup('GROUP', user);
+      const groupAchievement = new GroupAchievement(
+        'title',
+        user,
+        group,
+        null,
+        `content`,
+      );
+
+      // when
+      const saved =
+        await groupAchievementRepository.saveGroupAchievement(groupAchievement);
+
+      // then
+      expect(saved.user.id).toEqual(user.id);
+      expect(saved.group.id).toEqual(group.id);
+      expect(saved.title).toEqual('title');
+      expect(saved.content).toEqual('content');
+    });
+  });
+
+  test('그룹 달성 기록 id로 조회할 수 있다.', async () => {
+    await transactionTest(dataSource, async () => {
+      // given
+      const user = await usersFixture.getUser('ABC');
+      const group = await groupFixture.createGroup('GROUP', user);
+      const groupAchievement =
+        await groupAchievementFixture.createGroupAchievement(
+          user,
+          group,
+          null,
+          'title',
+        );
+
+      // when
+      const findById = await groupAchievementRepository.findById(
+        groupAchievement.id,
+      );
+
+      // then
+      expect(findById.user.id).toEqual(user.id);
+      expect(findById.user.userCode).toEqual(user.userCode);
+      expect(findById.group.id).toEqual(group.id);
+      expect(findById.id).toEqual(groupAchievement.id);
+      expect(findById.title).toEqual(groupAchievement.title);
+      expect(findById.content).toEqual(groupAchievement.content);
+      expect(findById.createdAt).toEqual(groupAchievement.createdAt);
+    });
+  });
+});

--- a/BE/src/group/achievement/entities/group-achievement.repository.ts
+++ b/BE/src/group/achievement/entities/group-achievement.repository.ts
@@ -10,4 +10,18 @@ export class GroupAchievementRepository extends TransactionalRepository<GroupAch
     await this.repository.save(newGroupAchievement);
     return newGroupAchievement.toModel();
   }
+
+  async findById(id: number) {
+    const groupAchievementEntity = await this.repository
+      .createQueryBuilder('group_achievement')
+      .select()
+      .leftJoin('group_achievement.group', 'group')
+      .leftJoin('group_achievement.user', 'user')
+      .addSelect('group.id')
+      .addSelect('user.id')
+      .addSelect('user.userCode')
+      .where('group_achievement.id = :id', { id })
+      .getOne();
+    return groupAchievementEntity?.toModel();
+  }
 }

--- a/BE/src/group/achievement/entities/user-blocked-group-achievement.repository.spec.ts
+++ b/BE/src/group/achievement/entities/user-blocked-group-achievement.repository.spec.ts
@@ -1,0 +1,89 @@
+import { DataSource } from 'typeorm';
+import { UsersFixture } from '../../../../test/user/users-fixture';
+import { typeOrmModuleOptions } from '../../../config/typeorm';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigModule } from '@nestjs/config';
+import { UsersTestModule } from '../../../../test/user/users-test.module';
+import { configServiceModuleOptions } from '../../../config/config';
+import { transactionTest } from '../../../../test/common/transaction-test';
+import { GroupFixture } from '../../../../test/group/group/group-fixture';
+import { CustomTypeOrmModule } from '../../../config/typeorm/custom-typeorm.module';
+import { GroupTestModule } from '../../../../test/group/group/group-test.module';
+import { GroupAchievementRepository } from './group-achievement.repository';
+import { UserBlockedGroupAchievementRepository } from './user-blocked-group-achievement.repository';
+import { GroupRepository } from '../../group/entities/group.repository';
+import { UserGroupRepository } from '../../group/entities/user-group.repository';
+import { UserBlockedGroupAchievement } from '../domain/user-blocked-group-achievement.domain';
+import { UserGroupGrade } from '../../group/domain/user-group-grade';
+import { GroupAchievementFixture } from '../../../../test/group/achievement/group-achievement-fixture';
+import { GroupAchievementTestModule } from '../../../../test/group/achievement/group-achievement-test.module';
+
+describe('UserBlockedGroupAchievementRepository Test', () => {
+  let userBlockedGroupAchievementRepository: UserBlockedGroupAchievementRepository;
+  let groupFixture: GroupFixture;
+  let usersFixture: UsersFixture;
+  let groupAchievementFixture: GroupAchievementFixture;
+  let dataSource: DataSource;
+
+  beforeAll(async () => {
+    const app: TestingModule = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot(configServiceModuleOptions),
+        TypeOrmModule.forRootAsync(typeOrmModuleOptions),
+        CustomTypeOrmModule.forCustomRepository([
+          GroupRepository,
+          UserGroupRepository,
+          GroupAchievementRepository,
+          UserBlockedGroupAchievementRepository,
+        ]),
+        UsersTestModule,
+        GroupTestModule,
+        GroupAchievementTestModule,
+      ],
+      controllers: [],
+      providers: [],
+    }).compile();
+
+    userBlockedGroupAchievementRepository =
+      app.get<UserBlockedGroupAchievementRepository>(
+        UserBlockedGroupAchievementRepository,
+      );
+    usersFixture = app.get<UsersFixture>(UsersFixture);
+    groupFixture = app.get<GroupFixture>(GroupFixture);
+    groupAchievementFixture = app.get<GroupAchievementFixture>(
+      GroupAchievementFixture,
+    );
+    dataSource = app.get<DataSource>(DataSource);
+  });
+
+  afterAll(async () => {
+    await dataSource.destroy();
+  });
+
+  test('특정 유저가 그룹 내에서 차단한 달성 기록 정보를 저장한다.', async () => {
+    await transactionTest(dataSource, async () => {
+      // given
+      const user1 = await usersFixture.getUser('ABC');
+      const user2 = await usersFixture.getUser('DEF');
+      const group = await groupFixture.createGroup('GROUP', user1);
+      await groupFixture.addMember(group, user2, UserGroupGrade.PARTICIPANT);
+      const groupAchievement =
+        await groupAchievementFixture.createGroupAchievement(
+          user2,
+          group,
+          null,
+          'title',
+        );
+      // when
+      const saved =
+        await userBlockedGroupAchievementRepository.saveUserBlockedGroupAchievement(
+          new UserBlockedGroupAchievement(user1, groupAchievement),
+        );
+
+      // then
+      expect(saved.user.id).toEqual(user1.id);
+      expect(saved.groupAchievement.id).toEqual(groupAchievement.id);
+    });
+  });
+});

--- a/BE/src/group/achievement/entities/user-blocked-group-achievement.repository.ts
+++ b/BE/src/group/achievement/entities/user-blocked-group-achievement.repository.ts
@@ -1,0 +1,16 @@
+import { TransactionalRepository } from '../../../config/transaction-manager/transactional-repository';
+import { CustomRepository } from '../../../config/typeorm/custom-repository.decorator';
+import { UserBlockedGroupAchievementEntity } from './user-blocked-group-achievement.entity';
+import { UserBlockedGroupAchievement } from '../domain/user-blocked-group-achievement.domain';
+
+@CustomRepository(UserBlockedGroupAchievementEntity)
+export class UserBlockedGroupAchievementRepository extends TransactionalRepository<UserBlockedGroupAchievementEntity> {
+  async saveUserBlockedGroupAchievement(
+    userBlockedGroupAchievement: UserBlockedGroupAchievement,
+  ) {
+    const newUserBlockedGroupAchievement =
+      UserBlockedGroupAchievementEntity.from(userBlockedGroupAchievement);
+    await this.repository.save(newUserBlockedGroupAchievement);
+    return newUserBlockedGroupAchievement.toModel();
+  }
+}

--- a/BE/src/group/achievement/exception/invalid-reject-request.exception.ts
+++ b/BE/src/group/achievement/exception/invalid-reject-request.exception.ts
@@ -1,0 +1,8 @@
+import { MotimateException } from '../../../common/exception/motimate.excpetion';
+import { ERROR_INFO } from '../../../common/exception/error-code';
+
+export class InvalidRejectRequestException extends MotimateException {
+  constructor() {
+    super(ERROR_INFO.INVALID_REJECT_REQUEST);
+  }
+}

--- a/BE/src/group/achievement/exception/no-such-group-achievement.exception.ts
+++ b/BE/src/group/achievement/exception/no-such-group-achievement.exception.ts
@@ -1,0 +1,8 @@
+import { MotimateException } from '../../../common/exception/motimate.excpetion';
+import { ERROR_INFO } from '../../../common/exception/error-code';
+
+export class NoSuchGroupAchievementException extends MotimateException {
+  constructor() {
+    super(ERROR_INFO.NO_SUCH_GROUP_ACHIEVEMENT);
+  }
+}

--- a/BE/src/group/achievement/group-achievement.module.ts
+++ b/BE/src/group/achievement/group-achievement.module.ts
@@ -1,0 +1,18 @@
+import { CustomTypeOrmModule } from '../../config/typeorm/custom-typeorm.module';
+import { GroupAchievementRepository } from './entities/group-achievement.repository';
+import { GroupAchievementService } from './application/group-achievement.service';
+import { GroupAchievementController } from './controller/group-achievement.controller';
+import { Module } from '@nestjs/common';
+import { UserBlockedGroupAchievementRepository } from './entities/user-blocked-group-achievement.repository';
+
+@Module({
+  imports: [
+    CustomTypeOrmModule.forCustomRepository([
+      GroupAchievementRepository,
+      UserBlockedGroupAchievementRepository,
+    ]),
+  ],
+  controllers: [GroupAchievementController],
+  providers: [GroupAchievementService],
+})
+export class GroupAchievementModule {}


### PR DESCRIPTION
## PR 요약
- 그룹내 특정 달성 기록을 차단할 수 있다.

##### 스크린샷

- 성공 
<img width="762" alt="image" src="https://github.com/boostcampwm2023/iOS02-moti/assets/34297340/2f8178ad-f672-49b3-b72d-9730a6dd9faa">

- 그룹 내 유효하지 않은 달성 기록 차단 요청
<img width="759" alt="image" src="https://github.com/boostcampwm2023/iOS02-moti/assets/34297340/53f682a0-19a4-4dc1-8f89-4ffbd4ed8e28">

- 타그룹 달성 기록 차단 요청
<img width="746" alt="image" src="https://github.com/boostcampwm2023/iOS02-moti/assets/34297340/07b4e139-b0fc-4f9e-92f3-3dc998d35ce1">

#### Linked Issue
close #266 
close #268 
