### PR TITLE
그룹의 카테고리 리스트 API를 작성한다.

### DIFF
--- a/BE/src/achievement/entities/achievement.repository.spec.ts
+++ b/BE/src/achievement/entities/achievement.repository.spec.ts
@@ -339,49 +339,4 @@ describe('AchievementRepository test', () => {
       expect(findOne.content).toEqual(achievement.content);
     });
   });
-
-  describe('findByUserWithCount는 카테고리와 그 개수를 조회할 수 있다.', () => {
-    it('findByUserWithCount는 사용자가 소유한 카테고리가 없으면 미등록 카테고리만 반환한다.', async () => {
-      await transactionTest(dataSource, async () => {
-        const user = await usersFixture.getUser(1);
-
-        const retrievedCategories =
-          await achievementRepository.findByCategoryWithCount(user);
-
-        expect(retrievedCategories).toBeDefined();
-        expect(retrievedCategories.length).toBe(0);
-      });
-    });
-
-    it('findByUserWithCount', async () => {
-      await transactionTest(dataSource, async () => {
-        const user = await usersFixture.getUser(1);
-        const categories: Category[] = await categoryFixture.getCategories(
-          4,
-          user,
-        );
-        await achievementFixture.getAchievements(4, user, categories[0]);
-        await achievementFixture.getAchievements(5, user, categories[1]);
-        await achievementFixture.getAchievements(7, user, categories[2]);
-        await achievementFixture.getAchievements(10, user, categories[3]);
-
-        const retrievedCategories =
-          await achievementRepository.findByCategoryWithCount(user);
-
-        expect(retrievedCategories.length).toBe(4);
-        expect(retrievedCategories[0].categoryId).toEqual(categories[0].id);
-        expect(retrievedCategories[0].insertedAt).toBeInstanceOf(Date);
-        expect(retrievedCategories[0].achievementCount).toBe(4);
-        expect(retrievedCategories[1].categoryId).toEqual(categories[1].id);
-        expect(retrievedCategories[1].insertedAt).toBeInstanceOf(Date);
-        expect(retrievedCategories[1].achievementCount).toBe(5);
-        expect(retrievedCategories[2].categoryId).toEqual(categories[2].id);
-        expect(retrievedCategories[2].insertedAt).toBeInstanceOf(Date);
-        expect(retrievedCategories[2].achievementCount).toBe(7);
-        expect(retrievedCategories[3].categoryId).toEqual(categories[3].id);
-        expect(retrievedCategories[3].insertedAt).toBeInstanceOf(Date);
-        expect(retrievedCategories[3].achievementCount).toBe(10);
-      });
-    });
-  });
 });

--- a/BE/src/achievement/entities/achievement.repository.ts
+++ b/BE/src/achievement/entities/achievement.repository.ts
@@ -73,22 +73,6 @@ export class AchievementRepository extends TransactionalRepository<AchievementEn
     return null;
   }
 
-  async findByCategoryWithCount(user: User) {
-    const categories = await this.repository
-      .createQueryBuilder('achievement')
-      .select('COALESCE(category.id, -1) as categoryId')
-      .addSelect('category.name', 'categoryName')
-      .addSelect('MAX(achievement.created_at)', 'insertedAt')
-      .addSelect('COUNT(*)', 'achievementCount')
-      .leftJoin('achievement.category', 'category')
-      .where('achievement.user_id = :user', { user: user.id })
-      .orderBy('category.id', 'ASC')
-      .groupBy('category.id')
-      .getRawMany<ICategoryMetaData>();
-
-    return categories.map((category) => new CategoryMetaData(category));
-  }
-
   async findByIdAndUser(userId: number, id: number): Promise<Achievement> {
     const achievementEntity = await this.repository.findOneBy({
       user: { id: userId },

--- a/BE/src/category/application/category.service.spec.ts
+++ b/BE/src/category/application/category.service.spec.ts
@@ -80,7 +80,8 @@ describe('CategoryService', () => {
 
       // then
       expect(retrievedCategories).toBeDefined();
-      expect(retrievedCategories.length).toBe(0);
+      expect(retrievedCategories.length).toBe(1);
+      expect(retrievedCategories[0].categoryId).toEqual(-1);
     });
 
     it('user에 대한 카테고리가 있을 때 카테고리를 반환한다.', async () => {
@@ -100,19 +101,22 @@ describe('CategoryService', () => {
         await categoryService.getCategoriesByUser(user);
 
       // then
-      expect(retrievedCategories.length).toBe(4);
-      expect(retrievedCategories[0].categoryId).toEqual(categories[0].id);
-      expect(retrievedCategories[0].insertedAt).toBeInstanceOf(Date);
-      expect(retrievedCategories[0].achievementCount).toBe(4);
-      expect(retrievedCategories[1].categoryId).toEqual(categories[1].id);
+      expect(retrievedCategories.length).toBe(5);
+      expect(retrievedCategories[0].categoryId).toEqual(-1);
+      expect(retrievedCategories[0].insertedAt).toBeNull();
+      expect(retrievedCategories[0].achievementCount).toBe(0);
+      expect(retrievedCategories[1].categoryId).toEqual(categories[0].id);
       expect(retrievedCategories[1].insertedAt).toBeInstanceOf(Date);
-      expect(retrievedCategories[1].achievementCount).toBe(5);
-      expect(retrievedCategories[2].categoryId).toEqual(categories[2].id);
+      expect(retrievedCategories[1].achievementCount).toBe(4);
+      expect(retrievedCategories[2].categoryId).toEqual(categories[1].id);
       expect(retrievedCategories[2].insertedAt).toBeInstanceOf(Date);
-      expect(retrievedCategories[2].achievementCount).toBe(7);
-      expect(retrievedCategories[3].categoryId).toEqual(categories[3].id);
+      expect(retrievedCategories[2].achievementCount).toBe(5);
+      expect(retrievedCategories[3].categoryId).toEqual(categories[2].id);
       expect(retrievedCategories[3].insertedAt).toBeInstanceOf(Date);
-      expect(retrievedCategories[3].achievementCount).toBe(10);
+      expect(retrievedCategories[3].achievementCount).toBe(7);
+      expect(retrievedCategories[4].categoryId).toEqual(categories[3].id);
+      expect(retrievedCategories[4].insertedAt).toBeInstanceOf(Date);
+      expect(retrievedCategories[4].achievementCount).toBe(10);
     });
   });
 });

--- a/BE/src/category/application/category.service.ts
+++ b/BE/src/category/application/category.service.ts
@@ -5,14 +5,10 @@ import { Transactional } from '../../config/transaction-manager';
 import { Category } from '../domain/category.domain';
 import { User } from '../../users/domain/user.domain';
 import { CategoryMetaData } from '../dto/category-metadata';
-import { AchievementRepository } from '../../achievement/entities/achievement.repository';
 
 @Injectable()
 export class CategoryService {
-  constructor(
-    private readonly categoryRepository: CategoryRepository,
-    private readonly achievementRepository: AchievementRepository,
-  ) {}
+  constructor(private readonly categoryRepository: CategoryRepository) {}
 
   @Transactional()
   async saveCategory(
@@ -25,6 +21,6 @@ export class CategoryService {
 
   @Transactional({ readonly: true })
   async getCategoriesByUser(user: User): Promise<CategoryMetaData[]> {
-    return this.achievementRepository.findByCategoryWithCount(user);
+    return this.categoryRepository.findCategoriesByUser(user);
   }
 }

--- a/BE/src/category/entities/category.repository.spec.ts
+++ b/BE/src/category/entities/category.repository.spec.ts
@@ -105,6 +105,7 @@ describe('CategoryRepository', () => {
         4,
         user,
       );
+      const category = await categoryFixture.getCategory(user);
       await achievementFixture.getAchievements(4, user, categories[0]);
       await achievementFixture.getAchievements(5, user, categories[1]);
       await achievementFixture.getAchievements(7, user, categories[2]);
@@ -113,7 +114,7 @@ describe('CategoryRepository', () => {
       const retrievedCategories =
         await categoryRepository.findByUserWithCount(user);
 
-      expect(retrievedCategories.length).toBe(4);
+      expect(retrievedCategories.length).toBe(5);
       expect(retrievedCategories[0].categoryId).toEqual(categories[0].id);
       expect(retrievedCategories[0].insertedAt).toBeInstanceOf(Date);
       expect(retrievedCategories[0].achievementCount).toBe(4);
@@ -126,6 +127,9 @@ describe('CategoryRepository', () => {
       expect(retrievedCategories[3].categoryId).toEqual(categories[3].id);
       expect(retrievedCategories[3].insertedAt).toBeInstanceOf(Date);
       expect(retrievedCategories[3].achievementCount).toBe(10);
+      expect(retrievedCategories[4].categoryId).toEqual(category.id);
+      expect(retrievedCategories[4].insertedAt).toBeNull();
+      expect(retrievedCategories[4].achievementCount).toBe(0);
     });
   });
 
@@ -145,5 +149,22 @@ describe('CategoryRepository', () => {
       expect(findOne.id).toEqual(category.id);
       expect(findOne.name).toEqual('ABC');
     });
+  });
+
+  it('findNotSpecifiedByUserAndId는 사용자의 미분류 카테고리를 조회할 수 있다.', async () => {
+    // given
+    const user = await usersFixture.getUser('ABC');
+    await categoryFixture.getCategory(user, '미분류');
+    await achievementFixture.getAchievements(4, user, null);
+
+    // when
+    const retrievedCategory =
+      await categoryRepository.findNotSpecifiedByUserAndId(user);
+
+    // then
+    expect(retrievedCategory.categoryId).toEqual(-1);
+    expect(retrievedCategory.categoryName).toEqual('미설정');
+    expect(retrievedCategory.insertedAt).toBeInstanceOf(Date);
+    expect(retrievedCategory.achievementCount).toBe(4);
   });
 });

--- a/BE/src/category/entities/category.repository.ts
+++ b/BE/src/category/entities/category.repository.ts
@@ -5,6 +5,8 @@ import { TransactionalRepository } from '../../config/transaction-manager/transa
 import { User } from '../../users/domain/user.domain';
 import { ICategoryMetaData } from '../index';
 import { CategoryMetaData } from '../dto/category-metadata';
+import { AchievementEntity } from '../../achievement/entities/achievement.entity';
+import { Repository } from 'typeorm';
 
 @CustomRepository(CategoryEntity)
 export class CategoryRepository extends TransactionalRepository<CategoryEntity> {
@@ -19,13 +21,20 @@ export class CategoryRepository extends TransactionalRepository<CategoryEntity> 
     return category?.toModel();
   }
 
+  async findCategoriesByUser(user: User): Promise<CategoryMetaData[]> {
+    const notSpecifiedCategoryMetaData =
+      await this.findNotSpecifiedByUserAndId(user);
+    const categoryMetaData = await this.findByUserWithCount(user);
+    return [notSpecifiedCategoryMetaData, ...categoryMetaData];
+  }
+
   async findByUserWithCount(user: User): Promise<CategoryMetaData[]> {
     const categories = await this.repository
       .createQueryBuilder('category')
       .select('category.id as categoryId')
       .addSelect('category.name', 'categoryName')
       .addSelect('MAX(achievement.created_at)', 'insertedAt')
-      .addSelect('COUNT(*)', 'achievementCount')
+      .addSelect('COUNT(achievement.id)', 'achievementCount')
       .leftJoin('category.achievements', 'achievement')
       .where('category.user_id = :user', { user: user.id })
       .orderBy('category.id', 'ASC')
@@ -33,6 +42,23 @@ export class CategoryRepository extends TransactionalRepository<CategoryEntity> 
       .getRawMany<ICategoryMetaData>();
 
     return categories.map((category) => new CategoryMetaData(category));
+  }
+
+  async findNotSpecifiedByUserAndId(user: User): Promise<CategoryMetaData> {
+    const achievementRepository: Repository<AchievementEntity> =
+      this.repository.manager.getRepository(AchievementEntity);
+
+    const category = await achievementRepository
+      .createQueryBuilder('achievement')
+      .select('-1 as categoryId')
+      .addSelect(`'미설정' as categoryName`)
+      .addSelect('MAX(achievement.created_at)', 'insertedAt')
+      .addSelect('COUNT(*)', 'achievementCount')
+      .where('achievement.category_id is NULL')
+      .andWhere('achievement.user_id = :user', { user: user.id })
+      .getRawOne<ICategoryMetaData>();
+
+    return new CategoryMetaData(category);
   }
 
   async findByIdAndUser(userId: number, id: number): Promise<Category> {

--- a/BE/src/common/exception/error-code.ts
+++ b/BE/src/common/exception/error-code.ts
@@ -103,4 +103,8 @@ export const ERROR_INFO = {
     statusCode: 400,
     message: '그룹의 리더만 권한 조정이 가능합니다.',
   },
+  UNAUTHORIZED_APPROACH_GROUP_CATEGORY: {
+    statusCode: 403,
+    message: '그룹에 카테고리를 조회할 수 없습니다.',
+  },
 } as const;

--- a/BE/src/group/category/application/group-category.service.spec.ts
+++ b/BE/src/group/category/application/group-category.service.spec.ts
@@ -13,11 +13,18 @@ import { GroupCategoryService } from './group-category.service';
 import { transactionTest } from '../../../../test/common/transaction-test';
 import { GroupCategoryCreate } from '../dto/group-category-create';
 import { UnauthorizedGroupCategoryException } from '../exception/unauthorized-group-category.exception';
+import { GroupCategoryTestModule } from '../../../../test/group/category/group-category-test.module';
+import { GroupCategoryFixture } from '../../../../test/group/category/group-category-fixture';
+import { GroupAchievementTestModule } from '../../../../test/group/achievement/group-achievement-test.module';
+import { GroupAchievementFixture } from '../../../../test/group/achievement/group-achievement-fixture';
+import { UnauthorizedApproachGroupCategoryException } from '../exception/unauthorized-approach-group-category.exception';
 
 describe('GroupCategoryService test', () => {
   let groupCategoryService: GroupCategoryService;
   let dataSource: DataSource;
   let usersFixture: UsersFixture;
+  let groupCategoryFixture: GroupCategoryFixture;
+  let groupAchievementFixture: GroupAchievementFixture;
   let groupFixture: GroupFixture;
 
   beforeAll(async () => {
@@ -28,11 +35,17 @@ describe('GroupCategoryService test', () => {
         ConfigModule.forRoot(configServiceModuleOptions),
         GroupTestModule,
         GroupCategoryModule,
+        GroupCategoryTestModule,
+        GroupAchievementTestModule,
       ],
       controllers: [],
       providers: [],
     }).compile();
 
+    groupAchievementFixture = app.get<GroupAchievementFixture>(
+      GroupAchievementFixture,
+    );
+    groupCategoryFixture = app.get<GroupCategoryFixture>(GroupCategoryFixture);
     groupFixture = app.get<GroupFixture>(GroupFixture);
     usersFixture = app.get<UsersFixture>(UsersFixture);
     groupCategoryService = app.get<GroupCategoryService>(GroupCategoryService);
@@ -118,6 +131,256 @@ describe('GroupCategoryService test', () => {
             groupCategoryCreate,
           ),
         ).rejects.toThrow(UnauthorizedGroupCategoryException);
+      });
+    });
+  });
+
+  describe('retrieveCategoryMetadata는 그룹의 카테고리 메타데이터를 조회할 수 있다.', () => {
+    it('그룹장은 그룹의 카테고리 메타데이터를 조회할 수 있다.', async () => {
+      await transactionTest(dataSource, async () => {
+        // given
+        const leader = await usersFixture.getUser('ABC');
+        const group = await groupFixture.createGroups(leader);
+        const groupCategory = await groupCategoryFixture.createCategory(
+          leader,
+          group,
+          '카테고리1',
+        );
+
+        await groupAchievementFixture.createGroupAchievement(
+          leader,
+          group,
+          groupCategory,
+          '업적1',
+        );
+        await groupAchievementFixture.createGroupAchievement(
+          leader,
+          group,
+          null,
+          '업적2',
+        );
+
+        // when
+        const categories = await groupCategoryService.retrieveCategoryMetadata(
+          leader,
+          group.id,
+        );
+
+        // then
+        expect(categories.length).toEqual(2);
+        expect(categories[0].categoryName).toEqual('미설정');
+        expect(categories[0].categoryId).toEqual(-1);
+        expect(categories[0].achievementCount).toEqual(1);
+        expect(categories[1].categoryName).toEqual('카테고리1');
+        expect(categories[1].categoryId).toEqual(groupCategory.id);
+        expect(categories[1].achievementCount).toEqual(1);
+      });
+    });
+
+    it('그룹 멤버는 그룹의 카테고리 메타데이터를 조회할 수 있다.', async () => {
+      await transactionTest(dataSource, async () => {
+        // given
+        const leader = await usersFixture.getUser('ABC');
+        const participants = await usersFixture.getUsers(5);
+
+        const group = await groupFixture.createGroups(leader, participants);
+        const groupCategory = await groupCategoryFixture.createCategory(
+          leader,
+          group,
+          '카테고리1',
+        );
+
+        await groupAchievementFixture.createGroupAchievement(
+          leader,
+          group,
+          groupCategory,
+          '업적1',
+        );
+        await groupAchievementFixture.createGroupAchievement(
+          leader,
+          group,
+          null,
+          '업적2',
+        );
+
+        // when
+        const categories = await groupCategoryService.retrieveCategoryMetadata(
+          participants[0],
+          group.id,
+        );
+
+        // then
+        expect(categories.length).toEqual(2);
+        expect(categories[0].categoryName).toEqual('미설정');
+        expect(categories[0].categoryId).toEqual(-1);
+        expect(categories[0].achievementCount).toEqual(1);
+        expect(categories[1].categoryName).toEqual('카테고리1');
+        expect(categories[1].categoryId).toEqual(groupCategory.id);
+        expect(categories[1].achievementCount).toEqual(1);
+      });
+    });
+
+    it('그룹 관리자는 그룹의 카테고리 메타데이터를 조회할 수 있다.', async () => {
+      await transactionTest(dataSource, async () => {
+        // given
+        const leader = await usersFixture.getUser('ABC');
+        const participants = await usersFixture.getUsers(5);
+        const managers = await usersFixture.getUsers(5);
+
+        const group = await groupFixture.createGroups(
+          leader,
+          participants,
+          managers,
+        );
+        const groupCategory = await groupCategoryFixture.createCategory(
+          leader,
+          group,
+          '카테고리1',
+        );
+
+        await groupAchievementFixture.createGroupAchievement(
+          leader,
+          group,
+          groupCategory,
+          '업적1',
+        );
+        await groupAchievementFixture.createGroupAchievement(
+          leader,
+          group,
+          null,
+          '업적2',
+        );
+
+        // when
+        const categories = await groupCategoryService.retrieveCategoryMetadata(
+          managers[4],
+          group.id,
+        );
+
+        // then
+        expect(categories.length).toEqual(2);
+        expect(categories[0].categoryName).toEqual('미설정');
+        expect(categories[0].categoryId).toEqual(-1);
+        expect(categories[0].achievementCount).toEqual(1);
+        expect(categories[1].categoryName).toEqual('카테고리1');
+        expect(categories[1].categoryId).toEqual(groupCategory.id);
+        expect(categories[1].achievementCount).toEqual(1);
+      });
+    });
+
+    it('그룹 멤버는 그룹의 카테고리 메타데이터를 조회할 수 있다.', async () => {
+      await transactionTest(dataSource, async () => {
+        // given
+        const leader = await usersFixture.getUser('ABC');
+        const participants = await usersFixture.getUsers(5);
+
+        const group = await groupFixture.createGroups(leader, participants);
+        const groupCategory = await groupCategoryFixture.createCategory(
+          leader,
+          group,
+          '카테고리1',
+        );
+
+        await groupAchievementFixture.createGroupAchievement(
+          leader,
+          group,
+          groupCategory,
+          '업적1',
+        );
+        await groupAchievementFixture.createGroupAchievement(
+          leader,
+          group,
+          null,
+          '업적2',
+        );
+
+        // when
+        const categories = await groupCategoryService.retrieveCategoryMetadata(
+          participants[0],
+          group.id,
+        );
+
+        // then
+        expect(categories.length).toEqual(2);
+        expect(categories[0].categoryName).toEqual('미설정');
+        expect(categories[0].categoryId).toEqual(-1);
+        expect(categories[0].achievementCount).toEqual(1);
+        expect(categories[1].categoryName).toEqual('카테고리1');
+        expect(categories[1].categoryId).toEqual(groupCategory.id);
+        expect(categories[1].achievementCount).toEqual(1);
+      });
+    });
+
+    it('그룹에 속하지 않은 사용자가 그룹의 카테고리 메타데이터를 조회할 수 없다.', async () => {
+      await transactionTest(dataSource, async () => {
+        // given
+        const leader = await usersFixture.getUser('ABC');
+        const participants = await usersFixture.getUsers(5);
+
+        const group = await groupFixture.createGroups(leader, participants);
+        const groupCategory = await groupCategoryFixture.createCategory(
+          leader,
+          group,
+          '카테고리1',
+        );
+
+        await groupAchievementFixture.createGroupAchievement(
+          leader,
+          group,
+          groupCategory,
+          '업적1',
+        );
+        await groupAchievementFixture.createGroupAchievement(
+          leader,
+          group,
+          null,
+          '업적2',
+        );
+
+        const other = await usersFixture.getUser('DEF');
+
+        // when
+        // then
+        await expect(
+          groupCategoryService.retrieveCategoryMetadata(other, group.id),
+        ).rejects.toThrow(UnauthorizedApproachGroupCategoryException);
+      });
+    });
+
+    it('그룹에 속하지 않은 사용자가 그룹의 카테고리 메타데이터를 조회할 수 없다.', async () => {
+      await transactionTest(dataSource, async () => {
+        // given
+        const leader = await usersFixture.getUser('ABC');
+        const participants = await usersFixture.getUsers(5);
+
+        const group = await groupFixture.createGroups(leader, participants);
+        const groupCategory = await groupCategoryFixture.createCategory(
+          leader,
+          group,
+          '카테고리1',
+        );
+
+        await groupAchievementFixture.createGroupAchievement(
+          leader,
+          group,
+          groupCategory,
+          '업적1',
+        );
+        await groupAchievementFixture.createGroupAchievement(
+          leader,
+          group,
+          null,
+          '업적2',
+        );
+
+        const other = await usersFixture.getUser('DEF');
+        await groupFixture.createGroups(other);
+
+        // when
+        // then
+        await expect(
+          groupCategoryService.retrieveCategoryMetadata(other, group.id),
+        ).rejects.toThrow(UnauthorizedApproachGroupCategoryException);
       });
     });
   });

--- a/BE/src/group/category/application/group-category.service.ts
+++ b/BE/src/group/category/application/group-category.service.ts
@@ -6,6 +6,7 @@ import { GroupCategoryCreate } from '../dto/group-category-create';
 import { GroupRepository } from '../../group/entities/group.repository';
 import { UnauthorizedGroupCategoryException } from '../exception/unauthorized-group-category.exception';
 import { GroupCategory } from '../domain/group.category';
+import { UnauthorizedApproachGroupCategoryException } from '../exception/unauthorized-approach-group-category.exception';
 
 @Injectable()
 export class GroupCategoryService {
@@ -20,17 +21,30 @@ export class GroupCategoryService {
     groupId: number,
     groupCtgCreate: GroupCategoryCreate,
   ): Promise<GroupCategory> {
-    const group = await this.getGroup(user, groupId);
+    const group = await this.getGroupByLeader(user, groupId);
     const groupCategory = groupCtgCreate.toModel(user, group);
     return this.groupCategoryRepository.saveGroupCategory(groupCategory);
   }
 
-  private async getGroup(user: User, groupId: number) {
+  @Transactional({ readonly: true })
+  async retrieveCategoryMetadata(user: User, groupId: number) {
+    const group = await this.getGroup(user, groupId);
+    return this.groupCategoryRepository.findGroupCategoriesByUser(user, group);
+  }
+
+  private async getGroupByLeader(user: User, groupId: number) {
     const group = await this.groupRepository.findGroupByIdAndLeaderUser(
       user,
       groupId,
     );
     if (!group) throw new UnauthorizedGroupCategoryException();
+
+    return group;
+  }
+
+  private async getGroup(user: User, groupId: number) {
+    const group = await this.groupRepository.findByIdAndUser(groupId, user);
+    if (!group) throw new UnauthorizedApproachGroupCategoryException();
 
     return group;
   }

--- a/BE/src/group/category/controller/group-category.controller.ts
+++ b/BE/src/group/category/controller/group-category.controller.ts
@@ -1,7 +1,8 @@
-import { Body, Controller, Param, Post, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post, UseGuards } from '@nestjs/common';
 import { GroupCategoryService } from '../application/group-category.service';
 import { AccessTokenGuard } from '../../../auth/guard/access-token.guard';
 import { AuthenticatedUser } from '../../../auth/decorator/athenticated-user.decorator';
+import { GroupCategoryListElementResponse } from '../dto/group-category-list-element.response';
 import { User } from '../../../users/domain/user.domain';
 import { GroupCategoryCreate } from '../dto/group-category-create';
 import { ApiData } from '../../../common/api/api-data';
@@ -41,5 +42,27 @@ export class GroupCategoryController {
       groupCtgCreate,
     );
     return ApiData.success(GroupCategoryResponse.from(groupCategory));
+  }
+
+  @ApiBearerAuth('accessToken')
+  @ApiOperation({
+    summary: '그룹 카테고리 리스트 API',
+    description: '그룹 카테고리 리스트를 조회한다.',
+  })
+  @ApiCreatedResponse({
+    description: '그룹 카테고리 조회',
+    type: GroupCategoryListElementResponse,
+  })
+  @Get()
+  @UseGuards(AccessTokenGuard)
+  async categoryList(
+    @AuthenticatedUser() user: User,
+    @Param('groupId', ParseIntPipe) groupId: number,
+  ): Promise<ApiData<GroupCategoryListElementResponse[]>> {
+    const groupCategory =
+      await this.groupCategoryService.retrieveCategoryMetadata(user, groupId);
+    return ApiData.success(
+      GroupCategoryListElementResponse.build(groupCategory),
+    );
   }
 }

--- a/BE/src/group/category/controller/group-category.controller.ts
+++ b/BE/src/group/category/controller/group-category.controller.ts
@@ -11,6 +11,7 @@ import { ParseIntPipe } from '../../../common/pipe/parse-int.pipe';
 import {
   ApiBearerAuth,
   ApiCreatedResponse,
+  ApiOkResponse,
   ApiOperation,
   ApiTags,
 } from '@nestjs/swagger';
@@ -49,7 +50,7 @@ export class GroupCategoryController {
     summary: '그룹 카테고리 리스트 API',
     description: '그룹 카테고리 리스트를 조회한다.',
   })
-  @ApiCreatedResponse({
+  @ApiOkResponse({
     description: '그룹 카테고리 조회',
     type: GroupCategoryListElementResponse,
   })

--- a/BE/src/group/category/dto/group-category-list-element.response.ts
+++ b/BE/src/group/category/dto/group-category-list-element.response.ts
@@ -1,0 +1,64 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { GroupCategoryMetadata } from './group-category-metadata';
+import { dateFormat } from '../../../common/utils/date-formatter';
+import { CategoryListElementResponse } from '../../../category/dto/category-list-element.response';
+
+export class GroupCategoryListElementResponse extends CategoryListElementResponse {
+  @ApiProperty({ description: 'id' })
+  id: number;
+  @ApiProperty({ description: 'name' })
+  name: string;
+  @ApiProperty({ description: 'continued' })
+  continued: number;
+  @ApiProperty({
+    description: 'lastChallenged',
+    example: '2023-11-23T15:35:26Z',
+  })
+  lastChallenged: string;
+
+  constructor(category: GroupCategoryMetadata) {
+    super(category);
+  }
+
+  static totalCategoryElement() {
+    return new GroupCategoryListElementResponse({
+      categoryId: 0,
+      categoryName: '전체',
+      insertedAt: null,
+      achievementCount: 0,
+    });
+  }
+
+  static notAssignedCategoryElement() {
+    return new CategoryListElementResponse({
+      categoryId: -1,
+      categoryName: '미설정',
+      insertedAt: null,
+      achievementCount: 0,
+    });
+  }
+
+  static build(
+    categoryMetaData: GroupCategoryMetadata[],
+  ): GroupCategoryListElementResponse[] {
+    const totalItem = CategoryListElementResponse.totalCategoryElement();
+    const categories: CategoryListElementResponse[] = [];
+    categories.push(totalItem);
+
+    if (categoryMetaData.length === 0 || categoryMetaData[0].categoryId !== -1)
+      categories.push(CategoryListElementResponse.notAssignedCategoryElement());
+
+    categoryMetaData?.forEach((category) => {
+      if (
+        !totalItem.lastChallenged ||
+        new Date(totalItem.lastChallenged) < category.insertedAt
+      )
+        totalItem.lastChallenged = dateFormat(category.insertedAt);
+      totalItem.continued += category.achievementCount;
+
+      categories.push(new CategoryListElementResponse(category));
+    });
+
+    return categories;
+  }
+}

--- a/BE/src/group/category/dto/group-category-metadata.ts
+++ b/BE/src/group/category/dto/group-category-metadata.ts
@@ -1,0 +1,8 @@
+import { CategoryMetaData } from '../../../category/dto/category-metadata';
+import { IGroupCategoryMetaData } from '../index';
+
+export class GroupCategoryMetadata extends CategoryMetaData {
+  constructor(groupCategoryMetaData: IGroupCategoryMetaData) {
+    super(groupCategoryMetaData);
+  }
+}

--- a/BE/src/group/category/entities/group-category.entity.ts
+++ b/BE/src/group/category/entities/group-category.entity.ts
@@ -3,6 +3,7 @@ import {
   Entity,
   JoinColumn,
   ManyToOne,
+  OneToMany,
   PrimaryGeneratedColumn,
 } from 'typeorm';
 import { UserEntity } from '../../../users/entities/user.entity';
@@ -10,6 +11,7 @@ import { BaseTimeEntity } from '../../../common/entities/base.entity';
 import { GroupEntity } from '../../group/entities/group.entity';
 import { GroupCategory } from '../domain/group.category';
 import { isNullOrUndefined } from '../../../common/utils/is-null-or-undefined';
+import { GroupAchievementEntity } from '../../achievement/entities/group-achievement.entity';
 
 @Entity('group_category')
 export class GroupCategoryEntity extends BaseTimeEntity {
@@ -26,6 +28,12 @@ export class GroupCategoryEntity extends BaseTimeEntity {
 
   @Column({ name: 'name' })
   name: string;
+
+  @OneToMany(
+    () => GroupAchievementEntity,
+    (achievements) => achievements.groupCategory,
+  )
+  achievements: GroupAchievementEntity[];
 
   toModel(): GroupCategory {
     const group = new GroupCategory(

--- a/BE/src/group/category/entities/group-category.repository.spec.ts
+++ b/BE/src/group/category/entities/group-category.repository.spec.ts
@@ -13,11 +13,20 @@ import { GroupCategoryModule } from '../group-category.module';
 import { GroupCategory } from '../domain/group.category';
 import { transactionTest } from '../../../../test/common/transaction-test';
 import { CustomTypeOrmModule } from '../../../config/typeorm/custom-typeorm.module';
+import { GroupCategoryTestModule } from '../../../../test/group/category/group-category-test.module';
+import { GroupCategoryFixture } from '../../../../test/group/category/group-category-fixture';
+import { GroupAchievementFixture } from '../../../../test/group/achievement/group-achievement-fixture';
+import { GroupAchievementTestModule } from '../../../../test/group/achievement/group-achievement-test.module';
+import { ImageFixture } from '../../../../test/image/image-fixture';
+import { ImageTestModule } from '../../../../test/image/image-test.module';
 
 describe('GroupCategoryRepository test', () => {
   let groupCategoryRepository: GroupCategoryRepository;
   let userFixture: UsersFixture;
   let groupFixture: GroupFixture;
+  let groupCategoryFixture: GroupCategoryFixture;
+  let groupAchievementFixture: GroupAchievementFixture;
+  let imageFixture: ImageFixture;
   let dataSource: DataSource;
 
   beforeAll(async () => {
@@ -26,12 +35,21 @@ describe('GroupCategoryRepository test', () => {
         ConfigModule.forRoot(configServiceModuleOptions),
         TypeOrmModule.forRootAsync(typeOrmModuleOptions),
         CustomTypeOrmModule.forCustomRepository([GroupCategoryRepository]),
+        GroupCategoryTestModule,
+        GroupAchievementTestModule,
+        ImageTestModule,
         GroupTestModule,
         UsersTestModule,
         GroupCategoryModule,
       ],
     }).compile();
 
+    imageFixture = module.get<ImageFixture>(ImageFixture);
+    groupAchievementFixture = module.get<GroupAchievementFixture>(
+      GroupAchievementFixture,
+    );
+    groupCategoryFixture =
+      module.get<GroupCategoryFixture>(GroupCategoryFixture);
     userFixture = module.get<UsersFixture>(UsersFixture);
     groupFixture = module.get<GroupFixture>(GroupFixture);
     groupCategoryRepository = module.get<GroupCategoryRepository>(
@@ -70,6 +88,145 @@ describe('GroupCategoryRepository test', () => {
         expect(saved.group.avatarUrl).toEqual(group.avatarUrl);
         expect(saved.group.userGroups.length).toEqual(group.userGroups.length);
       });
+    });
+  });
+
+  describe('findByGroupAndUserWithCount는 그룹의 카테고리를 찾을 수 있다.', () => {
+    it('그룹에 생성된 카테고리가 없을 때 그룹 카테고리를 조회할 수 있다.', async () => {
+      await transactionTest(dataSource, async () => {
+        // given
+        const leader = await userFixture.getUser('ABC');
+        const group = await groupFixture.createGroups(leader);
+
+        // when
+        const categories =
+          await groupCategoryRepository.findGroupCategoriesByUser(
+            leader,
+            group,
+          );
+
+        // then
+        expect(categories.length).toEqual(0);
+      });
+    });
+
+    it('user가 요청한 그룹에 속하면 카테고리 리스트를 반환한다.', async () => {
+      await transactionTest(dataSource, async () => {
+        // given
+        const leader = await userFixture.getUser('ABC');
+        const group = await groupFixture.createGroups(leader);
+        const groupCategory = await groupCategoryFixture.createCategory(
+          leader,
+          group,
+          '그룹-카테고리~',
+        );
+
+        // when
+        const categories =
+          await groupCategoryRepository.findGroupCategoriesByUser(
+            leader,
+            group,
+          );
+
+        // then
+        expect(categories.length).toEqual(2);
+        expect(categories[0].categoryName).toEqual('미설정');
+        expect(categories[0].categoryId).toEqual(-1);
+        expect(categories[0].achievementCount).toEqual(0);
+        expect(categories[1].categoryName).toEqual('그룹-카테고리~');
+        expect(categories[1].categoryId).toEqual(groupCategory.id);
+        expect(categories[1].achievementCount).toEqual(0);
+      });
+    });
+
+    it('user가 요청한 그룹에 속하면 카테고리 리스트를 반환한다.', async () => {
+      await transactionTest(dataSource, async () => {
+        // given
+        const leader = await userFixture.getUser('ABC');
+        const group = await groupFixture.createGroups(leader);
+        const groupCategory = await groupCategoryFixture.createCategory(
+          leader,
+          group,
+          '그룹-카테고리~',
+        );
+        const image = await imageFixture.getImage(leader);
+        await groupAchievementFixture.createGroupAchievement(
+          leader,
+          group,
+          groupCategory,
+          '업적1',
+          image,
+        );
+
+        // when
+        const categories =
+          await groupCategoryRepository.findGroupCategoriesByUser(
+            leader,
+            group,
+          );
+
+        // then
+        expect(categories.length).toEqual(2);
+        expect(categories[0].categoryName).toEqual('미설정');
+        expect(categories[0].categoryId).toEqual(-1);
+        expect(categories[0].achievementCount).toEqual(0);
+        expect(categories[1].categoryName).toEqual('그룹-카테고리~');
+        expect(categories[1].achievementCount).toEqual(1);
+      });
+    });
+
+    it('user가 요청한 그룹에 속하지 않는다면 카테고리 빈 리스트를 반환한다..', async () => {
+      await transactionTest(dataSource, async () => {
+        // given
+        const leader = await userFixture.getUser('ABC');
+        const group = await groupFixture.createGroups(leader);
+        const groupCategory = await groupCategoryFixture.createCategory(
+          leader,
+          group,
+          '그룹-카테고리~',
+        );
+        const image = await imageFixture.getImage(leader);
+        await groupAchievementFixture.createGroupAchievement(
+          leader,
+          group,
+          groupCategory,
+          '업적1',
+          image,
+        );
+
+        const user = await userFixture.getUser('DEF');
+
+        // when
+        const categories =
+          await groupCategoryRepository.findGroupCategoriesByUser(user, group);
+
+        // then
+        expect(categories.length).toEqual(0);
+      });
+    });
+  });
+
+  it('findNotSpecifiedByUserAndId는 사용자의 미분류 카테고리를 조회할 수 있다.', async () => {
+    await transactionTest(dataSource, async () => {
+      // given
+      const user = await userFixture.getUser('ABC');
+      const group = await groupFixture.createGroups(user);
+      await groupCategoryFixture.createCategory(user, group, '미분류');
+      await groupAchievementFixture.createGroupAchievements(
+        4,
+        user,
+        group,
+        null,
+      );
+
+      // when
+      const retrievedCategory =
+        await groupCategoryRepository.findNotSpecifiedByUserAndId(user, group);
+
+      // then
+      expect(retrievedCategory.categoryId).toEqual(-1);
+      expect(retrievedCategory.categoryName).toEqual('미설정');
+      expect(retrievedCategory.achievementCount).toEqual(4);
     });
   });
 });

--- a/BE/src/group/category/entities/group-category.repository.ts
+++ b/BE/src/group/category/entities/group-category.repository.ts
@@ -2,6 +2,13 @@ import { GroupCategoryEntity } from './group-category.entity';
 import { CustomRepository } from '../../../config/typeorm/custom-repository.decorator';
 import { TransactionalRepository } from '../../../config/transaction-manager/transactional-repository';
 import { GroupCategory } from '../domain/group.category';
+import { GroupCategoryMetadata } from '../dto/group-category-metadata';
+import { User } from '../../../users/domain/user.domain';
+import { ICategoryMetaData } from '../../../category';
+import { CategoryMetaData } from '../../../category/dto/category-metadata';
+import { Group } from '../../group/domain/group.domain';
+import { GroupAchievementEntity } from '../../achievement/entities/group-achievement.entity';
+import { Repository } from 'typeorm';
 
 @CustomRepository(GroupCategoryEntity)
 export class GroupCategoryRepository extends TransactionalRepository<GroupCategoryEntity> {
@@ -18,5 +25,62 @@ export class GroupCategoryRepository extends TransactionalRepository<GroupCatego
       id: ctgId,
     });
     return groupCategoryEntity?.toModel();
+  }
+
+  async findGroupCategoriesByUser(
+    user: User,
+    group: Group,
+  ): Promise<GroupCategoryMetadata[]> {
+    const categoryMetaData = await this.findByUserWithCount(user, group);
+    if (categoryMetaData.length === 0) return categoryMetaData;
+
+    const notSpecified = await this.findNotSpecifiedByUserAndId(user, group);
+    return [notSpecified, ...categoryMetaData];
+  }
+
+  async findByUserWithCount(
+    user: User,
+    group: Group,
+  ): Promise<GroupCategoryMetadata[]> {
+    const categories = await this.repository
+      .createQueryBuilder('groupCategory')
+      .select('groupCategory.id as categoryId')
+      .addSelect('groupCategory.name', 'categoryName')
+      .addSelect('MAX(achievement.created_at)', 'insertedAt')
+      .addSelect('COUNT(achievement.id)', 'achievementCount')
+      .leftJoin('groupCategory.achievements', 'achievement')
+      .where('groupCategory.group_id = :groupId', { groupId: group.id })
+      .andWhere(
+        'groupCategory.group_id in (select group_id from user_group where user_id = :userId)',
+        { userId: user.id },
+      )
+      .groupBy('groupCategory.id')
+      .getRawMany<ICategoryMetaData>();
+
+    return categories.map((category) => new CategoryMetaData(category));
+  }
+
+  async findNotSpecifiedByUserAndId(
+    user: User,
+    group: Group,
+  ): Promise<GroupCategoryMetadata> {
+    const groupAchievementRepository: Repository<GroupAchievementEntity> =
+      this.repository.manager.getRepository(GroupAchievementEntity);
+
+    const category = await groupAchievementRepository
+      .createQueryBuilder('groupAchievement')
+      .select('-1 as categoryId')
+      .addSelect(`'미설정' as categoryName`)
+      .addSelect('MAX(groupAchievement.created_at)', 'insertedAt')
+      .addSelect('COUNT(groupAchievement.id)', 'achievementCount')
+      .where('groupAchievement.group_category_id is NULL')
+      .andWhere('groupAchievement.group_id = :groupId', { groupId: group.id })
+      .andWhere(
+        'groupAchievement.group_id in (select group_id from user_group where user_id = :userId)',
+        { userId: user.id },
+      )
+      .getRawOne<ICategoryMetaData>();
+
+    return new CategoryMetaData(category);
   }
 }

--- a/BE/src/group/category/exception/unauthorized-approach-group-category.exception.ts
+++ b/BE/src/group/category/exception/unauthorized-approach-group-category.exception.ts
@@ -1,0 +1,8 @@
+import { MotimateException } from '../../../common/exception/motimate.excpetion';
+import { ERROR_INFO } from '../../../common/exception/error-code';
+
+export class UnauthorizedApproachGroupCategoryException extends MotimateException {
+  constructor() {
+    super(ERROR_INFO.UNAUTHORIZED_APPROACH_GROUP_CATEGORY);
+  }
+}

--- a/BE/src/group/category/index.ts
+++ b/BE/src/group/category/index.ts
@@ -1,0 +1,3 @@
+import { ICategoryMetaData } from '../../category';
+
+export interface IGroupCategoryMetaData extends ICategoryMetaData {}


### PR DESCRIPTION
## PR 요약
그룹의 카테고리 리스트 API를 작성한다.

#### 변경 사항
- 그룹의 카테고리 리스트 API를 작성
- 기존 카테고리 리스팅 이슈 해결

##### 스크린샷

* 개인 카테고리

![image](https://github.com/boostcampwm2023/iOS02-moti/assets/75921696/5a8edf48-cd54-4977-b1e7-2297d8d3ed77)

* 그룹 사용자가 아닐 때 조회

![image](https://github.com/boostcampwm2023/iOS02-moti/assets/75921696/8463f3d9-eceb-4eac-a55b-acebb02290e8)

* 그룹장의 조회

![image](https://github.com/boostcampwm2023/iOS02-moti/assets/75921696/c5a6354e-28c4-4deb-95ea-018a7f7132fe)

* 그룹원의 조회

![image](https://github.com/boostcampwm2023/iOS02-moti/assets/75921696/932b78e1-d089-4773-8dca-36e077a443ed)


#### Linked Issue
close #463
