### PR TITLE
그룹 홈 페이지네이션, 리프레시, 탭바 숨기기 적용 / 탭바 버그 수정

### DIFF
--- a/iOS/moti/moti/Data/Sources/Data/Network/Endpoint/MotiAPI.swift
+++ b/iOS/moti/moti/Data/Sources/Data/Network/Endpoint/MotiAPI.swift
@@ -142,6 +142,8 @@ extension MotiAPI {
         switch self {
         case .fetchAchievementList(let requestValue):
             return requestValue
+        case .fetchGroupAchievementList(let requestValue, _):
+            return requestValue
         default:
             return nil
         }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Capture/CaptureViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Capture/CaptureViewController.swift
@@ -16,7 +16,7 @@ protocol CaptureViewControllerDelegate: AnyObject {
     func didCapture(image: UIImage)
 }
 
-final class CaptureViewController: BaseViewController<CaptureView>, HiddenTabBarViewController {
+final class CaptureViewController: BaseViewController<CaptureView> {
     
     // MARK: - Properties
     weak var delegate: CaptureViewControllerDelegate?

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Celebrate/CelebrateViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Celebrate/CelebrateViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 import Design
 import Domain
 
-final class CelebrateViewController: UIViewController, HiddenTabBarViewController {
+final class CelebrateViewController: UIViewController {
     
     // MARK: - Properties
     private let achievement: Achievement

--- a/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementViewController.swift
@@ -16,7 +16,7 @@ protocol EditAchievementViewControllerDelegate: AnyObject {
     func doneButtonDidClickedFromCaptureView(newAchievement: Achievement)
 }
 
-final class EditAchievementViewController: BaseViewController<EditAchievementView>, HiddenTabBarViewController {
+final class EditAchievementViewController: BaseViewController<EditAchievementView> {
     
     // MARK: - Properties
     weak var coordinator: EditAchievementCoordinator?

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeViewController.swift
@@ -17,7 +17,8 @@ final class GroupHomeViewController: BaseViewController<HomeView>, LoadingIndica
     weak var coordinator: GroupHomeCoordinator?
     private let viewModel: GroupHomeViewModel
     private var cancellables: Set<AnyCancellable> = []
-    
+    private var isFetchingNextPage = false
+
     // MARK: - Init
     init(viewModel: GroupHomeViewModel) {
         self.viewModel = viewModel
@@ -47,6 +48,7 @@ final class GroupHomeViewController: BaseViewController<HomeView>, LoadingIndica
         if let tabBarController = navigationController?.tabBarController as? TabBarViewController {
             tabBarController.captureButton.addTarget(self, action: #selector(captureButtonDidClicked), for: .touchUpInside)
         }
+        layoutView.refreshControl.addTarget(self, action: #selector(refreshAchievementList), for: .valueChanged)
     }
     
     @objc private func captureButtonDidClicked() {
@@ -72,6 +74,10 @@ final class GroupHomeViewController: BaseViewController<HomeView>, LoadingIndica
         }
         
         present(textFieldAlertVC, animated: true)
+    }
+    
+    @objc private func refreshAchievementList() {
+        viewModel.action(.refreshAchievementList)
     }
     
     // MARK: - Setup
@@ -356,6 +362,41 @@ extension GroupHomeViewController: UICollectionViewDelegate {
         return config
 
     }
+    
+    func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+        // 드래그를 시작하면 탭바 숨기기
+        if let tabBarController = tabBarController as? TabBarViewController {
+            tabBarController.hideTabBar()
+        }
+    }
+    
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        let actualPos = scrollView.panGestureRecognizer.translation(in: scrollView.superview)
+        let pos = scrollView.contentOffset.y
+        let diff = layoutView.achievementCollectionView.contentSize.height - scrollView.frame.size.height
+     
+        // 아래로 드래그 && 마지막까지 스크롤
+        if actualPos.y < 0 && pos > diff && !isFetchingNextPage {
+            Logger.debug("Fetch New Data")
+            isFetchingNextPage = true
+            viewModel.action(.fetchNextPage)
+        }
+    }
+    
+    func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+        // 감속을 아예 하지 않으면 탭바를 보인다. -> 드래그를 천천히 하는 상황
+        if !decelerate, let tabBarController = tabBarController as? TabBarViewController {
+            tabBarController.showTabBar()
+        }
+    }
+    
+    // 스크롤뷰 움직임이 끝날 때 호출
+    func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+        // 스크롤뷰 감속이 끝나면 탭바를 보인다.
+        if let tabBarController = tabBarController as? TabBarViewController {
+            tabBarController.showTabBar()
+        }
+    }
 }
 
 // MARK: - Binding
@@ -377,9 +418,12 @@ private extension GroupHomeViewController {
                 case .loading:
                     break
                 case .finish:
-                    break
+                    isFetchingNextPage = false
+                    layoutView.endRefreshing()
                 case .error(let message):
                     Logger.error("Fetch Achievement Error: \(message)")
+                    isFetchingNextPage = false
+                    layoutView.endRefreshing()
                 }
             }
             .store(in: &cancellables)

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeViewController.swift
@@ -42,6 +42,13 @@ final class GroupHomeViewController: BaseViewController<HomeView>, LoadingIndica
         viewModel.action(.launch)
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        if let tabBarController = tabBarController as? TabBarViewController {
+            tabBarController.showTabBar()
+        }
+    }
+    
     // MARK: - Actions
     private func addTargets() {
         layoutView.categoryAddButton.addTarget(self, action: #selector(showAddGroupCategoryAlert), for: .touchUpInside)
@@ -52,8 +59,9 @@ final class GroupHomeViewController: BaseViewController<HomeView>, LoadingIndica
     }
     
     @objc private func captureButtonDidClicked() {
-        coordinator?.moveToCaptureViewController(group: viewModel.group)
-        if let tabBarController = tabBarController as? TabBarViewController {
+        if let tabBarController = tabBarController as? TabBarViewController,
+           tabBarController.selectedIndex == 1 {
+            coordinator?.moveToCaptureViewController(group: viewModel.group)
             tabBarController.hideTabBar()
         }
     }
@@ -229,7 +237,7 @@ private extension GroupHomeViewController {
             placeholder: "초대할 유저의 7자리 유저코드를 입력하세요.",
             okAction: { text in
                 guard let text = text else { return }
-                print("초대할 유저코드: \(text)")
+                Logger.debug("초대할 유저코드: \(text)")
                 self.viewModel.action(.invite(userCode: text))
             }
         )

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeViewModel.swift
@@ -299,7 +299,6 @@ private extension GroupHomeViewModel {
 private extension GroupHomeViewModel {
     /// 도전 기록을 가져오는 메서드
     func fetchAchievementList(requestValue: FetchAchievementListRequestValue? = nil) {
-        print("pagination: \(requestValue)")
         if requestValue?.whereIdLessThan == nil {
             // 새로운 카테고리 데이터를 가져오기 때문에 빈 배열로 초기화
             achievements = skeletonAchievements

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeViewModel.swift
@@ -299,6 +299,7 @@ private extension GroupHomeViewModel {
 private extension GroupHomeViewModel {
     /// 도전 기록을 가져오는 메서드
     func fetchAchievementList(requestValue: FetchAchievementListRequestValue? = nil) {
+        print("pagination: \(requestValue)")
         if requestValue?.whereIdLessThan == nil {
             // 새로운 카테고리 데이터를 가져오기 때문에 빈 배열로 초기화
             achievements = skeletonAchievements

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupList/GroupListViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupList/GroupListViewController.swift
@@ -232,7 +232,6 @@ extension GroupListViewController: LoadingIndicator {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] state in
                 guard let self else { return }
-                print("refetchGroupListState ..:\(state)")
                 switch state {
                 case .loading:
                     showLoadingIndicator()

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/Cell/AchievementCollectionViewCell.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/Cell/AchievementCollectionViewCell.swift
@@ -43,7 +43,7 @@ final class AchievementCollectionViewCell: UICollectionViewCell {
     
     func configure(imageURL: URL?) {
         if let imageURL {
-            imageView.jf.setImage(with: imageURL, placeHolder: MotiImage.skeleton, waitPlaceHolderTime: 1)
+            imageView.jf.setImage(with: imageURL, placeHolder: MotiImage.skeleton, waitPlaceHolderTime: 1, options: [.downsamplingScale(1.5)])
         } else {
             imageView.image = MotiImage.skeleton
             imageView.backgroundColor = .primaryDarkGray

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewController.swift
@@ -65,11 +65,11 @@ final class HomeViewController: BaseViewController<HomeView>, LoadingIndicator {
     }
     
     func achievementDidPosted(newAchievement: Achievement) {
-        viewModel.action(.postAchievement(newAchievement: newAchievement))
-        // 화면이 전환되고 즉시 표시하면 애니메이션이 부자연스러움
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-            self.showCelebrate(with: newAchievement)
+        if let tabBarController = tabBarController as? TabBarViewController {
+            tabBarController.showTabBar()
         }
+        viewModel.action(.postAchievement(newAchievement: newAchievement))
+        showCelebrate(with: newAchievement)
     }
     
     private func addTargets() {
@@ -82,8 +82,9 @@ final class HomeViewController: BaseViewController<HomeView>, LoadingIndicator {
     }
     
     @objc private func captureButtonDidClicked() {
-        coordinator?.moveToCaptureViewController()
-        if let tabBarController = tabBarController as? TabBarViewController {
+        if let tabBarController = tabBarController as? TabBarViewController,
+           tabBarController.selectedIndex == 0 {
+            coordinator?.moveToCaptureViewController()
             tabBarController.hideTabBar()
         }
     }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/TabBar/TabBarCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/TabBar/TabBarCoordinator.swift
@@ -52,12 +52,6 @@ public final class TabBarCoordinator: Coordinator {
     private func configureTabBarControllers(with viewControllers: [UIViewController]) {
         tabBarController.setupViewControllers(with: viewControllers)
     }
-  
-    private func moveCaptureViewController() {
-        let captureCoordinator = CaptureCoordinator(navigationController, self)
-        captureCoordinator.start()
-        childCoordinators.append(captureCoordinator)
-    }
 }
 
 // MARK: - Make Child ViewControllers


### PR DESCRIPTION
## PR 요약
- 그룹 홈 화면 페이지네이션, 리프레시, 스크롤할 때 탭바 숨기기 구현 (개인 홈처럼)
- 포스팅 후 탭바 안 나오는 버그 수정
    - HiddenTabBarViewController를 잘못 구현한듯. 나중에 개선해보겠음. 지금은 꼭 필요한 곳만 채택해둠
- 촬영 화면 여러 번 나오는 버그 수정
    - 캡처버튼 액션 중복 실행 문제였음

#### Linked Issue
close #487 