### PR TITLE
단 건의 그룹 카테고리 정보를 조회하는 API를 작성한다. 

### DIFF
--- a/BE/src/common/pipe/parse-int.pipe.ts
+++ b/BE/src/common/pipe/parse-int.pipe.ts
@@ -13,6 +13,6 @@ export class ParseIntPipe implements PipeTransform {
     return parseInt(value);
   }
   private isIntNumeric(str: string) {
-    return /^\d+$/.test(str);
+    return /^-?\d+$/.test(str);
   }
 }

--- a/BE/src/group/category/application/group-category.service.spec.ts
+++ b/BE/src/group/category/application/group-category.service.spec.ts
@@ -384,4 +384,230 @@ describe('GroupCategoryService test', () => {
       });
     });
   });
+
+  describe('retrieveCategoryMetadataById는 그룹의 카테고리 메타데이터를 조회할 수 있다.', () => {
+    it('그룹장은 그룹의 카테고리 메타데이터를 조회할 수 있다.', async () => {
+      await transactionTest(dataSource, async () => {
+        // given
+        const leader = await usersFixture.getUser('ABC');
+        const group = await groupFixture.createGroups(leader);
+        const groupCategory = await groupCategoryFixture.createCategory(
+          leader,
+          group,
+          '카테고리1',
+        );
+
+        await groupAchievementFixture.createGroupAchievement(
+          leader,
+          group,
+          groupCategory,
+          '업적1',
+        );
+
+        // when
+        const category =
+          await groupCategoryService.retrieveCategoryMetadataById(
+            leader,
+            group.id,
+            groupCategory.id,
+          );
+
+        // then
+        expect(category.categoryName).toEqual('카테고리1');
+        expect(category.categoryId).toEqual(groupCategory.id);
+        expect(category.achievementCount).toEqual(1);
+      });
+    });
+
+    it('그룹장은 그룹의 카테고리에 저장된 도전기록이 없어도 메타데이터를 조회할 수 있다.', async () => {
+      await transactionTest(dataSource, async () => {
+        // given
+        const leader = await usersFixture.getUser('ABC');
+        const group = await groupFixture.createGroups(leader);
+        const groupCategory = await groupCategoryFixture.createCategory(
+          leader,
+          group,
+          '카테고리1',
+        );
+
+        // when
+        const category =
+          await groupCategoryService.retrieveCategoryMetadataById(
+            leader,
+            group.id,
+            groupCategory.id,
+          );
+
+        // then
+        expect(category.categoryName).toEqual('카테고리1');
+        expect(category.categoryId).toEqual(groupCategory.id);
+        expect(category.achievementCount).toEqual(0);
+      });
+    });
+
+    it('그룹 멤버는 그룹의 카테고리 메타데이터를 조회할 수 있다.', async () => {
+      await transactionTest(dataSource, async () => {
+        // given
+        const leader = await usersFixture.getUser('ABC');
+        const participants = await usersFixture.getUsers(5);
+
+        const group = await groupFixture.createGroups(leader, participants);
+        const groupCategory = await groupCategoryFixture.createCategory(
+          leader,
+          group,
+          '카테고리1',
+        );
+
+        await groupAchievementFixture.createGroupAchievement(
+          leader,
+          group,
+          groupCategory,
+          '업적1',
+        );
+
+        // when
+        const category =
+          await groupCategoryService.retrieveCategoryMetadataById(
+            participants[0],
+            group.id,
+            groupCategory.id,
+          );
+
+        // then
+        expect(category.categoryName).toEqual('카테고리1');
+        expect(category.categoryId).toEqual(groupCategory.id);
+        expect(category.achievementCount).toEqual(1);
+      });
+    });
+
+    it('그룹 관리자는 그룹의 카테고리 메타데이터를 조회할 수 있다.', async () => {
+      await transactionTest(dataSource, async () => {
+        // given
+        const leader = await usersFixture.getUser('ABC');
+        const participants = await usersFixture.getUsers(5);
+        const managers = await usersFixture.getUsers(5);
+
+        const group = await groupFixture.createGroups(
+          leader,
+          participants,
+          managers,
+        );
+        const groupCategory = await groupCategoryFixture.createCategory(
+          leader,
+          group,
+          '카테고리1',
+        );
+
+        await groupAchievementFixture.createGroupAchievement(
+          leader,
+          group,
+          groupCategory,
+          '업적1',
+        );
+
+        // when
+        const category =
+          await groupCategoryService.retrieveCategoryMetadataById(
+            managers[4],
+            group.id,
+            groupCategory.id,
+          );
+
+        // then
+        expect(category.categoryName).toEqual('카테고리1');
+        expect(category.categoryId).toEqual(groupCategory.id);
+        expect(category.achievementCount).toEqual(1);
+      });
+    });
+
+    it('그룹 멤버는 그룹의 카테고리 메타데이터를 조회할 수 있다.', async () => {
+      await transactionTest(dataSource, async () => {
+        // given
+        const leader = await usersFixture.getUser('ABC');
+        const participants = await usersFixture.getUsers(5);
+
+        const group = await groupFixture.createGroups(leader, participants);
+        const groupCategory = await groupCategoryFixture.createCategory(
+          leader,
+          group,
+          '카테고리1',
+        );
+
+        await groupAchievementFixture.createGroupAchievement(
+          leader,
+          group,
+          groupCategory,
+          '업적1',
+        );
+
+        // when
+        const category =
+          await groupCategoryService.retrieveCategoryMetadataById(
+            participants[0],
+            group.id,
+            groupCategory.id,
+          );
+
+        // then
+        expect(category.categoryName).toEqual('카테고리1');
+        expect(category.categoryId).toEqual(groupCategory.id);
+        expect(category.achievementCount).toEqual(1);
+      });
+    });
+
+    it('그룹에 속하지 않은 사용자가 그룹의 카테고리 메타데이터를 조회할 수 없다.', async () => {
+      await transactionTest(dataSource, async () => {
+        // given
+        const leader = await usersFixture.getUser('ABC');
+        const participants = await usersFixture.getUsers(5);
+
+        const group = await groupFixture.createGroups(leader, participants);
+        const groupCategory = await groupCategoryFixture.createCategory(
+          leader,
+          group,
+          '카테고리1',
+        );
+
+        const other = await usersFixture.getUser('DEF');
+
+        // when
+        // then
+        await expect(
+          groupCategoryService.retrieveCategoryMetadataById(
+            other,
+            group.id,
+            groupCategory.id,
+          ),
+        ).rejects.toThrow(UnauthorizedApproachGroupCategoryException);
+      });
+    });
+
+    it('그룹에 속하지 않은 사용자가 그룹의 카테고리 메타데이터를 조회할 수 없다.', async () => {
+      await transactionTest(dataSource, async () => {
+        // given
+        const leader = await usersFixture.getUser('ABC');
+        const participants = await usersFixture.getUsers(5);
+
+        const group = await groupFixture.createGroups(leader, participants);
+        const groupCategory = await groupCategoryFixture.createCategory(
+          leader,
+          group,
+          '카테고리1',
+        );
+
+        const other = await usersFixture.getUser('DEF');
+        await groupFixture.createGroups(other);
+
+        // when
+        // then
+        await expect(
+          groupCategoryService.retrieveCategoryMetadataById(
+            other,
+            group.id,
+            groupCategory.id,
+          ),
+        ).rejects.toThrow(UnauthorizedApproachGroupCategoryException);
+      });
+    });
+  });
 });

--- a/BE/src/group/category/application/group-category.service.ts
+++ b/BE/src/group/category/application/group-category.service.ts
@@ -32,6 +32,16 @@ export class GroupCategoryService {
     return this.groupCategoryRepository.findGroupCategoriesByUser(user, group);
   }
 
+  @Transactional({ readonly: true })
+  async retrieveCategoryMetadataById(
+    user: User,
+    groupId: number,
+    categoryId: number,
+  ) {
+    const group = await this.getGroup(user, groupId);
+    return this.groupCategoryRepository.findGroupCategory(group, categoryId);
+  }
+
   private async getGroupByLeader(user: User, groupId: number) {
     const group = await this.groupRepository.findGroupByIdAndLeaderUser(
       user,

--- a/BE/src/group/category/controller/group-category.controller.ts
+++ b/BE/src/group/category/controller/group-category.controller.ts
@@ -66,4 +66,29 @@ export class GroupCategoryController {
       GroupCategoryListElementResponse.build(groupCategory),
     );
   }
+
+  @ApiBearerAuth('accessToken')
+  @ApiOperation({
+    summary: '그룹 카테고리 단 건 조회 API',
+    description: '특정 그룹 카테고리를 조회한다.',
+  })
+  @ApiOkResponse({
+    description: '그룹 카테고리 조회',
+    type: GroupCategoryListElementResponse,
+  })
+  @Get(':categoryId')
+  @UseGuards(AccessTokenGuard)
+  async category(
+    @AuthenticatedUser() user: User,
+    @Param('groupId', ParseIntPipe) groupId: number,
+    @Param('categoryId', ParseIntPipe) categoryId: number,
+  ): Promise<ApiData<GroupCategoryListElementResponse>> {
+    const groupCategory =
+      await this.groupCategoryService.retrieveCategoryMetadataById(
+        user,
+        groupId,
+        categoryId,
+      );
+    return ApiData.success(new GroupCategoryListElementResponse(groupCategory));
+  }
 }

--- a/BE/src/group/category/entities/group-category.repository.spec.ts
+++ b/BE/src/group/category/entities/group-category.repository.spec.ts
@@ -221,12 +221,76 @@ describe('GroupCategoryRepository test', () => {
 
       // when
       const retrievedCategory =
-        await groupCategoryRepository.findNotSpecifiedByUserAndId(user, group);
+        await groupCategoryRepository.findNotSpecifiedByUserAndId(group);
 
       // then
       expect(retrievedCategory.categoryId).toEqual(-1);
       expect(retrievedCategory.categoryName).toEqual('미설정');
       expect(retrievedCategory.achievementCount).toEqual(4);
+    });
+  });
+
+  describe('findByUserWithCount는 사용자의 그룹 카테고리를 조회할 수 있다.', () => {
+    it('사용자의 그룹 카테고리를 조회할 수 있다.', async () => {
+      await transactionTest(dataSource, async () => {
+        // given
+        const user = await userFixture.getUser('ABC');
+        const group = await groupFixture.createGroups(user);
+        const groupCategory = await groupCategoryFixture.createCategory(
+          user,
+          group,
+          '카테고리 테스트',
+        );
+        await groupAchievementFixture.createGroupAchievements(
+          4,
+          user,
+          group,
+          groupCategory,
+        );
+
+        // when
+        const retrievedCategory =
+          await groupCategoryRepository.findByUserWithCount(
+            group,
+            groupCategory.id,
+          );
+
+        // then
+        expect(retrievedCategory.categoryId).toEqual(groupCategory.id);
+        expect(retrievedCategory.categoryName).toEqual('카테고리 테스트');
+        expect(retrievedCategory.achievementCount).toEqual(4);
+      });
+    });
+
+    it('사용자의 그룹 카테고리를 조회할 수 있다.', async () => {
+      await transactionTest(dataSource, async () => {
+        // given
+        const user = await userFixture.getUser('ABC');
+        const group = await groupFixture.createGroups(user);
+        const groupCategory = await groupCategoryFixture.createCategory(
+          user,
+          group,
+          '카테고리 테스트',
+        );
+        await groupAchievementFixture.createGroupAchievements(
+          4,
+          user,
+          group,
+          groupCategory,
+        );
+
+        // when
+        const retrievedCategory =
+          await groupCategoryRepository.findByUserWithCount(
+            group,
+            groupCategory.id,
+          );
+
+        // then
+        expect(retrievedCategory.categoryId).toEqual(groupCategory.id);
+        expect(retrievedCategory.categoryName).toEqual('카테고리 테스트');
+        expect(retrievedCategory.achievementCount).toEqual(4);
+      });
     });
   });
 });

--- a/BE/src/group/category/entities/group-category.repository.ts
+++ b/BE/src/group/category/entities/group-category.repository.ts
@@ -31,14 +31,19 @@ export class GroupCategoryRepository extends TransactionalRepository<GroupCatego
     user: User,
     group: Group,
   ): Promise<GroupCategoryMetadata[]> {
-    const categoryMetaData = await this.findByUserWithCount(user, group);
+    const categoryMetaData = await this.findAllByUserWithCount(user, group);
     if (categoryMetaData.length === 0) return categoryMetaData;
 
-    const notSpecified = await this.findNotSpecifiedByUserAndId(user, group);
+    const notSpecified = await this.findNotSpecifiedByUserAndId(group);
     return [notSpecified, ...categoryMetaData];
   }
 
-  async findByUserWithCount(
+  async findGroupCategory(group: Group, categoryId: number) {
+    if (categoryId === -1) return this.findNotSpecifiedByUserAndId(group);
+    return this.findByUserWithCount(group, categoryId);
+  }
+
+  async findAllByUserWithCount(
     user: User,
     group: Group,
   ): Promise<GroupCategoryMetadata[]> {
@@ -60,8 +65,26 @@ export class GroupCategoryRepository extends TransactionalRepository<GroupCatego
     return categories.map((category) => new CategoryMetaData(category));
   }
 
+  async findByUserWithCount(
+    group: Group,
+    categoryId: number,
+  ): Promise<GroupCategoryMetadata> {
+    const category = await this.repository
+      .createQueryBuilder('groupCategory')
+      .select('groupCategory.id as categoryId')
+      .addSelect('groupCategory.name', 'categoryName')
+      .addSelect('MAX(achievement.created_at)', 'insertedAt')
+      .addSelect('COUNT(achievement.id)', 'achievementCount')
+      .leftJoin('groupCategory.achievements', 'achievement')
+      .where('groupCategory.group_id = :groupId', { groupId: group.id })
+      .andWhere('groupCategory.id = :categoryId', { categoryId })
+      .groupBy('groupCategory.id')
+      .getRawOne<ICategoryMetaData>();
+
+    return category ? new CategoryMetaData(category) : null;
+  }
+
   async findNotSpecifiedByUserAndId(
-    user: User,
     group: Group,
   ): Promise<GroupCategoryMetadata> {
     const groupAchievementRepository: Repository<GroupAchievementEntity> =
@@ -75,10 +98,6 @@ export class GroupCategoryRepository extends TransactionalRepository<GroupCatego
       .addSelect('COUNT(groupAchievement.id)', 'achievementCount')
       .where('groupAchievement.group_category_id is NULL')
       .andWhere('groupAchievement.group_id = :groupId', { groupId: group.id })
-      .andWhere(
-        'groupAchievement.group_id in (select group_id from user_group where user_id = :userId)',
-        { userId: user.id },
-      )
       .getRawOne<ICategoryMetaData>();
 
     return new CategoryMetaData(category);


### PR DESCRIPTION
## PR 요약
* 단 건의 그룹 카테고리 정보를 조회하는 API

#### 변경 사항
* 단 건의 카테고리 조회 API
* 기존의 ParseIntPipe 음수가 가능하도록 수정

##### 스크린샷

* 그룹에 속하지 않는 사용자의 요청

![image](https://github.com/boostcampwm2023/iOS02-moti/assets/75921696/4bd8f70f-14d3-4fd4-881a-f9116476aeab)

* 그룹에 속한 사용자의 요청

![image](https://github.com/boostcampwm2023/iOS02-moti/assets/75921696/aa23ea59-2bd8-4619-84a2-37a06fa64377)

* 그룹장의 요청

![image](https://github.com/boostcampwm2023/iOS02-moti/assets/75921696/afda5c00-c00e-498f-a2bc-79cb23b1f3a4)



#### Linked Issue
close #485