### PR TITLE
미설정 카테고리 기능

### DIFF
--- a/BE/src/achievement/application/achievement.service.ts
+++ b/BE/src/achievement/application/achievement.service.ts
@@ -77,6 +77,8 @@ export class AchievementService {
   }
 
   private async getCategory(userId: number, ctgId: number) {
+    if (ctgId === -1) return null;
+
     const ctg = await this.categoryRepository.findByIdAndUser(userId, ctgId);
     if (!ctg) throw new InvalidCategoryException();
     return ctg;

--- a/BE/src/achievement/domain/achievement.domain.ts
+++ b/BE/src/achievement/domain/achievement.domain.ts
@@ -31,8 +31,8 @@ export class Achievement {
   }
 
   update(achievementUpdate: AchievementUpdate) {
-    this.title = achievementUpdate.title || this.title;
-    this.content = achievementUpdate.content || this.content;
-    this.category = achievementUpdate.category || this.category;
+    this.title = achievementUpdate.title;
+    this.content = achievementUpdate.content;
+    this.category = achievementUpdate.category;
   }
 }

--- a/BE/src/achievement/dto/achievement-detail-response.ts
+++ b/BE/src/achievement/dto/achievement-detail-response.ts
@@ -24,8 +24,8 @@ export class AchievementDetailResponse {
     this.imageUrl = achievementDetail.imageUrl;
     this.createdAt = dateFormat(new Date(achievementDetail.createdAt));
     this.category = new CategoryInfo(
-      achievementDetail.categoryId,
-      achievementDetail.categoryName,
+      achievementDetail.categoryId || -1,
+      achievementDetail.categoryName || '미설정',
       Number(achievementDetail.achieveCount),
     );
   }

--- a/BE/src/achievement/entities/achievement.repository.spec.ts
+++ b/BE/src/achievement/entities/achievement.repository.spec.ts
@@ -17,6 +17,7 @@ import { CategoryTestModule } from '../../../test/category/category-test.module'
 import { Achievement } from '../domain/achievement.domain';
 import { PaginateAchievementRequest } from '../dto/paginate-achievement-request';
 import { ImageFixture } from '../../../test/image/image-fixture';
+import { Category } from '../../category/domain/category.domain';
 
 describe('AchievementRepository test', () => {
   let achievementRepository: AchievementRepository;
@@ -309,6 +310,51 @@ describe('AchievementRepository test', () => {
       expect(findOne.id).toEqual(achievement.id);
       expect(findOne.title).toEqual(achievement.title);
       expect(findOne.content).toEqual(achievement.content);
+    });
+  });
+
+  describe('findByUserWithCount는 카테고리와 그 개수를 조회할 수 있다.', () => {
+    it('findByUserWithCount는 사용자가 소유한 카테고리가 없으면 미등록 카테고리만 반환한다.', async () => {
+      await transactionTest(dataSource, async () => {
+        const user = await usersFixture.getUser(1);
+
+        const retrievedCategories =
+          await achievementRepository.findByCategoryWithCount(user);
+
+        expect(retrievedCategories).toBeDefined();
+        expect(retrievedCategories.length).toBe(0);
+      });
+    });
+
+    it('findByUserWithCount', async () => {
+      await transactionTest(dataSource, async () => {
+        const user = await usersFixture.getUser(1);
+        const categories: Category[] = await categoryFixture.getCategories(
+          4,
+          user,
+        );
+        await achievementFixture.getAchievements(4, user, categories[0]);
+        await achievementFixture.getAchievements(5, user, categories[1]);
+        await achievementFixture.getAchievements(7, user, categories[2]);
+        await achievementFixture.getAchievements(10, user, categories[3]);
+
+        const retrievedCategories =
+          await achievementRepository.findByCategoryWithCount(user);
+
+        expect(retrievedCategories.length).toBe(4);
+        expect(retrievedCategories[0].categoryId).toEqual(categories[0].id);
+        expect(retrievedCategories[0].insertedAt).toBeInstanceOf(Date);
+        expect(retrievedCategories[0].achievementCount).toBe(4);
+        expect(retrievedCategories[1].categoryId).toEqual(categories[1].id);
+        expect(retrievedCategories[1].insertedAt).toBeInstanceOf(Date);
+        expect(retrievedCategories[1].achievementCount).toBe(5);
+        expect(retrievedCategories[2].categoryId).toEqual(categories[2].id);
+        expect(retrievedCategories[2].insertedAt).toBeInstanceOf(Date);
+        expect(retrievedCategories[2].achievementCount).toBe(7);
+        expect(retrievedCategories[3].categoryId).toEqual(categories[3].id);
+        expect(retrievedCategories[3].insertedAt).toBeInstanceOf(Date);
+        expect(retrievedCategories[3].achievementCount).toBe(10);
+      });
     });
   });
 });

--- a/BE/src/category/application/category.service.ts
+++ b/BE/src/category/application/category.service.ts
@@ -5,10 +5,14 @@ import { Transactional } from '../../config/transaction-manager';
 import { Category } from '../domain/category.domain';
 import { User } from '../../users/domain/user.domain';
 import { CategoryMetaData } from '../dto/category-metadata';
+import { AchievementRepository } from '../../achievement/entities/achievement.repository';
 
 @Injectable()
 export class CategoryService {
-  constructor(private readonly categoryRepository: CategoryRepository) {}
+  constructor(
+    private readonly categoryRepository: CategoryRepository,
+    private readonly achievementRepository: AchievementRepository,
+  ) {}
 
   @Transactional()
   async saveCategory(
@@ -21,6 +25,6 @@ export class CategoryService {
 
   @Transactional({ readonly: true })
   async getCategoriesByUser(user: User): Promise<CategoryMetaData[]> {
-    return this.categoryRepository.findByUserWithCount(user);
+    return this.achievementRepository.findByCategoryWithCount(user);
   }
 }

--- a/BE/src/category/category.module.ts
+++ b/BE/src/category/category.module.ts
@@ -4,10 +4,16 @@ import { CategoryService } from './application/category.service';
 import { CustomTypeOrmModule } from '../config/typeorm/custom-typeorm.module';
 import { CategoryRepository } from './entities/category.repository';
 import { CategoryLegacyController } from './controller/category-legacy.controller';
+import { AchievementRepository } from '../achievement/entities/achievement.repository';
 
 @Module({
   controllers: [CategoryController, CategoryLegacyController],
-  imports: [CustomTypeOrmModule.forCustomRepository([CategoryRepository])],
+  imports: [
+    CustomTypeOrmModule.forCustomRepository([
+      CategoryRepository,
+      AchievementRepository,
+    ]),
+  ],
   providers: [CategoryService],
 })
 export class CategoryModule {}

--- a/BE/src/category/dto/category-list-element.response.spec.ts
+++ b/BE/src/category/dto/category-list-element.response.spec.ts
@@ -1,0 +1,82 @@
+import { CategoryMetaData } from './category-metadata';
+import { CategoryListElementResponse } from './category-list-element.response';
+
+describe('CategoryListElementResponse Test', () => {
+  it('전체가 0번 미설정이 1번에 포함되어야 한다.', () => {
+    // given
+    const categoryMetaData = [
+      new CategoryMetaData({
+        categoryId: '1',
+        categoryName: '카테고리1',
+        insertedAt: '2023-12-23T15:35:26Z',
+        achievementCount: '1',
+      }),
+      new CategoryMetaData({
+        categoryId: '2',
+        categoryName: '카테고리2',
+        insertedAt: '2023-12-23T15:35:26Z',
+        achievementCount: '5',
+      }),
+    ];
+
+    // when
+    const categories = CategoryListElementResponse.build(categoryMetaData);
+
+    // then
+
+    expect(categories.length).toBe(4);
+    expect(categories[0].id).toBe(0);
+    expect(categories[0].name).toBe('전체');
+    expect(categories[1].id).toBe(-1);
+    expect(categories[1].name).toBe('미설정');
+    expect(categories[2].id).toBe(1);
+    expect(categories[2].name).toBe('카테고리1');
+    expect(categories[3].id).toBe(2);
+    expect(categories[3].name).toBe('카테고리2');
+  });
+
+  it('전체가 0번 미설정이 1번에 포함되어야 한다.', () => {
+    // given
+    const categoryMetaData = [];
+
+    // when
+    const categories = CategoryListElementResponse.build(categoryMetaData);
+
+    // then
+    expect(categories.length).toBe(2);
+    expect(categories[0].id).toBe(0);
+    expect(categories[0].name).toBe('전체');
+    expect(categories[1].id).toBe(-1);
+    expect(categories[1].name).toBe('미설정');
+  });
+
+  it('미설정 카테고리가 포함되어 있다면 새로 생성하지 않아야 한다.', () => {
+    // given
+    const categoryMetaData = [
+      new CategoryMetaData({
+        categoryId: '-1',
+        categoryName: '미설정',
+        insertedAt: '2023-12-23T15:35:26Z',
+        achievementCount: '1',
+      }),
+      new CategoryMetaData({
+        categoryId: '2',
+        categoryName: '카테고리',
+        insertedAt: '2023-12-23T15:35:26Z',
+        achievementCount: '5',
+      }),
+    ];
+
+    // when
+    const categories = CategoryListElementResponse.build(categoryMetaData);
+
+    // then
+    expect(categories.length).toBe(3);
+    expect(categories[0].id).toBe(0);
+    expect(categories[0].name).toBe('전체');
+    expect(categories[1].id).toBe(-1);
+    expect(categories[1].name).toBe('미설정');
+    expect(categories[2].id).toBe(2);
+    expect(categories[2].name).toBe('카테고리');
+  });
+});

--- a/BE/src/category/dto/category-list-element.response.ts
+++ b/BE/src/category/dto/category-list-element.response.ts
@@ -31,12 +31,24 @@ export class CategoryListElementResponse {
     });
   }
 
+  static notAssignedCategoryElement() {
+    return new CategoryListElementResponse({
+      categoryId: -1,
+      categoryName: '미설정',
+      insertedAt: null,
+      achievementCount: 0,
+    });
+  }
+
   static build(
     categoryMetaData: CategoryMetaData[],
   ): CategoryListElementResponse[] {
     const totalItem = CategoryListElementResponse.totalCategoryElement();
     const categories: CategoryListElementResponse[] = [];
     categories.push(totalItem);
+
+    if (categoryMetaData.length === 0 || categoryMetaData[0].categoryId !== -1)
+      categories.push(CategoryListElementResponse.notAssignedCategoryElement());
 
     categoryMetaData?.forEach((category) => {
       if (

--- a/BE/src/category/dto/category-list-regacy.response.spec.ts
+++ b/BE/src/category/dto/category-list-regacy.response.spec.ts
@@ -52,7 +52,7 @@ describe('CategoryListLegacyResponse', () => {
       const categoryMetaData: CategoryMetaData[] = [];
       categoryMetaData.push(
         new CategoryMetaData({
-          categoryId: 1,
+          categoryId: '1',
           categoryName: '카테고리1',
           insertedAt: new Date('2021-01-01T00:00:00.000Z').toISOString(),
           achievementCount: '1',
@@ -60,7 +60,7 @@ describe('CategoryListLegacyResponse', () => {
       );
       categoryMetaData.push(
         new CategoryMetaData({
-          categoryId: 2,
+          categoryId: '2',
           categoryName: '카테고리2',
           insertedAt: new Date('2021-01-02T00:00:00.000Z').toISOString(),
           achievementCount: '2',

--- a/BE/src/category/dto/category-metadata.ts
+++ b/BE/src/category/dto/category-metadata.ts
@@ -7,8 +7,10 @@ export class CategoryMetaData {
   achievementCount: number;
 
   constructor(categoryMetaData: ICategoryMetaData) {
-    this.categoryId = categoryMetaData.categoryId;
-    this.categoryName = categoryMetaData.categoryName;
+    this.categoryId = isNaN(parseInt(categoryMetaData.categoryId))
+      ? -1
+      : parseInt(categoryMetaData.categoryId);
+    this.categoryName = categoryMetaData.categoryName || '미설정';
     this.insertedAt = categoryMetaData.insertedAt
       ? new Date(categoryMetaData.insertedAt)
       : null;

--- a/BE/src/category/entities/category.repository.ts
+++ b/BE/src/category/entities/category.repository.ts
@@ -22,10 +22,10 @@ export class CategoryRepository extends TransactionalRepository<CategoryEntity> 
   async findByUserWithCount(user: User): Promise<CategoryMetaData[]> {
     const categories = await this.repository
       .createQueryBuilder('category')
-      .select('category.id', 'categoryId')
+      .select('category.id as categoryId')
       .addSelect('category.name', 'categoryName')
       .addSelect('MAX(achievement.created_at)', 'insertedAt')
-      .addSelect('COUNT(achievement.id)', 'achievementCount')
+      .addSelect('COUNT(*)', 'achievementCount')
       .leftJoin('category.achievements', 'achievement')
       .where('category.user_id = :user', { user: user.id })
       .orderBy('category.id', 'ASC')

--- a/BE/src/category/index.ts
+++ b/BE/src/category/index.ts
@@ -1,5 +1,5 @@
 export interface ICategoryMetaData {
-  categoryId: number;
+  categoryId: string;
   categoryName: string;
   insertedAt: string;
   achievementCount: string;

--- a/BE/src/image/entities/image.entity.ts
+++ b/BE/src/image/entities/image.entity.ts
@@ -53,6 +53,8 @@ export class ImageEntity {
   }
 
   static strictFrom(image: Image): ImageEntity {
+    if (isNullOrUndefined(image)) return image;
+
     const imageEntity = new ImageEntity();
     imageEntity.id = image.id;
     imageEntity.originalName = image.originalName;


### PR DESCRIPTION
## PR 요약
* 미설정 카테고리에 대한 기능 추가

#### 변경 사항
* 카테고리 리스트에 미설정 카테고리 반환
* 미설정 카테고리로 달성기록 저장
* 미설정 카테고리로 달성기록 수정

##### 스크린샷

* 카테고리 리스트

![image](https://github.com/boostcampwm2023/iOS02-moti/assets/75921696/e9abee28-a28e-4522-9d4e-4e4abbd6836e)

![image](https://github.com/boostcampwm2023/iOS02-moti/assets/75921696/91502978-eaee-4d23-bb99-8a3806ae44e8)

* 미설정 카테고리로 달성기록 저장

![image](https://github.com/boostcampwm2023/iOS02-moti/assets/75921696/ba6191b9-3ea9-46a1-8d6b-8b37756ef451)

* 미설정 카테고리로 달성기록 수정

![image](https://github.com/boostcampwm2023/iOS02-moti/assets/75921696/c43b191a-0ef4-4c54-8e38-ceaa48a70637)

![image](https://github.com/boostcampwm2023/iOS02-moti/assets/75921696/b204a429-4a09-4ebd-b80a-1a0a1a50f6b0)

#### Linked Issue
close #361 
