### PR TITLE
그룹리스트에서 촬영 버튼 숨기기 / 탭바 버그 수정(임시)

### DIFF
--- a/iOS/moti/moti/Presentation/Sources/Presentation/Capture/CaptureCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Capture/CaptureCoordinator.swift
@@ -28,9 +28,23 @@ final class CaptureCoordinator: Coordinator {
         self.parentCoordinator = parentCoordinator
     }
     
-    func start() { }
+    func start() { 
+        let captureVC = CaptureViewController()
+        captureVC.delegate = self
+        captureVC.coordinator = self
+        
+        captureVC.navigationItem.leftBarButtonItem = UIBarButtonItem(
+            title: "취소", style: .plain, target: self,
+            action: #selector(cancelButtonAction)
+        )
+        
+        captureVC.navigationItem.rightBarButtonItem = nil
+        
+        navigationController.pushViewController(captureVC, animated: true)
+        navigationController.setNavigationBarHidden(false, animated: false)
+    }
     
-    func start(group: Group? = nil) {
+    func start(group: Group) {
         let captureVC = CaptureViewController(group: group)
         captureVC.delegate = self
         captureVC.coordinator = self

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupList/GroupListViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupList/GroupListViewController.swift
@@ -36,6 +36,20 @@ final class GroupListViewController: BaseViewController<GroupListView> {
         
         viewModel.action(.launch)
     }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        if let tabBarController = tabBarController as? TabBarViewController {
+            tabBarController.hideCaptureButton()
+        }
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        if let tabBarController = tabBarController as? TabBarViewController {
+            tabBarController.showCaptureButton()
+        }
+    }
 
     private func setupGroupListDataSource() {
         layoutView.groupListCollectionView.delegate = self

--- a/iOS/moti/moti/Presentation/Sources/Presentation/TabBar/TabBarViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/TabBar/TabBarViewController.swift
@@ -77,6 +77,30 @@ final class TabBarViewController: UITabBarController {
             self.borderView.isHidden = true
         })
     }
+    
+    // 그룹 리스트 화면에서 캡처 버튼을 숨겨야 함
+    /// 캡처버튼을 보일 때 사용
+    func showCaptureButton() {
+        if captureButton.isHidden {
+            captureButton.isHidden = false
+            UIView.animate(withDuration: 0.2, animations: {
+                self.captureButton.alpha = 1
+                self.captureButton.transform = .identity
+            })
+        }
+    }
+    
+    /// 캡처버튼을 숨길 때 사용
+    func hideCaptureButton() {
+        if !captureButton.isHidden {
+            UIView.animate(withDuration: 0.2, animations: {
+                self.captureButton.alpha = 0.1
+                self.captureButton.transform = CGAffineTransform(scaleX: 0.1, y: 0.1)
+            }, completion: { _ in
+                self.captureButton.isHidden = true
+            })
+        }
+    }
 }
 
 // MARK: - Setup UI

--- a/iOS/moti/moti/Presentation/Sources/Presentation/TabBar/TabBarViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/TabBar/TabBarViewController.swift
@@ -24,12 +24,18 @@ final class TabBarViewController: UITabBarController {
         return tabBar.frame.height
     }
     private var isShowing = true
+    private var standardOriginY: CGFloat = 0
     
     // MARK: - Life Cycles
     override func viewDidLoad() {
         super.viewDidLoad()
         setupUI()
         addTarget()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        standardOriginY = tabBar.frame.origin.y
     }
     
     func setupViewControllers(with viewControllers: [UIViewController]) {
@@ -55,10 +61,14 @@ final class TabBarViewController: UITabBarController {
         self.captureButton.isHidden = false
         self.borderView.isHidden = false
         
+        // TODO: 홈 -> 상세 -> 편집 -> 취소 -> 홈 시나리오에서
+        // 혼자서 tabBar.frame.y가 원상복구 되는 "원인" 찾아야 함
+        if tabBar.frame.origin.y == standardOriginY {
+            moveDownTabBar()
+        }
+        
         UIView.animate(withDuration: 0.3, animations: {
-            self.tabBar.frame.origin.y -= self.tabBarHeight
-            self.captureButton.frame.origin.y -= (self.tabBarHeight + 30)
-            self.borderView.frame.origin.y -= self.tabBarHeight
+            self.moveUpTabBar()
         })
     }
     
@@ -68,14 +78,24 @@ final class TabBarViewController: UITabBarController {
         isShowing = false
         
         UIView.animate(withDuration: 0.3, animations: {
-            self.tabBar.frame.origin.y += self.tabBarHeight
-            self.captureButton.frame.origin.y += (self.tabBarHeight + 30)
-            self.borderView.frame.origin.y += self.tabBarHeight
+            self.moveDownTabBar()
         }, completion: { _ in
             self.tabBar.isHidden = true
             self.captureButton.isHidden = true
             self.borderView.isHidden = true
         })
+    }
+    
+    private func moveUpTabBar() {
+        tabBar.frame.origin.y -= tabBarHeight
+        captureButton.frame.origin.y -= (tabBarHeight + 30)
+        borderView.frame.origin.y -= tabBarHeight
+    }
+    
+    private func moveDownTabBar() {
+        tabBar.frame.origin.y += tabBarHeight
+        captureButton.frame.origin.y += (tabBarHeight + 30)
+        borderView.frame.origin.y += tabBarHeight
     }
     
     // 그룹 리스트 화면에서 캡처 버튼을 숨겨야 함


### PR DESCRIPTION
## PR 요약
- 그룹리스트에서 촬영 버튼 숨기기
- 탭바 버그 수정 (임시)
    - 이전 origin을 저장해두고 show 할 때 비교해서 예외처리 진행함

##### 스크린샷
https://github.com/boostcampwm2023/iOS02-moti/assets/89075274/d0ff748a-918f-4271-83c9-27a90ee86795


#### Linked Issue
close #461 
