### PR TITLE
사용자 차단, 도전기록 차단 구현 (API 포함)

### DIFF
--- a/iOS/moti/moti/Data/Sources/Data/Network/DTO/BlockingDTO.swift
+++ b/iOS/moti/moti/Data/Sources/Data/Network/DTO/BlockingDTO.swift
@@ -1,0 +1,14 @@
+//
+//  BlockingDTO.swift
+//
+//
+//  Created by 유정주 on 12/6/23.
+//
+
+import Foundation
+
+// data 응답이 필요 없어서 따로 파싱하지 않았습니다.
+struct BlockingDTO: ResponseDTO {
+    let success: Bool?
+    let message: String?
+}

--- a/iOS/moti/moti/Data/Sources/Data/Network/Endpoint/MotiAPI.swift
+++ b/iOS/moti/moti/Data/Sources/Data/Network/Endpoint/MotiAPI.swift
@@ -33,6 +33,9 @@ enum MotiAPI: EndpointProtocol {
     case updateGroupAchievement(requestValue: UpdateAchievementRequestValue, groupId: Int)
     case postGroupAchievement(requestValue: PostAchievementRequestValue, groupId: Int)
     case fetchGroupMemberList(groupId: Int)
+    // 차단
+    case blockingUser(userCode: String)
+    case blockingAchievement(achievementId: Int, groupId: Int)
 
     private var keychainStorage: KeychainStorageProtocol {
         return KeychainStorage.shared
@@ -79,6 +82,10 @@ extension MotiAPI {
             return "/groups/\(groupId)/achievements"
         case .fetchGroupMemberList(let groupId):
             return "/groups/\(groupId)/users"
+        case .blockingUser(let userCode):
+            return "/users/\(userCode)/reject"
+        case .blockingAchievement(let achievementId, let groupId):
+            return "/groups/\(groupId)/achievements/\(achievementId)/reject"
         }
     }
     
@@ -105,6 +112,8 @@ extension MotiAPI {
         case .updateGroupAchievement: return .put
         case .postGroupAchievement: return .post
         case .fetchGroupMemberList: return .get
+        case .blockingUser: return .post
+        case .blockingAchievement: return .post
         }
     }
     

--- a/iOS/moti/moti/Data/Sources/Repository/BlockingRepository.swift
+++ b/iOS/moti/moti/Data/Sources/Repository/BlockingRepository.swift
@@ -1,0 +1,31 @@
+//
+//  BlockingRepository.swift
+//
+//
+//  Created by 유정주 on 12/6/23.
+//
+
+import Foundation
+import Domain
+
+public struct BlockingRepository: BlockingRepositoryProtocol {
+    private let provider: ProviderProtocol
+    private let groupId: Int
+    
+    public init(provider: ProviderProtocol = Provider(), groupId: Int) {
+        self.provider = provider
+        self.groupId = groupId
+    }
+    
+    public func blockingUser(userCode: String) async throws -> Bool {
+        let endpoint = MotiAPI.blockingUser(userCode: userCode)
+        let responseDTO = try await provider.request(with: endpoint, type: BlockingDTO.self)
+        return responseDTO.success ?? false
+    }
+    
+    public func blockingAchievement(achievementId: Int) async throws -> Bool {
+        let endpoint = MotiAPI.blockingAchievement(achievementId: achievementId, groupId: groupId)
+        let responseDTO = try await provider.request(with: endpoint, type: BlockingDTO.self)
+        return responseDTO.success ?? false
+    }
+}

--- a/iOS/moti/moti/Domain/Sources/Domain/RepositoryProtocol/BlockingRepositoryProtocol.swift
+++ b/iOS/moti/moti/Domain/Sources/Domain/RepositoryProtocol/BlockingRepositoryProtocol.swift
@@ -1,0 +1,13 @@
+//
+//  BlockingRepositoryProtocol.swift
+//
+//
+//  Created by 유정주 on 12/5/23.
+//
+
+import Foundation
+
+public protocol BlockingRepositoryProtocol {
+    func blockingUser(userCode: String) async throws -> Bool
+    func blockingAchievement(achievementId: Int) async throws -> Bool
+}

--- a/iOS/moti/moti/Domain/Sources/Domain/UseCase/BlockingAchievementUseCase.swift
+++ b/iOS/moti/moti/Domain/Sources/Domain/UseCase/BlockingAchievementUseCase.swift
@@ -1,0 +1,24 @@
+//
+//  BlockingAchievementUseCase.swift
+//  
+//
+//  Created by 유정주 on 12/5/23.
+//
+
+import Foundation
+import Core
+
+public struct BlockingAchievementUseCase {
+    private let blockingRepository: BlockingRepositoryProtocol
+    
+    public init(blockingRepository: BlockingRepositoryProtocol) {
+        self.blockingRepository = blockingRepository
+    }
+    
+    public func execute(achievementId: Int) {
+        Task {
+            let isSuccess = try? await blockingRepository.blockingAchievement(achievementId: achievementId)
+            Logger.debug("도전기록(\(achievementId)) 차단: \(isSuccess ?? false)")
+        }
+    }
+}

--- a/iOS/moti/moti/Domain/Sources/Domain/UseCase/BlockingUserUseCase.swift
+++ b/iOS/moti/moti/Domain/Sources/Domain/UseCase/BlockingUserUseCase.swift
@@ -1,0 +1,24 @@
+//
+//  BlockingUserUseCase.swift
+//
+//
+//  Created by 유정주 on 12/5/23.
+//
+
+import Foundation
+import Core
+
+public struct BlockingUserUseCase {
+    private let blockingRepository: BlockingRepositoryProtocol
+    
+    public init(blockingRepository: BlockingRepositoryProtocol) {
+        self.blockingRepository = blockingRepository
+    }
+    
+    public func execute(userCode: String) {
+        Task {
+            let isSuccess = try? await blockingRepository.blockingUser(userCode: userCode)
+            Logger.debug("사용자(\(userCode)) 차단: \(isSuccess ?? false)")
+        }
+    }
+}

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupDetailAchievement/GroupDetailAchievementCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupDetailAchievement/GroupDetailAchievementCoordinator.swift
@@ -11,8 +11,8 @@ import Domain
 import Data
 
 protocol GroupDetailAchievementCoordinatorDelegate: DetailAchievementCoordinatorDelegate {
-    func blockingAchievementMenuDidClicked(achievement: Achievement)
-    func blockingUserMenuDidClicked(user: User)
+    func blockingAchievementMenuDidClicked(achievementId: Int)
+    func blockingUserMenuDidClicked(userCode: String)
 }
 
 final class GroupDetailAchievementCoordinator: Coordinator {
@@ -48,10 +48,13 @@ final class GroupDetailAchievementCoordinator: Coordinator {
     func start(achievement: Achievement) {
         guard let group else { return }
         
+        let blockingRepository = BlockingRepository(groupId: group.id)
         let achievementRepository = GroupAchievementRepository(groupId: group.id)
         let groupDetailAchievementVM = GroupDetailAchievementViewModel(
             fetchDetailAchievementUseCase: .init(repository: achievementRepository),
             deleteAchievementUseCase: .init(repository: achievementRepository, storage: nil),
+            blockingUserUseCase: .init(blockingRepository: blockingRepository),
+            blockingAchievementUseCase: .init(blockingRepository: blockingRepository),
             achievement: achievement,
             group: group
         )
@@ -82,15 +85,15 @@ extension GroupDetailAchievementCoordinator: GroupDetailAchievementViewControlle
         delegate?.deleteButtonDidClicked(achievementId: achievementId)
     }
     
-    func blockingAchievementMenuDidClicked(achievement: Achievement) {
+    func blockingAchievementMenuDidClicked(achievementId: Int) {
         // TODO: VC에서 achievement 데이터 필터링하기
-        delegate?.blockingAchievementMenuDidClicked(achievement: achievement)
+        delegate?.blockingAchievementMenuDidClicked(achievementId: achievementId)
         finish(animated: true)
     }
     
-    func blockingUserMenuDidClicked(user: User) {
+    func blockingUserMenuDidClicked(userCode: String) {
         // TODO: VC에서 user 관련 데이터 필터링하기
-        delegate?.blockingUserMenuDidClicked(user: user)
+        delegate?.blockingUserMenuDidClicked(userCode: userCode)
         finish(animated: true)
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupDetailAchievement/GroupDetailAchievementCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupDetailAchievement/GroupDetailAchievementCoordinator.swift
@@ -86,13 +86,11 @@ extension GroupDetailAchievementCoordinator: GroupDetailAchievementViewControlle
     }
     
     func blockingAchievementMenuDidClicked(achievementId: Int) {
-        // TODO: VC에서 achievement 데이터 필터링하기
         delegate?.blockingAchievementMenuDidClicked(achievementId: achievementId)
         finish(animated: true)
     }
     
     func blockingUserMenuDidClicked(userCode: String) {
-        // TODO: VC에서 user 관련 데이터 필터링하기
         delegate?.blockingUserMenuDidClicked(userCode: userCode)
         finish(animated: true)
     }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupDetailAchievement/GroupDetailAchievementViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupDetailAchievement/GroupDetailAchievementViewController.swift
@@ -12,8 +12,8 @@ import Combine
 import Domain
 
 protocol GroupDetailAchievementViewControllerDelegate: DetailAchievementViewControllerDelegate {
-    func blockingAchievementMenuDidClicked(achievement: Achievement)
-    func blockingUserMenuDidClicked(user: User)
+    func blockingAchievementMenuDidClicked(achievementId: Int)
+    func blockingUserMenuDidClicked(userCode: String)
 }
 
 final class GroupDetailAchievementViewController: BaseViewController<GroupDetailAchievementView>, HiddenTabBarViewController {
@@ -77,11 +77,13 @@ final class GroupDetailAchievementViewController: BaseViewController<GroupDetail
         })
         // 작성자가 아닌 유저에게만 표시
         let blockingAchievementAction = UIAction(title: "도전기록 차단", attributes: .destructive, handler: { _ in
-            
+            self.viewModel.action(.blockingAchievement)
+            self.coordinator?.finish()
         })
         // 작성자가 아닌 유저에게만 표시
         let blockingUserAction = UIAction(title: "사용자 차단", attributes: .destructive, handler: { _ in
-            
+            self.viewModel.action(.blockingUser)
+            self.coordinator?.finish()
         })
         
         var children: [UIAction] = []

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupDetailAchievement/GroupDetailAchievementViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupDetailAchievement/GroupDetailAchievementViewModel.swift
@@ -15,6 +15,8 @@ final class GroupDetailAchievementViewModel {
         case launch
         case delete
         case update(updatedAchievement: Achievement)
+        case blockingAchievement
+        case blockingUser
     }
     
     enum LaunchState {
@@ -32,6 +34,9 @@ final class GroupDetailAchievementViewModel {
     // MARK: - UseCase
     private let fetchDetailAchievementUseCase: FetchDetailAchievementUseCase
     private let deleteAchievementUseCase: DeleteAchievementUseCase
+    // Blocking
+    private let blockingUserUseCase: BlockingUserUseCase
+    private let blockingAchievementUseCase: BlockingAchievementUseCase
     
     // MARK: - State
     private(set) var launchState = PassthroughSubject<LaunchState, Never>()
@@ -49,11 +54,15 @@ final class GroupDetailAchievementViewModel {
     init(
         fetchDetailAchievementUseCase: FetchDetailAchievementUseCase,
         deleteAchievementUseCase: DeleteAchievementUseCase,
-        achievement: Achievement, 
+        blockingUserUseCase: BlockingUserUseCase,
+        blockingAchievementUseCase: BlockingAchievementUseCase,
+        achievement: Achievement,
         group: Group
     ) {
         self.fetchDetailAchievementUseCase = fetchDetailAchievementUseCase
         self.deleteAchievementUseCase = deleteAchievementUseCase
+        self.blockingUserUseCase = blockingUserUseCase
+        self.blockingAchievementUseCase = blockingAchievementUseCase
         self.achievement = achievement
         self.group = group
     }
@@ -67,6 +76,10 @@ final class GroupDetailAchievementViewModel {
             deleteAchievement()
         case .update(let updatedAchievement):
             self.achievement = updatedAchievement
+        case .blockingAchievement:
+            blocking(achievementId: achievement.id)
+        case .blockingUser:
+            blocking(userCode: achievement.userCode)
         }
     }
 }
@@ -111,5 +124,15 @@ extension GroupDetailAchievementViewModel {
                 deleteState.send(.failed(message: error.localizedDescription))
             }
         }
+    }
+    
+    /// 도전기록을 차단하는 액션
+    func blocking(achievementId: Int) {
+        blockingAchievementUseCase.execute(achievementId: achievementId)
+    }
+    
+    /// 유저를 차단하는 액션
+    func blocking(userCode: String) {
+        blockingUserUseCase.execute(userCode: userCode)
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeActionState.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeActionState.swift
@@ -21,6 +21,8 @@ extension GroupHomeViewModel {
         case deleteAchievement(achievementId: Int, categoryId: Int)
         case fetchDetailAchievement(achievementId: Int)
         case logout
+        case blockingAchievement(achievement: Achievement)
+        case blockingUser(userCode: String)
     }
     
     enum CategoryListState {
@@ -51,6 +53,12 @@ extension GroupHomeViewModel {
         case loading
         case success
         case failed
+        case error(message: String)
+    }
+    
+    enum BlockingState {
+        case loading
+        case success
         case error(message: String)
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeActionState.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeActionState.swift
@@ -16,6 +16,7 @@ extension GroupHomeViewModel {
         case fetchAchievementList(category: CategoryItem)
         case refreshAchievementList
         case deleteAchievementDataSourceItem(achievementId: Int)
+        case deleteUserDataSourceItem(userCode: String)
         case updateAchievement(updatedAchievement: Achievement)
         case postAchievement(newAchievement: Achievement)
         case deleteAchievement(achievementId: Int, categoryId: Int)

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeActionState.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeActionState.swift
@@ -21,7 +21,7 @@ extension GroupHomeViewModel {
         case deleteAchievement(achievementId: Int, categoryId: Int)
         case fetchDetailAchievement(achievementId: Int)
         case logout
-        case blockingAchievement(achievement: Achievement)
+        case blockingAchievement(achievementId: Int)
         case blockingUser(userCode: String)
     }
     
@@ -53,12 +53,6 @@ extension GroupHomeViewModel {
         case loading
         case success
         case failed
-        case error(message: String)
-    }
-    
-    enum BlockingState {
-        case loading
-        case success
         case error(message: String)
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeCoordinator.swift
@@ -27,6 +27,7 @@ final class GroupHomeCoordinator: Coordinator {
     func start() { }
     
     func start(group: Group) {
+        let blockingRepository = BlockingRepository(groupId: group.id)
         let groupAchievementRepository = GroupAchievementRepository(groupId: group.id)
         let groupCategoryRepository = GroupCategoryRepository(groupId: group.id)
         let groupHomeVM = GroupHomeViewModel(
@@ -35,7 +36,9 @@ final class GroupHomeCoordinator: Coordinator {
             fetchCategoryListUseCase: .init(repository: groupCategoryRepository),
             addCategoryUseCase: .init(repository: groupCategoryRepository),
             deleteAchievementUseCase: .init(repository: groupAchievementRepository, storage: nil),
-            fetchDetailAchievementUseCase: .init(repository: groupAchievementRepository)
+            fetchDetailAchievementUseCase: .init(repository: groupAchievementRepository),
+            blockingUserUseCase: .init(blockingRepository: blockingRepository),
+            blockingAchievementUseCase: .init(blockingRepository: blockingRepository)
         )
         let groupHomeVC = GroupHomeViewController(viewModel: groupHomeVM)
         groupHomeVC.coordinator = self

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeCoordinator.swift
@@ -100,12 +100,12 @@ extension GroupHomeCoordinator: GroupDetailAchievementCoordinatorDelegate {
         currentViewController?.postedAchievement(newAchievement: newAchievement)
     }
     
-    func blockingAchievementMenuDidClicked(achievement: Achievement) {
-        currentViewController?.blockedAchievement(achievement)
+    func blockingAchievementMenuDidClicked(achievementId: Int) {
+        currentViewController?.blockedAchievement(achievementId)
     }
     
-    func blockingUserMenuDidClicked(user: User) {
-        currentViewController?.blockedUser(user)
+    func blockingUserMenuDidClicked(userCode: String) {
+        currentViewController?.blockedUser(userCode)
     }
 }
 

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeViewController.swift
@@ -334,11 +334,11 @@ extension GroupHomeViewController: UICollectionViewDelegate {
             })
             // 작성자가 아닌 유저에게만 표시
             let blockingAchievementAction = UIAction(title: "도전기록 차단", attributes: .destructive, handler: { _ in
-                
+                self?.viewModel.action(.blockingAchievement(achievement: selectedItem))
             })
             // 작성자가 아닌 유저에게만 표시
             let blockingUserAction = UIAction(title: "사용자 차단", attributes: .destructive, handler: { _ in
-                
+                self?.viewModel.action(.blockingUser(userCode: selectedItem.userCode))
             })
             
             var children: [UIAction] = []
@@ -370,6 +370,7 @@ private extension GroupHomeViewController {
     private func bind() {
         bindAchievement()
         bindCategory()
+        bindBlocking()
     }
     
     func bindAchievement() {
@@ -462,6 +463,23 @@ private extension GroupHomeViewController {
 
     }
     
+    func bindBlocking() {
+        viewModel.blockingState
+            .receive(on: RunLoop.main)
+            .sink { [weak self] state in
+                guard let self else { return }
+                switch state {
+                case .loading:
+                    showLoadingIndicator()
+                case .success:
+                    hideLoadingIndicator()
+                case .error(let message):
+                    hideLoadingIndicator()
+                    showErrorAlert(message: message)
+                }
+            }
+            .store(in: &cancellables)
+    }
 }
 
 // MARK: - UITextFieldDelegate

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeViewController.swift
@@ -140,11 +140,11 @@ final class GroupHomeViewController: BaseViewController<HomeView>, LoadingIndica
         }
     }
     
-    func blockedAchievement(_ achievement: Achievement) {
+    func blockedAchievement(_ achievementId: Int) {
         
     }
     
-    func blockedUser(_ user: User) {
+    func blockedUser(_ userCode: String) {
         
     }
     

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeViewController.swift
@@ -334,7 +334,7 @@ extension GroupHomeViewController: UICollectionViewDelegate {
             })
             // 작성자가 아닌 유저에게만 표시
             let blockingAchievementAction = UIAction(title: "도전기록 차단", attributes: .destructive, handler: { _ in
-                self?.viewModel.action(.blockingAchievement(achievement: selectedItem))
+                self?.viewModel.action(.blockingAchievement(achievementId: selectedItem.id))
             })
             // 작성자가 아닌 유저에게만 표시
             let blockingUserAction = UIAction(title: "사용자 차단", attributes: .destructive, handler: { _ in
@@ -370,7 +370,6 @@ private extension GroupHomeViewController {
     private func bind() {
         bindAchievement()
         bindCategory()
-        bindBlocking()
     }
     
     func bindAchievement() {
@@ -461,24 +460,6 @@ private extension GroupHomeViewController {
             }
             .store(in: &cancellables)
 
-    }
-    
-    func bindBlocking() {
-        viewModel.blockingState
-            .receive(on: RunLoop.main)
-            .sink { [weak self] state in
-                guard let self else { return }
-                switch state {
-                case .loading:
-                    showLoadingIndicator()
-                case .success:
-                    hideLoadingIndicator()
-                case .error(let message):
-                    hideLoadingIndicator()
-                    showErrorAlert(message: message)
-                }
-            }
-            .store(in: &cancellables)
     }
 }
 

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeViewModel.swift
@@ -46,7 +46,7 @@ final class GroupHomeViewModel {
     private let blockingUserUseCase: BlockingUserUseCase
     private let blockingAchievementUseCase: BlockingAchievementUseCase
 
-    // Pagenation
+    // Pagination
     private var lastRequestNextValue: FetchAchievementListRequestValue?
     private var nextRequestValue: FetchAchievementListRequestValue?
     private var nextAchievementTask: Task<Void, Never>?
@@ -116,6 +116,8 @@ final class GroupHomeViewModel {
             refreshAchievementList()
         case .deleteAchievementDataSourceItem(let achievementId):
             deleteOfDataSource(achievementId: achievementId)
+        case .deleteUserDataSourceItem(let userCode):
+            deleteOfDataSource(userCode: userCode)
         case .updateAchievement(let updatedAchievement):
             updateAchievement(updatedAchievement: updatedAchievement)
         case .postAchievement(let newAchievement):
@@ -258,18 +260,14 @@ private extension GroupHomeViewModel {
     
     /// 도전기록을 차단하는 액션
     func blocking(achievementId: Int) {
-        achievements = achievements.filter { $0.id != achievementId }
-        Task {
-            blockingAchievementUseCase.execute(achievementId: achievementId)
-        }
+        deleteOfDataSource(achievementId: achievementId)
+        blockingAchievementUseCase.execute(achievementId: achievementId)
     }
     
     /// 유저를 차단하는 액션
     func blocking(userCode: String) {
-        achievements = achievements.filter { $0.userCode != userCode }
-        Task {
-            blockingUserUseCase.execute(userCode: userCode)
-        }
+        deleteOfDataSource(userCode: userCode)
+        blockingUserUseCase.execute(userCode: userCode)
     }
 }
 
@@ -310,14 +308,13 @@ private extension GroupHomeViewModel {
         }
     }
     
-    /// Achievement의 첫 번째 index를 구하는 메서드
-    func firstIndexOf(achievementId: Int) -> Int? {
-        return achievements.firstIndex { $0.id == achievementId }
+    /// 도전 기록을 데이터소스에서 제거하는 액션
+    func deleteOfDataSource(achievementId: Int) {
+        achievements = achievements.filter { $0.id != achievementId }
     }
     
     /// 도전 기록을 데이터소스에서 제거하는 액션
-    func deleteOfDataSource(achievementId: Int) {
-        guard let foundIndex = firstIndexOf(achievementId: achievementId) else { return }
-        achievements.remove(at: foundIndex)
+    func deleteOfDataSource(userCode: String) {
+        achievements = achievements.filter { $0.userCode != userCode }
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeViewModel.swift
@@ -53,6 +53,7 @@ final class GroupHomeViewModel {
     private(set) var achievementListState = PassthroughSubject<AchievementListState, Never>()
     private(set) var deleteAchievementState = PassthroughSubject<DeleteAchievementState, Never>()
     private(set) var fetchDetailAchievementState = PassthroughSubject<FetchDetailAchievementState, Never>()
+    private(set) var blockingState = PassthroughSubject<BlockingState, Never>()
 
     // MARK: - Init
     init(
@@ -120,6 +121,10 @@ final class GroupHomeViewModel {
             NotificationCenter.default.post(name: .logout, object: nil)
             KeychainStorage.shared.remove(key: .accessToken)
             KeychainStorage.shared.remove(key: .refreshToken)
+        case .blockingAchievement(let achievement):
+            blocking(achievement: achievement)
+        case .blockingUser(let userCode):
+            blocking(userCode: userCode)
         }
     }
 }
@@ -242,6 +247,16 @@ private extension GroupHomeViewModel {
                 fetchDetailAchievementState.send(.error(message: error.localizedDescription))
             }
         }
+    }
+    
+    /// 도전기록을 차단하는 액션
+    func blocking(achievement: Achievement) {
+        achievements = achievements.filter { $0.id != achievement.id }
+    }
+    
+    /// 유저를 차단하는 액션
+    func blocking(userCode: String) {
+        achievements = achievements.filter { $0.userCode != userCode }
     }
 }
 


### PR DESCRIPTION
## PR 요약
- 사용자 차단 구현
- 도전기록 차단 구현

#### 참고 사항
- 차단 API는 POST지만 body가 없어서 requestValue 대신 데이터를 파라미터로 직접 전달했습니다.
- 도전기록 API가 완료되면 제대로 테스트가 가능할듯 싶네요.

##### 스크린샷

https://github.com/boostcampwm2023/iOS02-moti/assets/89075274/0cd65d47-a898-4c73-889f-4654c3320fde



#### Linked Issue
close #445
close #446 
close #447 
close #448 
