### PR TITLE
그룹장일때는 권한을 수정할 수 있는 ContextMenu를 표시하고 눌러서 수정한다.

### DIFF
--- a/iOS/moti/moti/Design/Sources/Design/SymbolImage.swift
+++ b/iOS/moti/moti/Design/Sources/Design/SymbolImage.swift
@@ -47,4 +47,7 @@ public enum SymbolImage {
     
     /// 􀰓. 공지사항 댓글  등록에 사용됨
     public static let sendMessage = UIImage(systemName: "arrow.forward.circle.fill")
+    
+    /// 􀆏. 그룹원 권한 수정 버튼에 사용됨
+    public static let chevronUpDown = UIImage(systemName: "chevron.up.chevron.down")
 }

--- a/iOS/moti/moti/Domain/Sources/Domain/Entity/Group.swift
+++ b/iOS/moti/moti/Domain/Sources/Domain/Entity/Group.swift
@@ -25,7 +25,7 @@ public enum GroupGrade: Hashable, CustomStringConvertible {
         switch self {
         case .leader: return "그룹장"
         case .manager: return "관리자"
-        case .participant: return "참가자"
+        case .participant: return "그룹원"
         }
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupInfo/GroupInfoCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupInfo/GroupInfoCoordinator.swift
@@ -30,9 +30,9 @@ final class GroupInfoCoordinator: Coordinator {
         navigationController.pushViewController(groupInfoVC, animated: true)
     }
     
-    func moveToGroupMemberViewController(group: Group) {
+    func moveToGroupMemberViewController(group: Group, manageMode: Bool) {
         let groupMemberCoordinator = GroupMemberCoordinator(navigationController, self)
-        groupMemberCoordinator.start(group: group)
+        groupMemberCoordinator.start(group: group, manageMode: manageMode)
         childCoordinators.append(groupMemberCoordinator)
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupInfo/GroupInfoTableViewDataSource.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupInfo/GroupInfoTableViewDataSource.swift
@@ -17,8 +17,12 @@ final class GroupInfoTableViewDataSource: NSObject, UITableViewDataSource {
         cellTexts.append(["그룹원 관리"])
     }
     
-    func isLeader(indexPath: IndexPath) -> Bool {
-        return indexPath.section == 1 || (indexPath.section == 0 && indexPath.row == 0)
+    func isGroupMemberCell(indexPath: IndexPath) -> Bool {
+        return indexPath.section == 0 && indexPath.row == 0
+    }
+    
+    func isLeaderCell(indexPath: IndexPath) -> Bool {
+        return indexPath.section == 1
     }
     
     // MARK: - Section

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupInfo/GroupInfoViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupInfo/GroupInfoViewController.swift
@@ -61,8 +61,10 @@ final class GroupInfoViewController: BaseViewController<GroupInfoView> {
 
 extension GroupInfoViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        if dataSource.isLeader(indexPath: indexPath) {
-            coordinator?.moveToGroupMemberViewController(group: group)
+        if dataSource.isGroupMemberCell(indexPath: indexPath) {
+            coordinator?.moveToGroupMemberViewController(group: group, manageMode: false)
+        } else if dataSource.isLeaderCell(indexPath: indexPath) {
+            coordinator?.moveToGroupMemberViewController(group: group, manageMode: true)
         }
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupMember/Cell/GroupMemberCollectionViewCell.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupMember/Cell/GroupMemberCollectionViewCell.swift
@@ -58,8 +58,8 @@ final class GroupMemberCollectionViewCell: UICollectionViewCell {
         return label
     }()
     
-    private let gradeButton = {
-        let button = UIButton()
+    private var gradeButton = {
+        let button = UIButton(type: .system)
         button.setTitleColor(.label, for: .normal)
         return button
     }()
@@ -76,13 +76,45 @@ final class GroupMemberCollectionViewCell: UICollectionViewCell {
     }
     
     // MARK: - Methods
-    func configure(with groupMember: GroupMember) {
+    func configureForMember(with groupMember: GroupMember) {
         if let url = groupMember.user.avatarURL {
             iconImageView.jf.setImage(with: url)
         }
         userCodeLabel.text = "@" + groupMember.user.code
         lastChallengedLabel.text = groupMember.lastChallenged?.convertStringyyyy_MM_dd() ?? "없음"
-        gradeButton.setTitle(groupMember.grade.description, for: .normal)
+        gradeButton.setTitle(groupMember.grade.description + " ", for: .normal)
+    }
+    
+    func configureForLeader(with groupMember: GroupMember) {
+        configureForMember(with: groupMember)
+        if groupMember.grade != .leader {
+            setupGradeButtonForLeader()
+        }
+    }
+    
+    private func setupGradeButtonForLeader() {
+        gradeButton.configuration = .plain()
+        gradeButton.setImage(SymbolImage.chevronUpDown, for: .normal)
+        gradeButton.tintColor = .label
+        gradeButton.configuration?.imagePlacement = .trailing
+        gradeButton.configuration?.contentInsets = .init(top: 0, leading: 0, bottom: 0, trailing: -5)
+        
+        gradeButton.showsMenuAsPrimaryAction = true
+        let managerAction = UIAction(title: "관리자") { _ in
+            self.managerMenuDidClicked()
+        }
+        let memberAction = UIAction(title: "그룹원") { _ in
+            self.memberMenuDidClicked()
+        }
+        gradeButton.menu = UIMenu(children: [managerAction, memberAction])
+    }
+    
+    private func managerMenuDidClicked() {
+        gradeButton.setTitle("관리자", for: .normal)
+    }
+    
+    private func memberMenuDidClicked() {
+        gradeButton.setTitle("그룹원", for: .normal)
     }
     
     func cancelDownloadImage() {

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupMember/GroupMemberCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupMember/GroupMemberCoordinator.swift
@@ -25,14 +25,14 @@ final class GroupMemberCoordinator: Coordinator {
     
     func start() { }
     
-    func start(group: Group) {
+    func start(group: Group, manageMode: Bool) {
         let groupMemberVM = GroupMemberViewModel(
             fetchGroupMemberListUseCase: .init(
                 groupMemberRepository: GroupMemberRepository(groupId: group.id)
             ),
             group: group
         )
-        let groupMemberVC = GroupMemberViewController(viewModel: groupMemberVM)
+        let groupMemberVC = GroupMemberViewController(viewModel: groupMemberVM, manageMode: manageMode)
         groupMemberVC.coordinator = self
         navigationController.pushViewController(groupMemberVC, animated: true)
     }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupMember/GroupMemberViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupMember/GroupMemberViewController.swift
@@ -15,10 +15,12 @@ final class GroupMemberViewController: BaseViewController<GroupMemberView> {
     weak var coordinator: GroupMemberCoordinator?
     private let viewModel: GroupMemberViewModel
     private var cancellables: Set<AnyCancellable> = []
+    private let manageMode: Bool
     
     // MARK: - Init
-    init(viewModel: GroupMemberViewModel) {
+    init(viewModel: GroupMemberViewModel, manageMode: Bool) {
         self.viewModel = viewModel
+        self.manageMode = manageMode
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -29,7 +31,7 @@ final class GroupMemberViewController: BaseViewController<GroupMemberView> {
     // MARK: - Life Cycles
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = "그룹원"
+        title = manageMode ? "그룹원 관리" : "그룹원"
         setupGroupMemberDataSource()
         
         bind()
@@ -54,9 +56,14 @@ final class GroupMemberViewController: BaseViewController<GroupMemberView> {
         layoutView.groupMemberCollectionView.delegate = self
         let dataSource = GroupMemberViewModel.GroupMemberDataSource.DataSource(
             collectionView: layoutView.groupMemberCollectionView,
-            cellProvider: { collectionView, indexPath, item in
+            cellProvider: { [weak self] collectionView, indexPath, item in
+                guard let self else { return UICollectionViewCell() }
                 let cell: GroupMemberCollectionViewCell = collectionView.dequeueReusableCell(for: indexPath)
-                cell.configure(with: item)
+                if self.manageMode {
+                    cell.configureForLeader(with: item)
+                } else {
+                    cell.configureForMember(with: item)
+                }
                 return cell
             }
         )


### PR DESCRIPTION
## PR 요약
- 직위에 따라 그룹원 리스트 뷰 다르게 보이기 (contextMenu)
- 메뉴를 눌러서 수정

#### 주의 사항
- API 연동을 해야함

##### 스크린샷
<img width="35%" src="https://github.com/boostcampwm2023/iOS02-moti/assets/60506170/c763c8ff-6d7d-490e-9c9f-4d2ffa9d82ef">

#### Linked Issue
close #454
close #455 
