### PR TITLE
그룹 탈퇴를 구현한다.

### DIFF
--- a/iOS/moti/moti/Data/Sources/Data/Network/DTO/DropGroupDTO.swift
+++ b/iOS/moti/moti/Data/Sources/Data/Network/DTO/DropGroupDTO.swift
@@ -1,0 +1,19 @@
+//
+//  DropGroupDTO.swift
+//
+//
+//  Created by Kihyun Lee on 12/6/23.
+//
+
+import Foundation
+
+struct DropGroupDTO: ResponseDataDTO {
+    let success: Bool?
+    let message: String?
+    let data: DropGroupDataDTO?
+}
+
+struct DropGroupDataDTO: Codable {
+    let userId: Int?
+    let groupId: Int?
+}

--- a/iOS/moti/moti/Data/Sources/Data/Network/Endpoint/MotiAPI.swift
+++ b/iOS/moti/moti/Data/Sources/Data/Network/Endpoint/MotiAPI.swift
@@ -35,6 +35,7 @@ enum MotiAPI: EndpointProtocol {
     case fetchGroupMemberList(groupId: Int)
     case updateGrade(groupId: Int, userCode: String, requestValue: UpdateGradeRequestValue)
     case invite(requestValue: InviteMemberRequestValue, groupId: Int)
+    case dropGroup(requestValue: DropGroupRequestValue)
     // 차단
     case blockingUser(userCode: String)
     case blockingAchievement(achievementId: Int, groupId: Int)
@@ -92,6 +93,8 @@ extension MotiAPI {
             return "/groups/\(groupId)/achievements/\(achievementId)/reject"
         case .invite(_, let groupId):
             return "/groups/\(groupId)/users"
+        case .dropGroup(let requestValue):
+            return "/groups/\(requestValue.groupId)/participation"
         }
     }
     
@@ -122,6 +125,7 @@ extension MotiAPI {
         case .blockingUser: return .post
         case .blockingAchievement: return .post
         case .invite: return .post
+        case .dropGroup: return .delete
         }
     }
     

--- a/iOS/moti/moti/Data/Sources/Data/Network/Endpoint/MotiAPI.swift
+++ b/iOS/moti/moti/Data/Sources/Data/Network/Endpoint/MotiAPI.swift
@@ -35,7 +35,7 @@ enum MotiAPI: EndpointProtocol {
     case fetchGroupMemberList(groupId: Int)
     case updateGrade(groupId: Int, userCode: String, requestValue: UpdateGradeRequestValue)
     case invite(requestValue: InviteMemberRequestValue, groupId: Int)
-    case dropGroup(requestValue: DropGroupRequestValue)
+    case dropGroup(groupId: Int)
     // 차단
     case blockingUser(userCode: String)
     case blockingAchievement(achievementId: Int, groupId: Int)
@@ -93,8 +93,8 @@ extension MotiAPI {
             return "/groups/\(groupId)/achievements/\(achievementId)/reject"
         case .invite(_, let groupId):
             return "/groups/\(groupId)/users"
-        case .dropGroup(let requestValue):
-            return "/groups/\(requestValue.groupId)/participation"
+        case .dropGroup(let groupId):
+            return "/groups/\(groupId)/participation"
         }
     }
     

--- a/iOS/moti/moti/Data/Sources/Repository/GroupRepository.swift
+++ b/iOS/moti/moti/Data/Sources/Repository/GroupRepository.swift
@@ -31,4 +31,12 @@ public struct GroupRepository: GroupRepositoryProtocol {
         // 생성한 사람은 항상 leader
         return Group(dto: groupDTO, grade: .leader)
     }
+    
+    public func dropGroup(requestValue: DropGroupRequestValue) async throws -> Bool {
+        let endpoint = MotiAPI.dropGroup(requestValue: requestValue)
+        let responseDTO = try await provider.request(with: endpoint, type: DropGroupDTO.self)
+        guard let dropGroupDataDTO = responseDTO.data else { throw NetworkError.decode }
+        
+        return responseDTO.success ?? false
+    }
 }

--- a/iOS/moti/moti/Data/Sources/Repository/GroupRepository.swift
+++ b/iOS/moti/moti/Data/Sources/Repository/GroupRepository.swift
@@ -32,8 +32,8 @@ public struct GroupRepository: GroupRepositoryProtocol {
         return Group(dto: groupDTO, grade: .leader)
     }
     
-    public func dropGroup(requestValue: DropGroupRequestValue) async throws -> Bool {
-        let endpoint = MotiAPI.dropGroup(requestValue: requestValue)
+    public func dropGroup(groupId: Int) async throws -> Bool {
+        let endpoint = MotiAPI.dropGroup(groupId: groupId)
         let responseDTO = try await provider.request(with: endpoint, type: DropGroupDTO.self)
         guard let dropGroupDataDTO = responseDTO.data else { throw NetworkError.decode }
         

--- a/iOS/moti/moti/Domain/Sources/Domain/RepositoryProtocol/GroupRepositoryProtocol.swift
+++ b/iOS/moti/moti/Domain/Sources/Domain/RepositoryProtocol/GroupRepositoryProtocol.swift
@@ -10,5 +10,5 @@ import Foundation
 public protocol GroupRepositoryProtocol {
     func fetchGroupList() async throws -> [Group]
     func createGroup(requestValue: CreateGroupRequestValue) async throws -> Group
-    func dropGroup(requestValue: DropGroupRequestValue) async throws -> Bool
+    func dropGroup(groupId: Int) async throws -> Bool
 }

--- a/iOS/moti/moti/Domain/Sources/Domain/RepositoryProtocol/GroupRepositoryProtocol.swift
+++ b/iOS/moti/moti/Domain/Sources/Domain/RepositoryProtocol/GroupRepositoryProtocol.swift
@@ -10,4 +10,5 @@ import Foundation
 public protocol GroupRepositoryProtocol {
     func fetchGroupList() async throws -> [Group]
     func createGroup(requestValue: CreateGroupRequestValue) async throws -> Group
+    func dropGroup(requestValue: DropGroupRequestValue) async throws -> Bool
 }

--- a/iOS/moti/moti/Domain/Sources/Domain/UseCase/DropGroupUseCase.swift
+++ b/iOS/moti/moti/Domain/Sources/Domain/UseCase/DropGroupUseCase.swift
@@ -1,0 +1,28 @@
+//
+//  DropGroupUseCase.swift
+//  
+//
+//  Created by Kihyun Lee on 12/6/23.
+//
+
+import Foundation
+
+public struct DropGroupRequestValue: RequestValue {
+    public let groupId: Int
+    
+    public init(groupId: Int) {
+        self.groupId = groupId
+    }
+}
+
+public struct DropGroupUseCase {
+    private let groupRepository: GroupRepositoryProtocol
+    
+    public init(groupRepository: GroupRepositoryProtocol) {
+        self.groupRepository = groupRepository
+    }
+    
+    public func execute(requestValue: DropGroupRequestValue) async throws -> Bool {
+        return try await groupRepository.dropGroup(requestValue: requestValue)
+    }
+}

--- a/iOS/moti/moti/Domain/Sources/Domain/UseCase/DropGroupUseCase.swift
+++ b/iOS/moti/moti/Domain/Sources/Domain/UseCase/DropGroupUseCase.swift
@@ -7,14 +7,6 @@
 
 import Foundation
 
-public struct DropGroupRequestValue: RequestValue {
-    public let groupId: Int
-    
-    public init(groupId: Int) {
-        self.groupId = groupId
-    }
-}
-
 public struct DropGroupUseCase {
     private let groupRepository: GroupRepositoryProtocol
     
@@ -22,7 +14,7 @@ public struct DropGroupUseCase {
         self.groupRepository = groupRepository
     }
     
-    public func execute(requestValue: DropGroupRequestValue) async throws -> Bool {
-        return try await groupRepository.dropGroup(requestValue: requestValue)
+    public func execute(groupId: Int) async throws -> Bool {
+        return try await groupRepository.dropGroup(groupId: groupId)
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeCoordinator.swift
@@ -10,16 +10,11 @@ import Core
 import Domain
 import Data
 
-protocol GroupHomeCoordinatorDelegate: AnyObject {
-    func dropCellDidClicked(groupId: Int)
-}
-
 final class GroupHomeCoordinator: Coordinator {
     public let parentCoordinator: Coordinator?
     public var childCoordinators: [Coordinator] = []
     public let navigationController: UINavigationController
     private var currentViewController: GroupHomeViewController?
-    weak var delegate: GroupHomeCoordinatorDelegate?
         
     public init(
         _ navigationController: UINavigationController,
@@ -60,7 +55,6 @@ final class GroupHomeCoordinator: Coordinator {
     
     func moveToGroupInfoViewController(group: Group) {
         let groupInfoCoordinator = GroupInfoCoordinator(navigationController, self)
-        groupInfoCoordinator.delegate = self
         groupInfoCoordinator.start(group: group)
         childCoordinators.append(groupInfoCoordinator)
     }
@@ -118,10 +112,3 @@ extension GroupHomeCoordinator: GroupDetailAchievementCoordinatorDelegate {
 
 // MARK: - CaptureCoordinatorDelegate
 extension GroupHomeCoordinator: CaptureCoordinatorDelegate { }
-
-extension GroupHomeCoordinator: GroupInfoCoordinatorDelegate {
-    func dropCellDidClicked(groupId: Int) {
-        finish(animated: true)
-        delegate?.dropCellDidClicked(groupId: groupId)
-    }
-}

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeCoordinator.swift
@@ -10,11 +10,16 @@ import Core
 import Domain
 import Data
 
+protocol GroupHomeCoordinatorDelegate: AnyObject {
+    func dropCellDidClicked(groupId: Int)
+}
+
 final class GroupHomeCoordinator: Coordinator {
     public let parentCoordinator: Coordinator?
     public var childCoordinators: [Coordinator] = []
     public let navigationController: UINavigationController
     private var currentViewController: GroupHomeViewController?
+    weak var delegate: GroupHomeCoordinatorDelegate?
         
     public init(
         _ navigationController: UINavigationController,
@@ -55,6 +60,7 @@ final class GroupHomeCoordinator: Coordinator {
     
     func moveToGroupInfoViewController(group: Group) {
         let groupInfoCoordinator = GroupInfoCoordinator(navigationController, self)
+        groupInfoCoordinator.delegate = self
         groupInfoCoordinator.start(group: group)
         childCoordinators.append(groupInfoCoordinator)
     }
@@ -112,3 +118,10 @@ extension GroupHomeCoordinator: GroupDetailAchievementCoordinatorDelegate {
 
 // MARK: - CaptureCoordinatorDelegate
 extension GroupHomeCoordinator: CaptureCoordinatorDelegate { }
+
+extension GroupHomeCoordinator: GroupInfoCoordinatorDelegate {
+    func dropCellDidClicked(groupId: Int) {
+        finish(animated: true)
+        delegate?.dropCellDidClicked(groupId: groupId)
+    }
+}

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupInfo/GroupInfoCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupInfo/GroupInfoCoordinator.swift
@@ -9,10 +9,15 @@ import UIKit
 import Core
 import Domain
 
+protocol GroupInfoCoordinatorDelegate: AnyObject {
+    func dropCellDidClicked(groupId: Int)
+}
+
 final class GroupInfoCoordinator: Coordinator {
     var parentCoordinator: Coordinator?
     var childCoordinators: [Coordinator] = []
     var navigationController: UINavigationController
+    weak var delegate: GroupInfoCoordinatorDelegate?
     
     init(
         _ navigationController: UINavigationController,
@@ -27,6 +32,7 @@ final class GroupInfoCoordinator: Coordinator {
     func start(group: Group) {
         let groupInfoVC = GroupInfoViewController(group: group)
         groupInfoVC.coordinator = self
+        groupInfoVC.delegate = self
         navigationController.pushViewController(groupInfoVC, animated: true)
     }
     
@@ -34,5 +40,12 @@ final class GroupInfoCoordinator: Coordinator {
         let groupMemberCoordinator = GroupMemberCoordinator(navigationController, self)
         groupMemberCoordinator.start(group: group, manageMode: manageMode)
         childCoordinators.append(groupMemberCoordinator)
+    }
+}
+
+extension GroupInfoCoordinator: GroupInfoViewControllerDelegate {
+    func dropCellDidClicked(groupId: Int) {
+        finish(animated: true)
+        delegate?.dropCellDidClicked(groupId: groupId)
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupInfo/GroupInfoCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupInfo/GroupInfoCoordinator.swift
@@ -8,16 +8,12 @@
 import UIKit
 import Core
 import Domain
-
-protocol GroupInfoCoordinatorDelegate: AnyObject {
-    func dropCellDidClicked(groupId: Int)
-}
+import Data
 
 final class GroupInfoCoordinator: Coordinator {
     var parentCoordinator: Coordinator?
     var childCoordinators: [Coordinator] = []
     var navigationController: UINavigationController
-    weak var delegate: GroupInfoCoordinatorDelegate?
     
     init(
         _ navigationController: UINavigationController,
@@ -30,9 +26,11 @@ final class GroupInfoCoordinator: Coordinator {
     func start() { }
     
     func start(group: Group) {
-        let groupInfoVC = GroupInfoViewController(group: group)
+        let groupInfoVC = GroupInfoViewController(
+            group: group,
+            viewModel: .init(dropGroupUseCase: .init(groupRepository: GroupRepository()))
+        )
         groupInfoVC.coordinator = self
-        groupInfoVC.delegate = self
         navigationController.pushViewController(groupInfoVC, animated: true)
     }
     
@@ -40,12 +38,5 @@ final class GroupInfoCoordinator: Coordinator {
         let groupMemberCoordinator = GroupMemberCoordinator(navigationController, self)
         groupMemberCoordinator.start(group: group, manageMode: manageMode)
         childCoordinators.append(groupMemberCoordinator)
-    }
-}
-
-extension GroupInfoCoordinator: GroupInfoViewControllerDelegate {
-    func dropCellDidClicked(groupId: Int) {
-        finish(animated: true)
-        delegate?.dropCellDidClicked(groupId: groupId)
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupInfo/GroupInfoTableViewDataSource.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupInfo/GroupInfoTableViewDataSource.swift
@@ -17,6 +17,10 @@ final class GroupInfoTableViewDataSource: NSObject, UITableViewDataSource {
         cellTexts.append(["그룹원 관리"])
     }
     
+    func isDropCell(indexPath: IndexPath) -> Bool {
+        return indexPath.section == 0 && indexPath.row == 1
+    }
+    
     func isGroupMemberCell(indexPath: IndexPath) -> Bool {
         return indexPath.section == 0 && indexPath.row == 0
     }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupInfo/GroupInfoViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupInfo/GroupInfoViewController.swift
@@ -58,14 +58,13 @@ extension GroupInfoViewController: UITableViewDelegate {
         } else if dataSource.isLeaderCell(indexPath: indexPath) {
             coordinator?.moveToGroupMemberViewController(group: group, manageMode: true)
         } else if dataSource.isDropCell(indexPath: indexPath) {
-            showDestructiveTwoButtonAlert(title: "그룹에서 탈퇴하시겠습니까?", okTitle: "탈퇴") { [weak self] in
-                guard let self else { return }
-                if group.grade == .leader {
-                    showErrorAlert(title: "그룹의 리더는 탈퇴를 할 수 없습니다.")
-                    return
+            if group.grade == .leader {
+                showErrorAlert(title: "그룹의 리더는 탈퇴를 할 수 없습니다.")
+            } else {
+                showDestructiveTwoButtonAlert(title: "그룹에서 탈퇴하시겠습니까?", okTitle: "탈퇴") { [weak self] in
+                    guard let self else { return }
+                    delegate?.dropCellDidClicked(groupId: group.id)
                 }
-                
-                delegate?.dropCellDidClicked(groupId: group.id)
             }
         }
     }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupInfo/GroupInfoViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupInfo/GroupInfoViewController.swift
@@ -8,25 +8,24 @@
 import UIKit
 import Design
 import Domain
-
-protocol GroupInfoViewControllerDelegate: AnyObject {
-    func dropCellDidClicked(groupId: Int)
-}
+import Combine
 
 final class GroupInfoViewController: BaseViewController<GroupInfoView>, HiddenTabBarViewController {
 
     // MARK: - Properties
     weak var coordinator: GroupInfoCoordinator?
-    weak var delegate: GroupInfoViewControllerDelegate?
     private let group: Group
     private let dataSource = GroupInfoTableViewDataSource()
+    private let viewModel: GroupInfoViewModel
+    private var cancellables: Set<AnyCancellable> = []
     
     // MARK: - Init
-    init(group: Group) {
+    init(group: Group, viewModel: GroupInfoViewModel) {
         self.group = group
         if group.grade == .leader {
             dataSource.appendLeaderSection()
         }
+        self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -37,6 +36,7 @@ final class GroupInfoViewController: BaseViewController<GroupInfoView>, HiddenTa
     // MARK: - Life Cycles
     override func viewDidLoad() {
         super.viewDidLoad()
+        bind()
         
         title = "그룹 정보"
         layoutView.configure(group: group)
@@ -63,9 +63,33 @@ extension GroupInfoViewController: UITableViewDelegate {
             } else {
                 showDestructiveTwoButtonAlert(title: "그룹에서 탈퇴하시겠습니까?", okTitle: "탈퇴") { [weak self] in
                     guard let self else { return }
-                    delegate?.dropCellDidClicked(groupId: group.id)
+                    viewModel.action(.dropGroup(groupId: group.id))
                 }
             }
         }
+    }
+}
+
+// MARK: - bind
+extension GroupInfoViewController: LoadingIndicator {
+    private func bind() {
+        viewModel.dropGroupState
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] state in
+                guard let self else { return }
+                switch state {
+                case .loading:
+                    showLoadingIndicator()
+                case .finish:
+                    hideLoadingIndicator()
+                    coordinator?.parentCoordinator?.finish(animated: true)
+                    coordinator?.finish(animated: true)
+                    // coordinator.finish를 먼저하면 coordinator가 없어져서 parent에 접근할 수 없음
+                case .error(let message):
+                    hideLoadingIndicator()
+                    showErrorAlert(message: message)
+                }
+            }
+            .store(in: &cancellables)
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupInfo/GroupInfoViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupInfo/GroupInfoViewController.swift
@@ -60,6 +60,11 @@ extension GroupInfoViewController: UITableViewDelegate {
         } else if dataSource.isDropCell(indexPath: indexPath) {
             showDestructiveTwoButtonAlert(title: "그룹에서 탈퇴하시겠습니까?", okTitle: "탈퇴") { [weak self] in
                 guard let self else { return }
+                if group.grade == .leader {
+                    showErrorAlert(title: "그룹의 리더는 탈퇴를 할 수 없습니다.")
+                    return
+                }
+                
                 delegate?.dropCellDidClicked(groupId: group.id)
             }
         }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupInfo/GroupInfoViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupInfo/GroupInfoViewController.swift
@@ -9,10 +9,15 @@ import UIKit
 import Design
 import Domain
 
+protocol GroupInfoViewControllerDelegate: AnyObject {
+    func dropCellDidClicked(groupId: Int)
+}
+
 final class GroupInfoViewController: BaseViewController<GroupInfoView>, HiddenTabBarViewController {
 
     // MARK: - Properties
     weak var coordinator: GroupInfoCoordinator?
+    weak var delegate: GroupInfoViewControllerDelegate?
     private let group: Group
     private let dataSource = GroupInfoTableViewDataSource()
     
@@ -52,6 +57,11 @@ extension GroupInfoViewController: UITableViewDelegate {
             coordinator?.moveToGroupMemberViewController(group: group, manageMode: false)
         } else if dataSource.isLeaderCell(indexPath: indexPath) {
             coordinator?.moveToGroupMemberViewController(group: group, manageMode: true)
+        } else if dataSource.isDropCell(indexPath: indexPath) {
+            showDestructiveTwoButtonAlert(title: "그룹에서 탈퇴하시겠습니까?", okTitle: "탈퇴") { [weak self] in
+                guard let self else { return }
+                delegate?.dropCellDidClicked(groupId: group.id)
+            }
         }
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupInfo/GroupInfoViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupInfo/GroupInfoViewController.swift
@@ -59,7 +59,7 @@ extension GroupInfoViewController: UITableViewDelegate {
             coordinator?.moveToGroupMemberViewController(group: group, manageMode: true)
         } else if dataSource.isDropCell(indexPath: indexPath) {
             if group.grade == .leader {
-                showErrorAlert(title: "그룹의 리더는 탈퇴를 할 수 없습니다.")
+                showErrorAlert(title: "그룹장은 탈퇴할 수 없습니다.")
             } else {
                 showDestructiveTwoButtonAlert(title: "그룹에서 탈퇴하시겠습니까?", okTitle: "탈퇴") { [weak self] in
                     guard let self else { return }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupInfo/GroupInfoViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupInfo/GroupInfoViewModel.swift
@@ -1,0 +1,60 @@
+//
+//  GroupInfoViewModel.swift
+//  
+//
+//  Created by Kihyun Lee on 12/6/23.
+//
+
+import Foundation
+import Domain
+import Core
+import Combine
+
+final class GroupInfoViewModel {
+    enum GroupInfoViewModelAction {
+        case dropGroup(groupId: Int)
+    }
+    
+    enum DropGroupState {
+        case loading
+        case finish
+        case error(message: String)
+    }
+    
+    // MARK: - Properties
+    private let dropGroupUseCase: DropGroupUseCase
+    
+    private(set) var dropGroupState = PassthroughSubject<DropGroupState, Never>()
+    
+    // MARK: - Init
+    init(
+        dropGroupUseCase: DropGroupUseCase
+    ) {
+        self.dropGroupUseCase = dropGroupUseCase
+    }
+    
+    func action(_ action: GroupInfoViewModelAction) {
+        switch action {
+        case .dropGroup(let groupId):
+            dropGroup(groupId: groupId)
+        }
+    }
+    
+    private func dropGroup(groupId: Int) {
+        Task {
+            dropGroupState.send(.loading)
+            do {
+                let requestValue = DropGroupRequestValue(groupId: groupId)
+                let isSuccess = try await dropGroupUseCase.execute(requestValue: requestValue)
+                if isSuccess {
+                    dropGroupState.send(.finish)
+                } else {
+                    dropGroupState.send(.error(message: "그룹 탈퇴에 실패했습니다."))
+                }
+            } catch {
+                Logger.error("\(#function) error: \(error.localizedDescription)")
+                dropGroupState.send(.error(message: error.localizedDescription))
+            }
+        }
+    }
+}

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupInfo/GroupInfoViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupInfo/GroupInfoViewModel.swift
@@ -44,8 +44,7 @@ final class GroupInfoViewModel {
         Task {
             dropGroupState.send(.loading)
             do {
-                let requestValue = DropGroupRequestValue(groupId: groupId)
-                let isSuccess = try await dropGroupUseCase.execute(requestValue: requestValue)
+                let isSuccess = try await dropGroupUseCase.execute(groupId: groupId)
                 if isSuccess {
                     dropGroupState.send(.finish)
                 } else {

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupList/GroupListCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupList/GroupListCoordinator.swift
@@ -14,6 +14,7 @@ final class GroupListCoordinator: Coordinator {
     var parentCoordinator: Coordinator?
     var childCoordinators: [Coordinator] = []
     var navigationController: UINavigationController
+    private var currentViewController: GroupListViewController?
     
     init(
         _ navigationController: UINavigationController,
@@ -30,12 +31,20 @@ final class GroupListCoordinator: Coordinator {
         )
         let groupListVC = GroupListViewController(viewModel: groupVM)
         groupListVC.coordinator = self
+        currentViewController = groupListVC
         navigationController.viewControllers = [groupListVC]
     }
     
     func moveToGroupHomeViewController(group: Group) {
         let groupHomeCoordinator = GroupHomeCoordinator(navigationController, self)
+        groupHomeCoordinator.delegate = self
         groupHomeCoordinator.start(group: group)
         childCoordinators.append(groupHomeCoordinator)
+    }
+}
+
+extension GroupListCoordinator: GroupHomeCoordinatorDelegate {
+    func dropCellDidClicked(groupId: Int) {
+        print(currentViewController, groupId)
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupList/GroupListCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupList/GroupListCoordinator.swift
@@ -25,9 +25,11 @@ final class GroupListCoordinator: Coordinator {
     }
     
     func start() {
+        let groupRepository = GroupRepository()
         let groupVM = GroupListViewModel(
-            fetchGroupListUseCase: .init(groupRepository: GroupRepository()),
-            createGroupUseCase: .init(groupRepository: GroupRepository())
+            fetchGroupListUseCase: .init(groupRepository: groupRepository),
+            createGroupUseCase: .init(groupRepository: groupRepository), 
+            dropGroupUseCase: .init(groupRepository: groupRepository)
         )
         let groupListVC = GroupListViewController(viewModel: groupVM)
         groupListVC.coordinator = self
@@ -45,6 +47,6 @@ final class GroupListCoordinator: Coordinator {
 
 extension GroupListCoordinator: GroupHomeCoordinatorDelegate {
     func dropCellDidClicked(groupId: Int) {
-        print(currentViewController, groupId)
+        currentViewController?.dropGroup(groupId: groupId)
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupList/GroupListCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupList/GroupListCoordinator.swift
@@ -39,14 +39,7 @@ final class GroupListCoordinator: Coordinator {
     
     func moveToGroupHomeViewController(group: Group) {
         let groupHomeCoordinator = GroupHomeCoordinator(navigationController, self)
-        groupHomeCoordinator.delegate = self
         groupHomeCoordinator.start(group: group)
         childCoordinators.append(groupHomeCoordinator)
-    }
-}
-
-extension GroupListCoordinator: GroupHomeCoordinatorDelegate {
-    func dropCellDidClicked(groupId: Int) {
-        currentViewController?.dropGroup(groupId: groupId)
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupList/GroupListViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupList/GroupListViewController.swift
@@ -37,6 +37,10 @@ final class GroupListViewController: BaseViewController<GroupListView> {
         viewModel.action(.launch)
     }
     
+    func dropGroup(groupId: Int) {
+        viewModel.action(.dropGroup(groupId: groupId))
+    }
+    
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         if let tabBarController = tabBarController as? TabBarViewController {

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupList/GroupListViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupList/GroupListViewController.swift
@@ -46,6 +46,8 @@ final class GroupListViewController: BaseViewController<GroupListView> {
         if let tabBarController = tabBarController as? TabBarViewController {
             tabBarController.hideCaptureButton()
         }
+        
+        print("그룹 리스트 어피어!!")
     }
     
     override func viewWillDisappear(_ animated: Bool) {

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupList/GroupListViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupList/GroupListViewController.swift
@@ -207,5 +207,21 @@ extension GroupListViewController: LoadingIndicator {
                 }
             }
             .store(in: &cancellables)
+        
+        viewModel.dropGroupState
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] state in
+                guard let self else { return }
+                switch state {
+                case .loading:
+                    showLoadingIndicator()
+                case .finish:
+                    hideLoadingIndicator()
+                case .error(let message):
+                    hideLoadingIndicator()
+                    showErrorAlert(message: message)
+                }
+            }
+            .store(in: &cancellables)
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupList/GroupListViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupList/GroupListViewModel.swift
@@ -161,8 +161,7 @@ extension GroupListViewModel {
         Task {
             dropGroupState.send(.loading)
             do {
-                let requestValue = DropGroupRequestValue(groupId: groupId)
-                let isSuccess = try await dropGroupUseCase.execute(requestValue: requestValue)
+                let isSuccess = try await dropGroupUseCase.execute(groupId: groupId)
                 if isSuccess {
                     deleteOfDataSource(groupId: groupId)
                     dropGroupState.send(.finish)

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupList/GroupListViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupList/GroupListViewModel.swift
@@ -72,10 +72,6 @@ final class GroupListViewModel {
     func findGroup(at index: Int) -> Group {
         return groups[index]
     }
-    
-    private func firstIndexOf(groupId: Int) -> Int? {
-        return groups.firstIndex { $0.id == groupId }
-    }
 
     func action(_ action: GroupListViewModelAction) {
         switch action {
@@ -120,14 +116,13 @@ extension GroupListViewModel {
     }
     
     private func dropGroup(groupId: Int) {
-        guard let foundIndex = firstIndexOf(groupId: groupId) else { return }
         Task {
             dropGroupState.send(.loading)
             do {
                 let requestValue = DropGroupRequestValue(groupId: groupId)
                 let isSuccess = try await dropGroupUseCase.execute(requestValue: requestValue)
                 if isSuccess {
-                    groups.remove(at: foundIndex)
+                    deleteOfDataSource(groupId: groupId)
                     dropGroupState.send(.finish)
                 } else {
                     dropGroupState.send(.error(message: "아이디가 \(groupId)인 그룹 탈퇴에 실패했습니다."))
@@ -137,5 +132,9 @@ extension GroupListViewModel {
                 dropGroupState.send(.error(message: error.localizedDescription))
             }
         }
+    }
+    
+    private func deleteOfDataSource(groupId: Int) {
+        groups = groups.filter { $0.id != groupId }
     }
 }


### PR DESCRIPTION
## PR 요약
- 그룹 탈퇴 alert 띄우기
- 탈퇴 버튼을 누르면 GroupList 뷰로 이동 (2번 pop)
- 탈퇴 API 연동
- 탈퇴가 성공이면 GroupList 에서 해당 그룹 삭제

#### 주의 사항
- 정주님이 초대해준 그룹에서 탈퇴되는 정상 동작 확인했으나
- 현재 내가 리더인 그룹밖에 안 남아서 삭제되는 결과 화면이 없음
- 내일 그룹 초대를 주고 받고 테스트할 예정

##### 스크린샷
- 리더 탈퇴
<img width="33%" src="https://github.com/boostcampwm2023/iOS02-moti/assets/60506170/7193765c-b423-4095-af8d-17dad87b640a">

- **그룹 탈퇴 성공**
<img width="50%" src="https://github.com/boostcampwm2023/iOS02-moti/assets/60506170/d47dd076-61dd-4af9-b0fa-a6c735830d02">

- **그룹 초대 완료**
<img width="50%" src="https://github.com/boostcampwm2023/iOS02-moti/assets/60506170/f113e556-be81-4eae-a74f-c48114dbb25e">

#### Linked Issue
close #456
close #457
close #458
