### PR TITLE
categoryId get-only로 변경 / Context menu에 제목도 표시

### DIFF
--- a/iOS/moti/moti/Domain/Sources/Domain/Entity/Achievement.swift
+++ b/iOS/moti/moti/Domain/Sources/Domain/Entity/Achievement.swift
@@ -13,12 +13,15 @@ public struct Achievement: Hashable {
         didSet {
             // categoryId 속성 동기화
             guard let category else { return }
-            categoryId = category.id
+            _categoryId = category.id
         }
     }
     // CategoryItem 속성을 바꾸는 것보다 Id만 하나 추가하는 게 수정 범위가 더 적다고 판단하여 추가
     // 카테고리 id만 필요한 경우 해당 속성 사용
-    public var categoryId: Int
+    public var categoryId: Int {
+        return _categoryId
+    }
+    private var _categoryId: Int
     public var title: String
     public let imageURL: URL?
     public var body: String?
@@ -34,7 +37,7 @@ public struct Achievement: Hashable {
     ) {
         self.id = id
         self.category = category
-        self.categoryId = category.id
+        self._categoryId = category.id
         self.title = title
         self.imageURL = imageURL
         self.body = body
@@ -49,7 +52,7 @@ public struct Achievement: Hashable {
     ) {
         self.id = id
         self.category = nil
-        self.categoryId = categoryId
+        self._categoryId = categoryId
         self.title = title
         self.imageURL = imageURL
         self.body = nil

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewController.swift
@@ -267,7 +267,11 @@ extension HomeViewController: UICollectionViewDelegate {
                 }
             }
             
-            return UIMenu(options: .displayInline, children: [editAchievementAction, deleteAchievementAction])
+            return UIMenu(
+                title: selectedItem.title,
+                options: .displayInline, 
+                children: [editAchievementAction, deleteAchievementAction]
+            )
         }
 
         return config

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewModel.swift
@@ -109,7 +109,7 @@ final class HomeViewModel {
         case .deleteAchievementDataSourceItem(let achievementId):
             deleteOfDataSource(achievementId: achievementId)
         case .updateAchievement(let updatedAchievement):
-            updateAchievementCategory(updatedAchievement: updatedAchievement)
+            updateAchievement(updatedAchievement: updatedAchievement)
         case .postAchievement(let newAchievement):
             postAchievement(newAchievement: newAchievement)
         case .deleteAchievement(let achievementId, let categoryId):
@@ -186,7 +186,13 @@ private extension HomeViewModel {
     }
     
     /// 도전 기록의 카테고리를 변경하는 액션
-    func updateAchievementCategory(updatedAchievement: Achievement) {
+    func updateAchievement(updatedAchievement: Achievement) {
+        // 홈 화면 데이터 업데이트
+        for i in 0..<achievements.count where achievements[i].id == updatedAchievement.id {
+            achievements[i] = updatedAchievement
+        }
+        
+        // 카테고리가 변경된거면 홈 화면 리스트 갱신
         guard let currentCategory,
               let updatedCategory = updatedAchievement.category else { return }
         syncCurrentCategoryWithStorage()

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewModel.swift
@@ -188,8 +188,8 @@ private extension HomeViewModel {
     /// 도전 기록의 카테고리를 변경하는 액션
     func updateAchievement(updatedAchievement: Achievement) {
         // 홈 화면 데이터 업데이트
-        for i in 0..<achievements.count where achievements[i].id == updatedAchievement.id {
-            achievements[i] = updatedAchievement
+        for index in 0..<achievements.count where achievements[index].id == updatedAchievement.id {
+            achievements[index] = updatedAchievement
         }
         
         // 카테고리가 변경된거면 홈 화면 리스트 갱신


### PR DESCRIPTION
## PR 요약
- categoryId get-only로 변경
- Context menu에 제목도 표시

#### 변경 사항
- Achievement의 categoryId를 get-only로 변경
    - _categoryId로 private에서 set까지 가능한 프로퍼티 구현
    - public에서 접근 가능한 프로퍼티는 _categoryId를 반환하는 categoryId를 계산 프로퍼티로 구현
    - 참고자료: https://ios-development.tistory.com/690

##### 스크린샷
- categoryId를 수정하면 컴파일 에러 발생
<img width="1273" alt="스크린샷 2023-12-03 오후 8 00 00" src="https://github.com/boostcampwm2023/iOS02-moti/assets/89075274/3c79829d-d277-4ac5-8a52-7a5822495892">

- Context Menu에 제목도 표시
<img width="349" alt="스크린샷 2023-12-03 오후 8 02 37" src="https://github.com/boostcampwm2023/iOS02-moti/assets/89075274/4b3d3e49-ac95-44c0-b158-2dc4c5b508dd">


#### Linked Issue
close #378 
