### PR TITLE
그룹 생성 구현

### DIFF
--- a/iOS/moti/moti/Data/Sources/Data/Network/DTO/CreateGroupDTO.swift
+++ b/iOS/moti/moti/Data/Sources/Data/Network/DTO/CreateGroupDTO.swift
@@ -1,0 +1,15 @@
+//
+//  CreateGroupDTO.swift
+//
+//
+//  Created by 유정주 on 12/4/23.
+//
+
+import Foundation
+import Domain
+
+struct CreateGroupDTO: ResponseDataDTO {
+    let success: Bool?
+    let message: String?
+    let data: GroupDTO?
+}

--- a/iOS/moti/moti/Data/Sources/Data/Network/DTO/FetchGroupListDTO.swift
+++ b/iOS/moti/moti/Data/Sources/Data/Network/DTO/FetchGroupListDTO.swift
@@ -24,7 +24,7 @@ struct GroupDTO: Codable {
     let avatarUrl: URL?
     let continued: Int?
     let lastChallenged: Date?
-    let grade: String
+    let grade: String?
 }
 
 extension Group {
@@ -35,6 +35,16 @@ extension Group {
             avatarUrl: dto.avatarUrl,
             continued: dto.continued ?? 0,
             lastChallenged: dto.lastChallenged,
-            grade: GroupGrade(grade: dto.grade) ?? .participant)
+            grade: GroupGrade(grade: dto.grade ?? "") ?? .participant)
+    }
+    
+    init(dto: GroupDTO, grade: GroupGrade) {
+        self.init(
+            id: dto.id,
+            name: dto.name ?? "",
+            avatarUrl: dto.avatarUrl,
+            continued: dto.continued ?? 0,
+            lastChallenged: dto.lastChallenged,
+            grade: grade)
     }
 }

--- a/iOS/moti/moti/Data/Sources/Data/Network/Endpoint/MotiAPI.swift
+++ b/iOS/moti/moti/Data/Sources/Data/Network/Endpoint/MotiAPI.swift
@@ -21,6 +21,7 @@ enum MotiAPI: EndpointProtocol {
     case updateAchievement(requestValue: UpdateAchievementRequestValue)
     case postAchievement(requestValue: PostAchievementRequestValue)
     case fetchGroupList
+    case createGroup(requestValue: CreateGroupRequestValue)
     
     private var keychainStorage: KeychainStorageProtocol {
         return KeychainStorage.shared
@@ -50,6 +51,7 @@ extension MotiAPI {
         case .updateAchievement(let requestValue): return "/achievements/\(requestValue.id)"
         case .postAchievement: return "/achievements"
         case .fetchGroupList: return "/groups"
+        case .createGroup: return "/groups"
         }
     }
     
@@ -67,6 +69,7 @@ extension MotiAPI {
         case .updateAchievement: return .put
         case .postAchievement: return .post
         case .fetchGroupList: return .get
+        case .createGroup: return .post
         }
     }
     
@@ -90,6 +93,8 @@ extension MotiAPI {
         case .updateAchievement(let requestValue):
             return requestValue.body
         case .postAchievement(let requestValue):
+            return requestValue
+        case .createGroup(let requestValue):
             return requestValue
         default:
             return nil

--- a/iOS/moti/moti/Data/Sources/Repository/GroupRepository.swift
+++ b/iOS/moti/moti/Data/Sources/Repository/GroupRepository.swift
@@ -22,4 +22,13 @@ public struct GroupRepository: GroupRepositoryProtocol {
         
         return groupDTOs.map { Group(dto: $0) }
     }
+    
+    public func createGroup(requestValue: CreateGroupRequestValue) async throws -> Group {
+        let endpoint = MotiAPI.createGroup(requestValue: requestValue)
+        let responseDTO = try await provider.request(with: endpoint, type: CreateGroupDTO.self)
+        guard let groupDTO = responseDTO.data else { throw NetworkError.decode }
+        
+        // 생성한 사람은 항상 leader
+        return Group(dto: groupDTO, grade: .leader)
+    }
 }

--- a/iOS/moti/moti/Domain/Sources/Domain/RepositoryProtocol/GroupRepositoryProtocol.swift
+++ b/iOS/moti/moti/Domain/Sources/Domain/RepositoryProtocol/GroupRepositoryProtocol.swift
@@ -9,4 +9,5 @@ import Foundation
 
 public protocol GroupRepositoryProtocol {
     func fetchGroupList() async throws -> [Group]
+    func createGroup(requestValue: CreateGroupRequestValue) async throws -> Group
 }

--- a/iOS/moti/moti/Domain/Sources/Domain/UseCase/CreateGroupUseCase.swift
+++ b/iOS/moti/moti/Domain/Sources/Domain/UseCase/CreateGroupUseCase.swift
@@ -1,0 +1,30 @@
+//
+//  CreateGroupUseCase.swift
+//
+//
+//  Created by 유정주 on 12/4/23.
+//
+
+import Foundation
+
+public struct CreateGroupRequestValue: RequestValue {
+    private let name: String
+    private let avatarUrl: URL?
+    
+    init(name: String, avatarUrl: URL? = nil) {
+        self.name = name
+        self.avatarUrl = avatarUrl
+    }
+}
+
+public struct CreateGroupUseCase {
+    private let groupRepository: GroupRepositoryProtocol
+    
+    public init(groupRepository: GroupRepositoryProtocol) {
+        self.groupRepository = groupRepository
+    }
+    
+    func execute(requestValue: CreateGroupRequestValue) async throws -> Group {
+        return try await groupRepository.createGroup()
+    }
+}

--- a/iOS/moti/moti/Domain/Sources/Domain/UseCase/CreateGroupUseCase.swift
+++ b/iOS/moti/moti/Domain/Sources/Domain/UseCase/CreateGroupUseCase.swift
@@ -11,7 +11,7 @@ public struct CreateGroupRequestValue: RequestValue {
     private let name: String
     private let avatarUrl: URL?
     
-    init(name: String, avatarUrl: URL? = nil) {
+    public init(name: String, avatarUrl: URL? = nil) {
         self.name = name
         self.avatarUrl = avatarUrl
     }
@@ -24,7 +24,7 @@ public struct CreateGroupUseCase {
         self.groupRepository = groupRepository
     }
     
-    func execute(requestValue: CreateGroupRequestValue) async throws -> Group {
+    public func execute(requestValue: CreateGroupRequestValue) async throws -> Group {
         return try await groupRepository.createGroup(requestValue: requestValue)
     }
 }

--- a/iOS/moti/moti/Domain/Sources/Domain/UseCase/CreateGroupUseCase.swift
+++ b/iOS/moti/moti/Domain/Sources/Domain/UseCase/CreateGroupUseCase.swift
@@ -25,6 +25,6 @@ public struct CreateGroupUseCase {
     }
     
     func execute(requestValue: CreateGroupRequestValue) async throws -> Group {
-        return try await groupRepository.createGroup()
+        return try await groupRepository.createGroup(requestValue: requestValue)
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeViewController.swift
@@ -83,14 +83,20 @@ final class GroupHomeViewController: BaseViewController<HomeView> {
     }
     
     @objc private func showAddGroupCategoryAlert() {
-        showTextFieldAlert(
+        let textFieldAlertVC = AlertFactory.makeTextFieldAlert(
             title: "추가할 카테고리 이름을 입력하세요.",
             okTitle: "생성",
-            placeholder: "카테고리 이름은 최대 10글자입니다."
-        ) { [weak self] text in
-            guard let self, let text else { return }
-            Logger.debug("그룹 카테고리 생성 입력: \(text)")
+            placeholder: "카테고리 이름은 최대 10글자입니다.",
+            okAction: { [weak self] text in
+                guard let self, let text else { return }
+                Logger.debug("그룹 카테고리 생성 입력: \(text)")
+            })
+        
+        if let textField = textFieldAlertVC.textFields?.first {
+            textField.delegate = self
         }
+        
+        present(textFieldAlertVC, animated: true)
     }
 
     // MARK: - Setup
@@ -235,4 +241,13 @@ extension GroupHomeViewController: UICollectionViewDelegate {
         cell.cancelDownloadImage()
     }
 
+}
+
+// MARK: - UITextFieldDelegate
+extension GroupHomeViewController: UITextFieldDelegate {
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        guard let text = textField.text else { return true }
+        let newLength = text.count + string.count - range.length
+        return newLength <= 10
+    }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupList/GroupListCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupList/GroupListCoordinator.swift
@@ -24,7 +24,10 @@ final class GroupListCoordinator: Coordinator {
     }
     
     func start() {
-        let groupVM = GroupListViewModel(fetchGroupListUseCase: .init(groupRepository: GroupRepository()))
+        let groupVM = GroupListViewModel(
+            fetchGroupListUseCase: .init(groupRepository: GroupRepository()),
+            createGroupUseCase: .init(groupRepository: GroupRepository())
+        )
         let groupListVC = GroupListViewController(viewModel: groupVM)
         groupListVC.coordinator = self
         navigationController.viewControllers = [groupListVC]

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupList/GroupListViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupList/GroupListViewController.swift
@@ -32,6 +32,7 @@ final class GroupListViewController: BaseViewController<GroupListView> {
         super.viewDidLoad()
         setupUI()
         setupGroupListDataSource()
+        bind()
         
         viewModel.action(.launch)
     }
@@ -157,7 +158,6 @@ extension GroupListViewController: LoadingIndicator {
                 case .loading:
                     // TODO: 스켈레톤
                     showLoadingIndicator()
-                    break
                 case .finish:
                     hideLoadingIndicator()
                 case .error(let message):
@@ -174,7 +174,6 @@ extension GroupListViewController: LoadingIndicator {
                 switch state {
                 case .loading:
                     showLoadingIndicator()
-                    break
                 case .finish:
                     hideLoadingIndicator()
                 case .error(let message):

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupList/GroupListViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupList/GroupListViewController.swift
@@ -56,6 +56,23 @@ final class GroupListViewController: BaseViewController<GroupListView> {
         viewModel.setupGroupDataSource(diffableDataSource)
     }
 
+    // MARK: - Actions
+    @objc private func showCreateGroupTextFieldAlert() {
+        let textFieldAlertVC = AlertFactory.makeTextFieldAlert(
+            title: "생성할 그룹 이름을 입력하세요.",
+            okTitle: "생성",
+            placeholder: "그룹 이름은 최대 10글자입니다.",
+            okAction: { [weak self] text in
+                guard let self, let text else { return }
+                Logger.debug("그룹 생성 입력: \(text)")
+            })
+        
+        if let textField = textFieldAlertVC.textFields?.first {
+            textField.delegate = self
+        }
+        
+        present(textFieldAlertVC, animated: true)
+    }
 }
 
 // MARK: - Setup
@@ -91,7 +108,7 @@ private extension GroupListViewController {
         
         let createGroupItem = UIBarButtonItem(
             title: "생성", style: .plain, target: self,
-            action: nil
+            action: #selector(showCreateGroupTextFieldAlert)
         )
 
         navigationItem.rightBarButtonItems = [profileItem, createGroupItem, editGroupItem]
@@ -114,5 +131,14 @@ extension GroupListViewController: UICollectionViewDelegate {
         let selectedGroup = viewModel.findGroup(at: indexPath.row)
         Logger.debug("Clicked \(selectedGroup)")
         coordinator?.moveToGroupHomeViewController(group: selectedGroup)
+    }
+}
+
+// MARK: - UITextFieldDelegate
+extension GroupListViewController: UITextFieldDelegate {
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        guard let text = textField.text else { return true }
+        let newLength = text.count + string.count - range.length
+        return newLength <= 10
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupList/GroupListViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupList/GroupListViewModel.swift
@@ -17,7 +17,6 @@ final class GroupListViewModel {
     }
     
     enum GroupListState {
-        case initial
         case loading
         case finish
         case error(message: String)
@@ -41,7 +40,7 @@ final class GroupListViewModel {
         }
     }
     
-    @Published private(set) var groupListState: GroupListState = .initial
+    private(set) var groupListState = PassthroughSubject<GroupListState, Never>()
     private(set) var createGroupState = PassthroughSubject<CreateGroupState, Never>()
     
     // MARK: - Init
@@ -76,15 +75,14 @@ final class GroupListViewModel {
 // MARK: - Action
 extension GroupListViewModel {
     private func fetchGroupList() {
-        groupListState = .loading
-        
         Task {
+            groupListState.send(.loading)
             do {
                 groups = try await fetchGroupListUseCase.execute()
-                groupListState = .finish
+                groupListState.send(.finish)
             } catch {
                 Logger.error("\(#function) error: \(error.localizedDescription)")
-                groupListState = .error(message: error.localizedDescription)
+                groupListState.send(.error(message: error.localizedDescription))
             }
         }
     }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewController.swift
@@ -67,14 +67,20 @@ final class HomeViewController: BaseViewController<HomeView>, LoadingIndicator {
     }
     
     @objc private func showCreateCategoryAlert() {
-        showTextFieldAlert(
+        let textFieldAlertVC = AlertFactory.makeTextFieldAlert(
             title: "추가할 카테고리 이름을 입력하세요.",
             okTitle: "생성",
-            placeholder: "카테고리 이름은 최대 10글자입니다."
-        ) { [weak self] text in
-            guard let self, let text else { return }
-            viewModel.action(.addCategory(name: text))
+            placeholder: "카테고리 이름은 최대 10글자입니다.",
+            okAction: { [weak self] text in
+                guard let self, let text else { return }
+                viewModel.action(.addCategory(name: text))
+            })
+        
+        if let textField = textFieldAlertVC.textFields?.first {
+            textField.delegate = self
         }
+        
+        present(textFieldAlertVC, animated: true)
     }
     
     @objc private func refreshAchievementList() {
@@ -426,5 +432,14 @@ private extension HomeViewController {
                 }
             }
             .store(in: &cancellables)
+    }
+}
+
+// MARK: - UITextFieldDelegate
+extension HomeViewController: UITextFieldDelegate {
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        guard let text = textField.text else { return true }
+        let newLength = text.count + string.count - range.length
+        return newLength <= 10
     }
 }


### PR DESCRIPTION
## PR 요약
- 텍스트필드 Alert 10글자 제한
    - BaseVC에서 진행하면 모든 화면의 모든 텍스트필드에 적용되서 따로 따로 적용했습니다.
- 그룹 생성 UI 구현
- 그룹 생성 API 연결

#### 변경 사항
- Group DTO의 grade가 옵셔널로 변경됨 -> 그룹 생성에서 grade가 오지 않아 옵셔널로 변경

##### 스크린샷
<img src = "https://github.com/boostcampwm2023/iOS02-moti/assets/89075274/9d95e1e5-d055-474e-906a-d3f15bc02dcd" width = "50%">

#### Linked Issue
close #421 
close #422 
