### PR TITLE
그룹의 단 건의 달성 기록 조회를 위한 API를 작성한다.

### DIFF
--- a/BE/src/achievement/exception/unauthorized-achievement.exception.ts
+++ b/BE/src/achievement/exception/unauthorized-achievement.exception.ts
@@ -1,0 +1,8 @@
+import { MotimateException } from '../../common/exception/motimate.excpetion';
+import { ERROR_INFO } from '../../common/exception/error-code';
+
+export class UnauthorizedAchievementException extends MotimateException {
+  constructor() {
+    super(ERROR_INFO.UNAUTHORIZED_ACHIEVEMENT_APPROACH);
+  }
+}

--- a/BE/src/common/exception/error-code.ts
+++ b/BE/src/common/exception/error-code.ts
@@ -103,4 +103,8 @@ export const ERROR_INFO = {
     statusCode: 400,
     message: '그룹의 리더만 권한 조정이 가능합니다.',
   },
+  UNAUTHORIZED_ACHIEVEMENT_APPROACH: {
+    statusCode: 403,
+    message: '달성기록에 접근할 수 없습니다.',
+  },
 } as const;

--- a/BE/src/group/achievement/application/group-achievement.service.ts
+++ b/BE/src/group/achievement/application/group-achievement.service.ts
@@ -15,6 +15,7 @@ import { NoUserImageException } from '../../../achievement/exception/no-user-ima
 import { GroupRepository } from '../../group/entities/group.repository';
 import { NoSuchGroupUserException } from '../exception/no-such-group-user.exception';
 import { NoSuchAchievementException } from '../../../achievement/exception/no-such-achievement.exception';
+import { UnauthorizedAchievementException } from '../../../achievement/exception/unauthorized-achievement.exception';
 
 @Injectable()
 export class GroupAchievementService {
@@ -40,6 +41,19 @@ export class GroupAchievementService {
       );
 
     return RejectGroupAchievementResponse.from(userBlockedGroupAchievement);
+  }
+
+  @Transactional({ readonly: true })
+  async getAchievementDetail(user: User, achievementId: number) {
+    const groupAchievementDetailResponse =
+      await this.groupAchievementRepository.findAchievementDetailByIdAndBelongingGroup(
+        achievementId,
+        user.id,
+      );
+
+    if (!groupAchievementDetailResponse)
+      throw new UnauthorizedAchievementException();
+    return groupAchievementDetailResponse;
   }
 
   @Transactional()
@@ -87,7 +101,7 @@ export class GroupAchievementService {
 
   private async getAchievementResponse(userId: number, achieveId: number) {
     const achievement =
-      await this.groupAchievementRepository.findAchievementDetail(
+      await this.groupAchievementRepository.findAchievementDetailByIdAndUser(
         userId,
         achieveId,
       );

--- a/BE/src/group/achievement/controller/group-achievement.controller.ts
+++ b/BE/src/group/achievement/controller/group-achievement.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Get,
   HttpCode,
   HttpStatus,
   Param,
@@ -21,6 +22,7 @@ import { GroupAchievementService } from '../application/group-achievement.servic
 import { ParseIntPipe } from '../../../common/pipe/parse-int.pipe';
 import { RejectGroupAchievementResponse } from '../dto/reject-group-achievement-response.dto';
 import { GroupAchievementCreateRequest } from '../dto/group-achievement-create-request';
+import { AchievementDetailResponse } from '../../../achievement/dto/achievement-detail-response';
 
 @Controller('/api/v1/groups')
 @ApiTags('그룹 달성기록 API')
@@ -75,5 +77,28 @@ export class GroupAchievementController {
         achievementCreate,
       ),
     );
+  }
+
+  @ApiBearerAuth('accessToken')
+  @ApiOperation({
+    summary: '그룹 달성기록 상세정보 API',
+    description: '달성기록 상세정보를 조회한다.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '그룹 달성기록 상세정보',
+    type: AchievementDetailResponse,
+  })
+  @Get('/:groupId/achievements/:achievementId')
+  @UseGuards(AccessTokenGuard)
+  async getAchievement(
+    @AuthenticatedUser() user: User,
+    @Param('achievementId', ParseIntPipe) id: number,
+  ) {
+    const response = await this.groupAchievementService.getAchievementDetail(
+      user,
+      id,
+    );
+    return ApiData.success(response);
   }
 }


### PR DESCRIPTION
## PR 요약

그룹의 단 건의 달성 기록 조회를 위한 API를 작성한다.

#### 변경 사항

* 유저가 그룹에 속한지 검사 후 조회

##### 스크린샷

* 조회 성공

<img width="431" alt="image" src="https://github.com/boostcampwm2023/iOS02-moti/assets/75921696/79526ac5-53e9-4b58-b188-744e34910605">

* 조회 실패

<img width="432" alt="image" src="https://github.com/boostcampwm2023/iOS02-moti/assets/75921696/b0a64f93-0fae-4bc0-93b3-e23b25f1e360">

#### Linked Issue
close #264
