### PR TITLE
그룹 달성 기록 리스트를 조회한다

### DIFF
--- a/BE/src/group/achievement/application/group-achievement.service.ts
+++ b/BE/src/group/achievement/application/group-achievement.service.ts
@@ -16,6 +16,9 @@ import { GroupRepository } from '../../group/entities/group.repository';
 import { NoSuchGroupUserException } from '../exception/no-such-group-user.exception';
 import { NoSuchAchievementException } from '../../../achievement/exception/no-such-achievement.exception';
 import { UnauthorizedAchievementException } from '../../../achievement/exception/unauthorized-achievement.exception';
+import { PaginateGroupAchievementRequest } from '../dto/paginate-group-achievement-request';
+import { PaginateGroupAchievementResponse } from '../dto/paginate-group-achievement-response';
+import { GroupAchievementResponse } from '../dto/group-achievement-response';
 
 @Injectable()
 export class GroupAchievementService {
@@ -71,6 +74,24 @@ export class GroupAchievementService {
     return this.getAchievementResponse(user.id, saved.id);
   }
 
+  @Transactional({ readonly: true })
+  async getAchievements(
+    user: User,
+    groupId: number,
+    paginateGroupAchievementRequest: PaginateGroupAchievementRequest,
+  ) {
+    const achievements = await this.groupAchievementRepository.findAll(
+      user.id,
+      groupId,
+      paginateGroupAchievementRequest,
+    );
+    return new PaginateGroupAchievementResponse(
+      paginateGroupAchievementRequest,
+      achievements.map((achievement) =>
+        GroupAchievementResponse.from(achievement),
+      ),
+    );
+  }
   private async getCategory(userId: number, ctgId: number) {
     if (ctgId === -1) return null;
 

--- a/BE/src/group/achievement/controller/group-achievement.controller.ts
+++ b/BE/src/group/achievement/controller/group-achievement.controller.ts
@@ -6,6 +6,7 @@ import {
   HttpStatus,
   Param,
   Post,
+  Query,
   UseGuards,
 } from '@nestjs/common';
 import {
@@ -22,6 +23,8 @@ import { GroupAchievementService } from '../application/group-achievement.servic
 import { ParseIntPipe } from '../../../common/pipe/parse-int.pipe';
 import { RejectGroupAchievementResponse } from '../dto/reject-group-achievement-response.dto';
 import { GroupAchievementCreateRequest } from '../dto/group-achievement-create-request';
+import { PaginateGroupAchievementRequest } from '../dto/paginate-group-achievement-request';
+import { PaginateGroupAchievementResponse } from '../dto/paginate-group-achievement-response';
 import { AchievementDetailResponse } from '../../../achievement/dto/achievement-detail-response';
 
 @Controller('/api/v1/groups')
@@ -100,5 +103,32 @@ export class GroupAchievementController {
       id,
     );
     return ApiData.success(response);
+  }
+
+  @ApiBearerAuth('accessToken')
+  @ApiOperation({
+    summary: '그룹 달성기록 리스트 API',
+    description: '그룹 달성기록 리스트를 조회한다.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '그룹 달성기록 리스트',
+    type: PaginateGroupAchievementResponse,
+  })
+  @Get(`/:groupId/achievements`)
+  @UseGuards(AccessTokenGuard)
+  @HttpCode(HttpStatus.OK)
+  async getAchievements(
+    @AuthenticatedUser() user: User,
+    @Param('groupId', ParseIntPipe) groupId: number,
+    @Query() paginateGroupAchievementRequest: PaginateGroupAchievementRequest,
+  ) {
+    return ApiData.success(
+      await this.groupAchievementService.getAchievements(
+        user,
+        groupId,
+        paginateGroupAchievementRequest,
+      ),
+    );
   }
 }

--- a/BE/src/group/achievement/dto/group-achievement-response.ts
+++ b/BE/src/group/achievement/dto/group-achievement-response.ts
@@ -1,0 +1,39 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IGroupAchievementListDetail } from '../index';
+
+export class GroupAchievementResponse {
+  @ApiProperty({ description: 'id' })
+  id: number;
+  @ApiProperty({ description: 'thumbnailUrl' })
+  thumbnailUrl: string;
+  @ApiProperty({ description: 'title' })
+  title: string;
+  @ApiProperty({ description: 'categoryId' })
+  categoryId: number;
+  @ApiProperty({ description: 'userCode' })
+  userCode: string;
+
+  constructor(
+    id: number,
+    thumbnailUrl: string,
+    title: string,
+    userCode: string,
+    categoryId: number | null,
+  ) {
+    this.id = id;
+    this.thumbnailUrl = thumbnailUrl;
+    this.title = title;
+    this.userCode = userCode;
+    this.categoryId = categoryId ? categoryId : -1;
+  }
+
+  static from(groupAchievementListDetail: IGroupAchievementListDetail) {
+    return new GroupAchievementResponse(
+      groupAchievementListDetail.id,
+      groupAchievementListDetail.thumbnailUrl,
+      groupAchievementListDetail.title,
+      groupAchievementListDetail.userCode,
+      groupAchievementListDetail.categoryId,
+    );
+  }
+}

--- a/BE/src/group/achievement/dto/paginate-group-achievement-request.ts
+++ b/BE/src/group/achievement/dto/paginate-group-achievement-request.ts
@@ -1,0 +1,29 @@
+import { IsNumber, IsOptional } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class PaginateGroupAchievementRequest {
+  @IsNumber()
+  @IsOptional()
+  @ApiProperty({ description: 'next cursor id', required: false })
+  whereIdLessThan?: number;
+
+  @IsNumber()
+  @IsOptional()
+  @ApiProperty({ description: 'take', required: false })
+  take: number;
+
+  @IsNumber()
+  @IsOptional()
+  @ApiProperty({ description: 'categoryId', required: false })
+  categoryId: number;
+
+  constructor(
+    categoryId?: number,
+    take: number = 30,
+    whereIdLessThan?: number,
+  ) {
+    this.categoryId = categoryId;
+    this.take = take;
+    this.whereIdLessThan = whereIdLessThan;
+  }
+}

--- a/BE/src/group/achievement/dto/paginate-group-achievement-response.ts
+++ b/BE/src/group/achievement/dto/paginate-group-achievement-response.ts
@@ -1,0 +1,47 @@
+import { GroupAchievementResponse } from './group-achievement-response';
+import { PaginateGroupAchievementRequest } from './paginate-group-achievement-request';
+import { ApiProperty } from '@nestjs/swagger';
+import { Next } from '../../../achievement';
+
+export class PaginateGroupAchievementResponse {
+  @ApiProperty({ type: [GroupAchievementResponse], description: 'data' })
+  data: GroupAchievementResponse[];
+  @ApiProperty({ description: 'count' })
+  count: number;
+  @ApiProperty({ description: 'next' })
+  next: Next | null;
+
+  constructor(
+    paginateAchievementRequest: PaginateGroupAchievementRequest,
+    achievements: GroupAchievementResponse[],
+  ) {
+    this.data = achievements;
+
+    const last =
+      achievements.length > 0 &&
+      achievements.length === paginateAchievementRequest.take
+        ? achievements[achievements.length - 1]
+        : null;
+
+    this.count = achievements.length;
+    this.next = this.makeNext(paginateAchievementRequest, last);
+  }
+
+  private makeNext(
+    paginateAchievementRequest: PaginateGroupAchievementRequest,
+    last: GroupAchievementResponse,
+  ) {
+    const next: Next | null = last && {};
+
+    if (next) {
+      for (const key of Object.keys(paginateAchievementRequest)) {
+        if (key !== 'whereIdLessThan') {
+          next[key] = paginateAchievementRequest[key];
+        }
+      }
+      next.whereIdLessThan = parseInt(last.id.toString());
+    }
+
+    return next ?? null;
+  }
+}

--- a/BE/src/group/achievement/entities/group-achievement.repository.ts
+++ b/BE/src/group/achievement/entities/group-achievement.repository.ts
@@ -2,8 +2,13 @@ import { TransactionalRepository } from '../../../config/transaction-manager/tra
 import { CustomRepository } from '../../../config/typeorm/custom-repository.decorator';
 import { GroupAchievementEntity } from './group-achievement.entity';
 import { GroupAchievement } from '../domain/group-achievement.domain';
-import { IGroupAchievementDetail } from '../index';
+import { IGroupAchievementDetail, IGroupAchievementListDetail } from '../index';
 import { GroupAchievementDetailResponse } from '../dto/group-achievement-detail-response';
+import { PaginateGroupAchievementRequest } from '../dto/paginate-group-achievement-request';
+import { UserEntity } from '../../../users/entities/user.entity';
+import { UserBlockedUserEntity } from '../../../users/entities/user-blocked-user.entity';
+import { UserBlockedGroupAchievementEntity } from './user-blocked-group-achievement.entity';
+import { GroupAchievementResponse } from '../dto/group-achievement-response';
 
 @CustomRepository(GroupAchievementEntity)
 export class GroupAchievementRepository extends TransactionalRepository<GroupAchievementEntity> {
@@ -85,5 +90,75 @@ export class GroupAchievementRepository extends TransactionalRepository<GroupAch
       .leftJoin('image', 'i', 'i.group_achievement_id = groupAchievement.id')
       .leftJoin('groupAchievement.user', 'user')
       .where('groupAchievement.id = :achievementId', { achievementId });
+  }
+
+  async findAll(
+    userId: number,
+    groupId: number,
+    achievementPaginationOption: PaginateGroupAchievementRequest,
+  ) {
+    const blockedUserFilter = this.repository.manager
+      .getRepository(UserBlockedUserEntity)
+      .createQueryBuilder()
+      .select('user_blocked_user.blocked_user_id')
+      .from(UserBlockedUserEntity, 'user_blocked_user')
+      .where(`user_blocked_user.user_id = ${userId}`)
+      .getQuery();
+
+    const blockedAchievementFilter = this.repository.manager
+      .getRepository(UserBlockedGroupAchievementEntity)
+      .createQueryBuilder()
+      .select('user_blocked_achievement.group_achievement_id')
+      .from(UserBlockedGroupAchievementEntity, 'user_blocked_achievement')
+      .where(`user_blocked_achievement.user_id = ${userId}`)
+      .getQuery();
+
+    const query = this.repository
+      .createQueryBuilder('group_achievement')
+      .select([
+        'group_achievement.id as id',
+        'group_achievement.title as title',
+      ])
+      .innerJoin(
+        (qp) => qp.select('*').from(UserEntity, 'u'),
+        'user',
+        'group_achievement.user_id = user.id',
+      )
+      .addSelect(['user.user_code as userCode'])
+
+      .leftJoin('group_achievement.groupCategory', 'category')
+      .addSelect('category.id as categoryId')
+
+      .leftJoin('group_achievement.image', 'image')
+      .addSelect('image.thumbnailUrl as thumbnailUrl')
+
+      .where('group_achievement.group_id = :groupId', { groupId })
+      .andWhere(`group_achievement.id NOT IN (${blockedAchievementFilter})`)
+      .andWhere(`group_achievement.user_id NOT IN (${blockedUserFilter})`);
+
+    const { whereIdLessThan, categoryId, take } = achievementPaginationOption;
+
+    if (categoryId && categoryId !== 0 && categoryId !== -1) {
+      query.andWhere('group_achievement.groupCategory.id = :categoryId', {
+        categoryId,
+      });
+    }
+    if (categoryId === -1) {
+      query.andWhere('group_achievement.groupCategory.id IS NULL');
+    }
+    if (whereIdLessThan) {
+      query.andWhere('group_achievement.id < :id', {
+        id: whereIdLessThan,
+      });
+    }
+
+    const result = await query
+      .orderBy('group_achievement.created_at', 'DESC')
+      .limit(take)
+      .getRawMany<IGroupAchievementListDetail>();
+
+    return result.map((groupAchievementListDetail) =>
+      GroupAchievementResponse.from(groupAchievementListDetail),
+    );
   }
 }

--- a/BE/src/group/achievement/index.ts
+++ b/BE/src/group/achievement/index.ts
@@ -3,3 +3,11 @@ import { IAchievementDetail } from '../../achievement';
 export interface IGroupAchievementDetail extends IAchievementDetail {
   userCode: string;
 }
+
+export interface IGroupAchievementListDetail {
+  id: number;
+  title: string;
+  thumbnailUrl: string;
+  userCode: string;
+  categoryId: number;
+}

--- a/BE/src/users/entities/user.entity.ts
+++ b/BE/src/users/entities/user.entity.ts
@@ -32,7 +32,7 @@ export class UserEntity extends BaseTimeEntity {
     () => GroupAchievementEntity,
     (groupAchievement) => groupAchievement.user,
   )
-  groupAchievement: GroupAchievementEntity;
+  groupAchievement: GroupAchievementEntity[];
 
   static from(user: User): UserEntity {
     if (isNullOrUndefined(user)) return user;


### PR DESCRIPTION
## PR 요약
- 그룹 달성 기록 리스트를 조회한다.
- 커서 기반 페이지 네이션 적용 
- 차단된 멤버의 달성기록은 조회 되지 않음
- 차단된 달성기록은 조회되지 않음

##### 스크린샷
- 전체 조회 
<img width="764" alt="image" src="https://github.com/boostcampwm2023/iOS02-moti/assets/34297340/3cf2001e-f509-4c35-bf5a-d9b875ba8e84">

- 미달성 조회
<img width="748" alt="image" src="https://github.com/boostcampwm2023/iOS02-moti/assets/34297340/d1e6fc27-22bd-4b72-b82c-7066fdcb5901">


#### Linked Issue
close #278 
close #279 
close #280 
close #281 
close #282 
