### PR TITLE
그룹 정보 화면으로 이동 & UI 구현중

### DIFF
--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeCoordinator.swift
@@ -38,4 +38,10 @@ final class GroupHomeCoordinator: Coordinator {
         groupDetailAchievementCoordinator.start(achievement: achievement, group: group)
         childCoordinators.append(groupDetailAchievementCoordinator)
     }
+    
+    func moveToGroupInfoViewController(group: Group) {
+        let groupInfoCoordinator = GroupInfoCoordinator(navigationController, self)
+        groupInfoCoordinator.start(group: group)
+        childCoordinators.append(groupInfoCoordinator)
+    }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeViewController.swift
@@ -156,6 +156,10 @@ final class GroupHomeViewController: BaseViewController<HomeView> {
         } else {
             avatarImageView.backgroundColor = .primaryGray
         }
+        let avatarImageTapGesture = UITapGestureRecognizer(target: self, action: #selector(avatarImageTapAction))
+        avatarImageView.isUserInteractionEnabled = true
+        avatarImageView.addGestureRecognizer(avatarImageTapGesture)
+        
         let profileItem = UIBarButtonItem(customView: avatarImageView)
         profileItem.customView?.atl
             .size(width: avatarItemSize, height: avatarItemSize)
@@ -169,6 +173,10 @@ final class GroupHomeViewController: BaseViewController<HomeView> {
         )
 
         navigationItem.rightBarButtonItems = [profileItem, moreItem]
+    }
+    
+    @objc private func avatarImageTapAction() {
+        coordinator?.moveToGroupInfoViewController(group: viewModel.group)
     }
     
     private func selectFirstCategory() {

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupInfo/GroupInfoCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupInfo/GroupInfoCoordinator.swift
@@ -1,0 +1,33 @@
+//
+//  GroupInfoCoordinator.swift
+//
+//
+//  Created by Kihyun Lee on 12/4/23.
+//
+
+import UIKit
+import Core
+import Domain
+
+final class GroupInfoCoordinator: Coordinator {
+    var parentCoordinator: Coordinator?
+    var childCoordinators: [Coordinator] = []
+    var navigationController: UINavigationController
+    
+    init(
+        _ navigationController: UINavigationController,
+        _ parentCoordinator: Coordinator?
+    ) {
+        self.navigationController = navigationController
+        self.parentCoordinator = parentCoordinator
+    }
+    
+    func start() { }
+    
+    func start(group: Group) {
+        let groupInfoVC = GroupInfoViewController(group: group)
+        groupInfoVC.coordinator = self
+        navigationController.pushViewController(groupInfoVC, animated: true)
+    }
+    
+}

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupInfo/GroupInfoView.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupInfo/GroupInfoView.swift
@@ -1,0 +1,53 @@
+//
+//  GroupInfoView.swift
+//
+//
+//  Created by Kihyun Lee on 12/4/23.
+//
+
+import UIKit
+import Design
+import Domain
+
+final class GroupInfoView: UIView {
+    
+    // MARK: - Views
+    private let imageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFill
+        imageView.backgroundColor = .primaryDarkGray
+        imageView.image = MotiImage.skeleton
+        imageView.clipsToBounds = true
+        return imageView
+    }()
+    
+    // MARK: - Init
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupUI()
+    }
+    
+    func configure(group: Group) {
+        if let url = group.avatarUrl {
+            imageView.jf.setImage(with: url)
+        }
+    }
+    
+    func cancelDownloadImage() {
+        imageView.jf.cancelDownloadImage()
+    }
+    
+}
+
+extension GroupInfoView {
+    private func setupUI() {
+        addSubview(imageView)
+        imageView.atl
+            .center(of: self)
+    }
+}

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupInfo/GroupInfoView.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupInfo/GroupInfoView.swift
@@ -11,14 +11,21 @@ import Domain
 
 final class GroupInfoView: UIView {
     
+    let imageViewSize: CGFloat = 130
     // MARK: - Views
-    private let imageView: UIImageView = {
+    private lazy var imageView: UIImageView = {
         let imageView = UIImageView()
-        imageView.contentMode = .scaleAspectFill
+        imageView.clipsToBounds = true
+        imageView.layer.cornerRadius = imageViewSize / 2
         imageView.backgroundColor = .primaryDarkGray
         imageView.image = MotiImage.skeleton
-        imageView.clipsToBounds = true
         return imageView
+    }()
+    
+    private let groupNameLabel: UILabel = {
+        let label = UILabel()
+        label.font = .largeBold
+        return label
     }()
     
     // MARK: - Init
@@ -33,6 +40,7 @@ final class GroupInfoView: UIView {
     }
     
     func configure(group: Group) {
+        groupNameLabel.text = group.name
         if let url = group.avatarUrl {
             imageView.jf.setImage(with: url)
         }
@@ -48,6 +56,13 @@ extension GroupInfoView {
     private func setupUI() {
         addSubview(imageView)
         imageView.atl
-            .center(of: self)
+            .size(width: imageViewSize, height: imageViewSize)
+            .top(equalTo: safeAreaLayoutGuide.topAnchor, constant: 30)
+            .centerX(equalTo: safeAreaLayoutGuide.centerXAnchor)
+        
+        addSubview(groupNameLabel)
+        groupNameLabel.atl
+            .top(equalTo: imageView.bottomAnchor, constant: 20)
+            .centerX(equalTo: safeAreaLayoutGuide.centerXAnchor)
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupInfo/GroupInfoViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupInfo/GroupInfoViewController.swift
@@ -30,7 +30,6 @@ final class GroupInfoViewController: BaseViewController<GroupInfoView> {
         super.viewDidLoad()
         
         title = "그룹 정보"
-        print("hello!")
         layoutView.configure(group: group)
     }
     

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupInfo/GroupInfoViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupInfo/GroupInfoViewController.swift
@@ -1,0 +1,56 @@
+//
+//  GroupInfoViewController.swift
+//
+//
+//  Created by Kihyun Lee on 12/4/23.
+//
+
+import UIKit
+import Design
+import Domain
+
+final class GroupInfoViewController: BaseViewController<GroupInfoView> {
+
+    // MARK: - Properties
+    weak var coordinator: GroupInfoCoordinator?
+    private let group: Group
+    
+    // MARK: - Init
+    init(group: Group) {
+        self.group = group
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
+    
+    // MARK: - Life Cycles
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        title = "그룹 정보"
+        print("hello!")
+        layoutView.configure(group: group)
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        if let tabBarController = tabBarController as? TabBarViewController {
+            tabBarController.hideTabBar()
+        }
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        if let tabBarController = tabBarController as? TabBarViewController {
+            tabBarController.showTabBar()
+        }
+    }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        layoutView.cancelDownloadImage()
+    }
+}
+


### PR DESCRIPTION
## PR 요약
- 그룹 홈에서 그룹 프로필 사진 클릭시 화면 이동 구현
- 전달 받은 group으로 이미지 및 이름 보여주기

##### 스크린샷
<img width="50%" src="https://github.com/boostcampwm2023/iOS02-moti/assets/60506170/6e3c6354-2f4a-4032-816d-3d4a81571e90">

#### Linked Issue
close #424
