### PR TITLE
그룹 달성 기록 삭제 및 수정 기능 

### DIFF
--- a/BE/src/group/achievement/application/group-achievement.service.spec.ts
+++ b/BE/src/group/achievement/application/group-achievement.service.spec.ts
@@ -28,9 +28,11 @@ import { PaginateAchievementRequest } from '../../../achievement/dto/paginate-ac
 import { PaginateGroupAchievementRequest } from '../dto/paginate-group-achievement-request';
 import { UsersService } from '../../../users/application/users.service';
 import { UsersModule } from '../../../users/users.module';
+import { GroupAchievementRepository } from '../entities/group-achievement.repository';
 
 describe('GroupAchievementService Test', () => {
   let groupAchievementService: GroupAchievementService;
+  let groupAchievementRepository: GroupAchievementRepository;
   let userService: UsersService;
   let usersFixture: UsersFixture;
   let groupFixture: GroupFixture;
@@ -58,6 +60,9 @@ describe('GroupAchievementService Test', () => {
 
     groupAchievementService = module.get<GroupAchievementService>(
       GroupAchievementService,
+    );
+    groupAchievementRepository = module.get<GroupAchievementRepository>(
+      GroupAchievementRepository,
     );
     userService = module.get<UsersService>(UsersService);
     imageFixture = module.get<ImageFixture>(ImageFixture);
@@ -539,6 +544,86 @@ describe('GroupAchievementService Test', () => {
       expect(paginateGroupAchievementResponse.count).toEqual(10);
       expect(paginateGroupAchievementResponse.data.length).toEqual(10);
       expect(paginateGroupAchievementResponse.next).toEqual(null);
+    });
+  });
+
+  test('내가 작성한 달성기록을 삭제할 수 있다.', async () => {
+    await transactionTest(dataSource, async () => {
+      // given
+      const user = await usersFixture.getUser('ABC');
+      const group = await groupFixture.createGroup('GROUP', user);
+      const groupAchievement =
+        await groupAchievementFixture.createGroupAchievement(
+          user,
+          group,
+          null,
+          'title',
+        );
+
+      // when
+      await groupAchievementService.delete(
+        user.id,
+        group.id,
+        groupAchievement.id,
+      );
+      const findOne =
+        await groupAchievementRepository.findOneByIdAndUserAndGroup(
+          user.id,
+          group.id,
+          groupAchievement.id,
+        );
+
+      // then
+      expect(findOne).toBeUndefined();
+    });
+  });
+
+  test('남의 달성기록을 삭제하려하면 NoSuchGroupAchievementException를 던진다.', async () => {
+    await transactionTest(dataSource, async () => {
+      // given
+      const user1 = await usersFixture.getUser('ABC');
+      const user2 = await usersFixture.getUser('DEF');
+      const group = await groupFixture.createGroup('GROUP1', user1);
+      await groupFixture.addMember(group, user2, UserGroupGrade.PARTICIPANT);
+      const groupAchievement =
+        await groupAchievementFixture.createGroupAchievement(
+          user1,
+          group,
+          null,
+          'title',
+        );
+
+      // when
+      // then
+      await expect(
+        groupAchievementService.delete(user2.id, group.id, groupAchievement.id),
+      ).rejects.toThrow(NoSuchGroupAchievementException);
+    });
+  });
+  test('다른 그룹의 달성을 삭제하려하면 NoSuchGroupAchievementException를 던진다.', async () => {
+    await transactionTest(dataSource, async () => {
+      // given
+      const user1 = await usersFixture.getUser('ABC');
+      const user2 = await usersFixture.getUser('DEF');
+      const group1 = await groupFixture.createGroup('GROUP1', user1);
+      const group2 = await groupFixture.createGroup('GROUP2', user2);
+      const groupAchievement =
+        await groupAchievementFixture.createGroupAchievement(
+          user1,
+          group1,
+          null,
+          'title',
+        );
+
+      // when
+      // then
+      await expect(
+        groupAchievementService.delete(
+          user2.id,
+          group1.id,
+          groupAchievement.id,
+        ),
+      ).rejects.toThrow(NoSuchGroupAchievementException);
     });
   });
 });

--- a/BE/src/group/achievement/application/group-achievement.service.ts
+++ b/BE/src/group/achievement/application/group-achievement.service.ts
@@ -19,6 +19,7 @@ import { UnauthorizedAchievementException } from '../../../achievement/exception
 import { PaginateGroupAchievementRequest } from '../dto/paginate-group-achievement-request';
 import { PaginateGroupAchievementResponse } from '../dto/paginate-group-achievement-response';
 import { GroupAchievementResponse } from '../dto/group-achievement-response';
+import { GroupAchievementDeleteResponse } from '../dto/group-achievement-delete-response';
 
 @Injectable()
 export class GroupAchievementService {
@@ -128,6 +129,31 @@ export class GroupAchievementService {
       );
     if (!achievement) throw new NoSuchAchievementException();
 
+    return achievement;
+  }
+
+  async delete(userId: number, groupId: number, achievementId: number) {
+    const achievement = await this.getAchievement(
+      achievementId,
+      userId,
+      groupId,
+    );
+    await this.groupAchievementRepository.repository.softDelete(achievement.id);
+    return GroupAchievementDeleteResponse.from(achievement);
+  }
+
+  private async getAchievement(
+    achieveId: number,
+    userId: number,
+    groupId: number,
+  ) {
+    const achievement =
+      await this.groupAchievementRepository.findOneByIdAndUserAndGroup(
+        achieveId,
+        userId,
+        groupId,
+      );
+    if (!achievement) throw new NoSuchGroupAchievementException();
     return achievement;
   }
 }

--- a/BE/src/group/achievement/application/group-achievement.service.ts
+++ b/BE/src/group/achievement/application/group-achievement.service.ts
@@ -20,6 +20,8 @@ import { PaginateGroupAchievementRequest } from '../dto/paginate-group-achieveme
 import { PaginateGroupAchievementResponse } from '../dto/paginate-group-achievement-response';
 import { GroupAchievementResponse } from '../dto/group-achievement-response';
 import { GroupAchievementDeleteResponse } from '../dto/group-achievement-delete-response';
+import { GroupAchievementUpdateRequest } from '../dto/group-achievement-update-request';
+import { GroupAchievementUpdateResponse } from '../dto/group-achievement-update-response';
 
 @Injectable()
 export class GroupAchievementService {
@@ -92,6 +94,33 @@ export class GroupAchievementService {
         GroupAchievementResponse.from(achievement),
       ),
     );
+  }
+  @Transactional()
+  async update(
+    userId: number,
+    groupId: number,
+    achievementId: number,
+    groupAchievementUpdateRequest: GroupAchievementUpdateRequest,
+  ) {
+    const achievement =
+      await this.groupAchievementRepository.findOneByIdAndUserAndGroup(
+        achievementId,
+        userId,
+        groupId,
+      );
+    if (!achievement) throw new NoSuchGroupAchievementException();
+
+    const category = await this.groupCategoryRepository.findByIdAndGroup(
+      groupId,
+      groupAchievementUpdateRequest.categoryId,
+    );
+
+    achievement.update(
+      groupAchievementUpdateRequest.toAchievementUpdate(category),
+    );
+    const updated =
+      await this.groupAchievementRepository.saveAchievement(achievement);
+    return GroupAchievementUpdateResponse.from(updated);
   }
   private async getCategory(userId: number, ctgId: number) {
     if (ctgId === -1) return null;

--- a/BE/src/group/achievement/controller/group-achievement.controller.spec.ts
+++ b/BE/src/group/achievement/controller/group-achievement.controller.spec.ts
@@ -27,6 +27,7 @@ import { GroupAchievementDetailResponse } from '../dto/group-achievement-detail-
 import { PaginateGroupAchievementResponse } from '../dto/paginate-group-achievement-response';
 import { PaginateGroupAchievementRequest } from '../dto/paginate-group-achievement-request';
 import { UnauthorizedAchievementException } from '../../../achievement/exception/unauthorized-achievement.exception';
+import { GroupAchievementDeleteResponse } from '../dto/group-achievement-delete-response';
 
 describe('GroupAchievementController', () => {
   let app: INestApplication;
@@ -530,6 +531,94 @@ describe('GroupAchievementController', () => {
       // then
       return request(app.getHttpServer())
         .get('/api/v1/groups/1/achievements/1007')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(401)
+        .expect((res: request.Response) => {
+          expect(res.body.success).toBe(false);
+          expect(res.body.message).toBe('만료된 토큰입니다.');
+        });
+    });
+  });
+
+  describe('내가 작성한 달성기록을 삭제할 수 있다.', () => {
+    it('성공 시 200을 반환한다.', async () => {
+      // given
+      const { accessToken, user } =
+        await authFixture.getAuthenticatedUser('ABC');
+
+      const groupAchievementDeleteResponse = new GroupAchievementDeleteResponse(
+        1,
+      );
+
+      when(
+        mockGroupAchievementService.delete(
+          anyNumber(),
+          anyNumber(),
+          anyNumber(),
+        ),
+      ).thenResolve(groupAchievementDeleteResponse);
+
+      // when
+      // then
+      return request(app.getHttpServer())
+        .delete('/api/v1/groups/1/achievements/1')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(200)
+        .expect((res: request.Response) => {
+          expect(res.body.success).toBe(true);
+          expect(res.body.data).toEqual({ id: 1 });
+        });
+    });
+
+    it('삭제할 수 없는 달성기록에 대해 400을 반환한다.', async () => {
+      // given
+      const { accessToken } = await authFixture.getAuthenticatedUser('ABC');
+
+      when(
+        mockGroupAchievementService.delete(
+          anyNumber(),
+          anyNumber(),
+          anyNumber(),
+        ),
+      ).thenThrow(new NoSuchGroupAchievementException());
+
+      // when
+      // then
+      return request(app.getHttpServer())
+        .delete('/api/v1/groups/1/achievements/1')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(400)
+        .expect((res: request.Response) => {
+          expect(res.body.success).toBe(false);
+          expect(res.body.message).toBe('존재하지 않는 그룹 달성기록 입니다.');
+        });
+    });
+
+    it('잘못된 인증시 401을 반환한다.', async () => {
+      // given
+      const accessToken = 'abcd.abcd.efgh';
+
+      // when
+      // then
+      return request(app.getHttpServer())
+        .delete('/api/v1/groups/1/achievements/1')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(401)
+        .expect((res: request.Response) => {
+          expect(res.body.success).toBe(false);
+          expect(res.body.message).toBe('잘못된 토큰입니다.');
+        });
+    });
+
+    it('만료된 인증정보에 401을 반환한다.', async () => {
+      // given
+      const { accessToken } =
+        await authFixture.getExpiredAccessTokenUser('ABC');
+
+      // when
+      // then
+      return request(app.getHttpServer())
+        .delete('/api/v1/groups/1/achievements/1')
         .set('Authorization', `Bearer ${accessToken}`)
         .expect(401)
         .expect((res: request.Response) => {

--- a/BE/src/group/achievement/controller/group-achievement.controller.spec.ts
+++ b/BE/src/group/achievement/controller/group-achievement.controller.spec.ts
@@ -28,6 +28,8 @@ import { PaginateGroupAchievementResponse } from '../dto/paginate-group-achievem
 import { PaginateGroupAchievementRequest } from '../dto/paginate-group-achievement-request';
 import { UnauthorizedAchievementException } from '../../../achievement/exception/unauthorized-achievement.exception';
 import { GroupAchievementDeleteResponse } from '../dto/group-achievement-delete-response';
+import { GroupAchievementUpdateRequest } from '../dto/group-achievement-update-request';
+import { GroupAchievementUpdateResponse } from '../dto/group-achievement-update-response';
 
 describe('GroupAchievementController', () => {
   let app: INestApplication;
@@ -620,6 +622,100 @@ describe('GroupAchievementController', () => {
       return request(app.getHttpServer())
         .delete('/api/v1/groups/1/achievements/1')
         .set('Authorization', `Bearer ${accessToken}`)
+        .expect(401)
+        .expect((res: request.Response) => {
+          expect(res.body.success).toBe(false);
+          expect(res.body.message).toBe('만료된 토큰입니다.');
+        });
+    });
+  });
+
+  describe('내가 작성한 달성기록을 수정 할 수 있다.', () => {
+    it('성공 시 200을 반환한다.', async () => {
+      // given
+      const { accessToken, user } =
+        await authFixture.getAuthenticatedUser('ABC');
+
+      const groupAchievementUpdateResponse = new GroupAchievementUpdateResponse(
+        1,
+      );
+
+      when(
+        mockGroupAchievementService.update(
+          anyNumber(),
+          anyNumber(),
+          anyNumber(),
+          anyOfClass(GroupAchievementUpdateRequest),
+        ),
+      ).thenResolve(groupAchievementUpdateResponse);
+
+      // when
+      // then
+      return request(app.getHttpServer())
+        .put('/api/v1/groups/1/achievements/1')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send(new GroupAchievementUpdateRequest('title', 'content', 1))
+        .expect(200)
+        .expect((res: request.Response) => {
+          expect(res.body.success).toBe(true);
+          expect(res.body.data).toEqual({ id: 1 });
+        });
+    });
+
+    it('삭제할 수 없는 달성기록에 대해 400을 반환한다.', async () => {
+      // given
+      const { accessToken } = await authFixture.getAuthenticatedUser('ABC');
+
+      when(
+        mockGroupAchievementService.update(
+          anyNumber(),
+          anyNumber(),
+          anyNumber(),
+          anyOfClass(GroupAchievementUpdateRequest),
+        ),
+      ).thenThrow(new NoSuchGroupAchievementException());
+
+      // when
+      // then
+      return request(app.getHttpServer())
+        .put('/api/v1/groups/1/achievements/1')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send(new GroupAchievementUpdateRequest('title', 'content', 1))
+        .expect(400)
+        .expect((res: request.Response) => {
+          expect(res.body.success).toBe(false);
+          expect(res.body.message).toBe('존재하지 않는 그룹 달성기록 입니다.');
+        });
+    });
+
+    it('잘못된 인증시 401을 반환한다.', async () => {
+      // given
+      const accessToken = 'abcd.abcd.efgh';
+
+      // when
+      // then
+      return request(app.getHttpServer())
+        .put('/api/v1/groups/1/achievements/1')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send(new GroupAchievementUpdateRequest('title', 'content', 1))
+        .expect(401)
+        .expect((res: request.Response) => {
+          expect(res.body.success).toBe(false);
+          expect(res.body.message).toBe('잘못된 토큰입니다.');
+        });
+    });
+
+    it('만료된 인증정보에 401을 반환한다.', async () => {
+      // given
+      const { accessToken } =
+        await authFixture.getExpiredAccessTokenUser('ABC');
+
+      // when
+      // then
+      return request(app.getHttpServer())
+        .put('/api/v1/groups/1/achievements/1')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send(new GroupAchievementUpdateRequest('title', 'content', 1))
         .expect(401)
         .expect((res: request.Response) => {
           expect(res.body.success).toBe(false);

--- a/BE/src/group/achievement/controller/group-achievement.controller.ts
+++ b/BE/src/group/achievement/controller/group-achievement.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
   HttpCode,
   HttpStatus,
@@ -130,5 +131,30 @@ export class GroupAchievementController {
         paginateGroupAchievementRequest,
       ),
     );
+  }
+
+  @ApiBearerAuth('accessToken')
+  @ApiOperation({
+    summary: '그룹 달성기록 삭제 API',
+    description: '달성기록을 삭제한다.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '그룹 달성기록 삭제',
+    type: AchievementDetailResponse,
+  })
+  @Delete('/:groupId/achievements/:achievementId')
+  @UseGuards(AccessTokenGuard)
+  async delete(
+    @AuthenticatedUser() user: User,
+    @Param('groupId', ParseIntPipe) groupId: number,
+    @Param('achievementId', ParseIntPipe) achievementId: number,
+  ) {
+    const response = await this.groupAchievementService.delete(
+      user.id,
+      groupId,
+      achievementId,
+    );
+    return ApiData.success(response);
   }
 }

--- a/BE/src/group/achievement/controller/group-achievement.controller.ts
+++ b/BE/src/group/achievement/controller/group-achievement.controller.ts
@@ -32,6 +32,7 @@ import { AchievementUpdateResponse } from '../../../achievement/dto/achievement-
 import { AchievementUpdateRequest } from '../../../achievement/dto/achievement-update-request';
 import { GroupAchievementUpdateRequest } from '../dto/group-achievement-update-request';
 import { GroupAchievementUpdateResponse } from '../dto/group-achievement-update-response';
+import { GroupAchievementDeleteResponse } from '../dto/group-achievement-delete-response';
 
 @Controller('/api/v1/groups')
 @ApiTags('그룹 달성기록 API')
@@ -146,7 +147,7 @@ export class GroupAchievementController {
   @ApiResponse({
     status: 200,
     description: '그룹 달성기록 삭제',
-    type: AchievementDetailResponse,
+    type: GroupAchievementDeleteResponse,
   })
   @Delete('/:groupId/achievements/:achievementId')
   @UseGuards(AccessTokenGuard)

--- a/BE/src/group/achievement/controller/group-achievement.controller.ts
+++ b/BE/src/group/achievement/controller/group-achievement.controller.ts
@@ -7,6 +7,7 @@ import {
   HttpStatus,
   Param,
   Post,
+  Put,
   Query,
   UseGuards,
 } from '@nestjs/common';
@@ -27,6 +28,10 @@ import { GroupAchievementCreateRequest } from '../dto/group-achievement-create-r
 import { PaginateGroupAchievementRequest } from '../dto/paginate-group-achievement-request';
 import { PaginateGroupAchievementResponse } from '../dto/paginate-group-achievement-response';
 import { AchievementDetailResponse } from '../../../achievement/dto/achievement-detail-response';
+import { AchievementUpdateResponse } from '../../../achievement/dto/achievement-update-response';
+import { AchievementUpdateRequest } from '../../../achievement/dto/achievement-update-request';
+import { GroupAchievementUpdateRequest } from '../dto/group-achievement-update-request';
+import { GroupAchievementUpdateResponse } from '../dto/group-achievement-update-response';
 
 @Controller('/api/v1/groups')
 @ApiTags('그룹 달성기록 API')
@@ -154,6 +159,33 @@ export class GroupAchievementController {
       user.id,
       groupId,
       achievementId,
+    );
+    return ApiData.success(response);
+  }
+
+  @ApiBearerAuth('accessToken')
+  @ApiOperation({
+    summary: '그룹 달성기록 수정 API',
+    description: '그룹 달성기록을 수정한다.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '그룹 달성기록 수정',
+    type: GroupAchievementUpdateResponse,
+  })
+  @Put('/:groupId/achievements/:achievementId')
+  @UseGuards(AccessTokenGuard)
+  async update(
+    @AuthenticatedUser() user: User,
+    @Param('groupId', ParseIntPipe) groupId: number,
+    @Param('achievementId', ParseIntPipe) achievementId: number,
+    @Body() groupAchievementUpdateRequest: GroupAchievementUpdateRequest,
+  ) {
+    const response = await this.groupAchievementService.update(
+      user.id,
+      groupId,
+      achievementId,
+      groupAchievementUpdateRequest,
     );
     return ApiData.success(response);
   }

--- a/BE/src/group/achievement/domain/group-achievement.domain.ts
+++ b/BE/src/group/achievement/domain/group-achievement.domain.ts
@@ -2,6 +2,7 @@ import { GroupCategory } from '../../category/domain/group.category';
 import { Group } from '../../group/domain/group.domain';
 import { User } from '../../../users/domain/user.domain';
 import { Image } from '../../../image/domain/image.domain';
+import { GroupAchievementUpdate } from '../index';
 
 export class GroupAchievement {
   id: number;
@@ -27,5 +28,10 @@ export class GroupAchievement {
     this.groupCategory = groupCategory;
     this.content = content;
     this.image = image;
+  }
+  update(achievementUpdate: GroupAchievementUpdate) {
+    this.title = achievementUpdate.title;
+    this.content = achievementUpdate.content;
+    this.groupCategory = achievementUpdate.category;
   }
 }

--- a/BE/src/group/achievement/dto/group-achievement-delete-response.ts
+++ b/BE/src/group/achievement/dto/group-achievement-delete-response.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { GroupAchievement } from '../domain/group-achievement.domain';
+
+export class GroupAchievementDeleteResponse {
+  @ApiProperty({ description: 'id' })
+  id: number;
+
+  constructor(id: number) {
+    this.id = id;
+  }
+
+  static from(achievement: GroupAchievement) {
+    return new GroupAchievementDeleteResponse(achievement.id);
+  }
+}

--- a/BE/src/group/achievement/dto/group-achievement-update-request.ts
+++ b/BE/src/group/achievement/dto/group-achievement-update-request.ts
@@ -1,0 +1,36 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNumber, IsString } from 'class-validator';
+import { GroupCategory } from '../../category/domain/group.category';
+import { GroupAchievementUpdate } from '../index';
+import { IsNotEmptyString } from '../../../config/config/validation-decorator';
+
+export class GroupAchievementUpdateRequest {
+  @IsNotEmptyString({ message: '잘못된 제목 이름입니다.' })
+  @ApiProperty({ description: 'title' })
+  title: string;
+
+  @IsString({ message: '잘못된 내용입니다.' })
+  @ApiProperty({ description: 'content' })
+  content: string;
+
+  @IsNumber(
+    { allowNaN: false, allowInfinity: false },
+    { message: '카테고리를 선택해주세요' },
+  )
+  @ApiProperty({ description: 'categoryId' })
+  categoryId: number;
+
+  constructor(title: string, content: string, categoryId: number) {
+    this.title = title;
+    this.content = content;
+    this.categoryId = categoryId;
+  }
+
+  toAchievementUpdate(category: GroupCategory): GroupAchievementUpdate {
+    return {
+      title: this.title,
+      content: this.content,
+      category,
+    };
+  }
+}

--- a/BE/src/group/achievement/dto/group-achievement-update-response.ts
+++ b/BE/src/group/achievement/dto/group-achievement-update-response.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { GroupAchievement } from '../domain/group-achievement.domain';
+
+export class GroupAchievementUpdateResponse {
+  @ApiProperty({ description: 'id' })
+  id: number;
+
+  constructor(id: number) {
+    this.id = id;
+  }
+
+  static from(achievement: GroupAchievement) {
+    return new GroupAchievementUpdateResponse(achievement.id);
+  }
+}

--- a/BE/src/group/achievement/entities/group-achievement.repository.spec.ts
+++ b/BE/src/group/achievement/entities/group-achievement.repository.spec.ts
@@ -254,9 +254,31 @@ describe('GroupRepository Test', () => {
       );
 
       // then
-      expect(findById.user.id).toEqual(user.id);
-      expect(findById.user.userCode).toEqual(user.userCode);
       expect(findById.group.id).toEqual(group.id);
+      expect(findById.id).toEqual(groupAchievement.id);
+      expect(findById.title).toEqual(groupAchievement.title);
+      expect(findById.content).toEqual(groupAchievement.content);
+      expect(findById.createdAt).toEqual(groupAchievement.createdAt);
+    });
+  });
+
+  test('유저 id, 그룹 id, 그룹 달성 기록 id로 조회할 수 있다.', async () => {
+    await transactionTest(dataSource, async () => {
+      // given
+      const user = await usersFixture.getUser('ABC');
+      const group = await groupFixture.createGroup('GROUP', user);
+      const groupAchievement =
+        await groupAchievementFixture.createGroupAchievement(user, group, null);
+
+      // when
+      const findById =
+        await groupAchievementRepository.findOneByIdAndUserAndGroup(
+          groupAchievement.id,
+          user.id,
+          group.id,
+        );
+
+      // then
       expect(findById.id).toEqual(groupAchievement.id);
       expect(findById.title).toEqual(groupAchievement.title);
       expect(findById.content).toEqual(groupAchievement.content);

--- a/BE/src/group/achievement/entities/group-achievement.repository.spec.ts
+++ b/BE/src/group/achievement/entities/group-achievement.repository.spec.ts
@@ -267,8 +267,17 @@ describe('GroupRepository Test', () => {
       // given
       const user = await usersFixture.getUser('ABC');
       const group = await groupFixture.createGroup('GROUP', user);
+      const category = await groupCategoryFixture.createCategory(
+        user,
+        group,
+        'category',
+      );
       const groupAchievement =
-        await groupAchievementFixture.createGroupAchievement(user, group, null);
+        await groupAchievementFixture.createGroupAchievement(
+          user,
+          group,
+          category,
+        );
 
       // when
       const findById =
@@ -282,6 +291,9 @@ describe('GroupRepository Test', () => {
       expect(findById.id).toEqual(groupAchievement.id);
       expect(findById.title).toEqual(groupAchievement.title);
       expect(findById.content).toEqual(groupAchievement.content);
+      expect(findById.groupCategory.id).toEqual(category.id);
+      expect(findById.groupCategory.name).toEqual(category.name);
+      expect(findById.createdAt).toEqual(groupAchievement.createdAt);
       expect(findById.createdAt).toEqual(groupAchievement.createdAt);
     });
   });

--- a/BE/src/group/achievement/entities/group-achievement.repository.ts
+++ b/BE/src/group/achievement/entities/group-achievement.repository.ts
@@ -169,6 +169,9 @@ export class GroupAchievementRepository extends TransactionalRepository<GroupAch
   ) {
     const findOne = await this.repository.findOne({
       where: { id: achieveId, group: { id: groupId }, user: { id: userId } },
+      relations: {
+        groupCategory: true,
+      },
     });
     return findOne?.toModel();
   }

--- a/BE/src/group/achievement/entities/group-achievement.repository.ts
+++ b/BE/src/group/achievement/entities/group-achievement.repository.ts
@@ -161,4 +161,15 @@ export class GroupAchievementRepository extends TransactionalRepository<GroupAch
       GroupAchievementResponse.from(groupAchievementListDetail),
     );
   }
+
+  async findOneByIdAndUserAndGroup(
+    achieveId: number,
+    userId: number,
+    groupId: number,
+  ) {
+    const findOne = await this.repository.findOne({
+      where: { id: achieveId, group: { id: groupId }, user: { id: userId } },
+    });
+    return findOne?.toModel();
+  }
 }

--- a/BE/src/group/achievement/index.ts
+++ b/BE/src/group/achievement/index.ts
@@ -1,4 +1,6 @@
 import { IAchievementDetail } from '../../achievement';
+import { User } from '../../users/domain/user.domain';
+import { GroupCategory } from '../category/domain/group.category';
 
 export interface IGroupAchievementDetail extends IAchievementDetail {
   userCode: string;
@@ -10,4 +12,13 @@ export interface IGroupAchievementListDetail {
   thumbnailUrl: string;
   userCode: string;
   categoryId: number;
+}
+
+export interface GroupAchievementUpdate {
+  user?: User;
+  category?: GroupCategory;
+  title?: string;
+  content?: string;
+  imageUrl?: string;
+  thumbnailUrl?: string;
 }

--- a/BE/src/group/category/entities/group-category.repository.ts
+++ b/BE/src/group/category/entities/group-category.repository.ts
@@ -26,6 +26,13 @@ export class GroupCategoryRepository extends TransactionalRepository<GroupCatego
     });
     return groupCategoryEntity?.toModel();
   }
+  async findByIdAndGroup(groupId: number, ctgId: number) {
+    const groupCategoryEntity = await this.repository.findOneBy({
+      group: { id: groupId },
+      id: ctgId,
+    });
+    return groupCategoryEntity?.toModel();
+  }
 
   async findGroupCategoriesByUser(
     user: User,


### PR DESCRIPTION
## PR 요약
- 그룹 달성 기록 삭제 및 수정 기능 

### 스크린샷
#### 삭제 API

- 성공
<img width="606" alt="image" src="https://github.com/boostcampwm2023/iOS02-moti/assets/34297340/6e6a2f8a-2c5f-4bd0-bcf7-e0ed6f0941f3">



- 없는 달성 기록이거나, 자신의 달성 기록이 아닐 때
<img width="609" alt="image" src="https://github.com/boostcampwm2023/iOS02-moti/assets/34297340/eea8b19f-b5ef-4288-8fa7-be891b8469f7">


#### 수정 API 

- 성공
<img width="683" alt="image" src="https://github.com/boostcampwm2023/iOS02-moti/assets/34297340/7b9713f0-c812-4ea2-bbb2-1993684aec4d">

- 없는 달성 기록이거나, 자신의 달성 기록이 아닐 때 
<img width="619" alt="image" src="https://github.com/boostcampwm2023/iOS02-moti/assets/34297340/4cdf9781-6325-4234-b17d-f3849b8bf7f9">



#### Linked Issue
close #403 
close #404 
close #407 
close #408 
close #409 
