### PR TITLE
그룹의 달성기록 생성 및 조회 이슈

### DIFF
--- a/BE/src/group/achievement/application/group-achievement.service.spec.ts
+++ b/BE/src/group/achievement/application/group-achievement.service.spec.ts
@@ -284,6 +284,164 @@ describe('GroupAchievementService Test', () => {
         ).rejects.toThrow(NoUserImageException);
       });
     });
+
+    it('그룹에 속한 사용자는 그룹내 달성기록을 생성할 수 있다.', async () => {
+      await transactionTest(dataSource, async () => {
+        // given
+        const leader = await usersFixture.getUser('ABC');
+        const group = await groupFixture.createGroup('GROUP', leader);
+        const groupCategory = await groupCategoryFixture.createCategory(
+          leader,
+          group,
+          'category',
+        );
+
+        const user = await usersFixture.getUser('DEF');
+        await groupFixture.addMember(group, user, UserGroupGrade.PARTICIPANT);
+        const image = await imageFixture.getImage(user, 'image');
+
+        const groupAchievementCreateRequest = new GroupAchievementCreateRequest(
+          '제목',
+          '내용',
+          groupCategory.id,
+          image.id,
+        );
+
+        // when
+        const groupAchievementResponse = await groupAchievementService.create(
+          user,
+          group.id,
+          groupAchievementCreateRequest,
+        );
+
+        // then
+        expect(groupAchievementResponse.id).toBeDefined();
+        expect(groupAchievementResponse.title).toEqual('제목');
+        expect(groupAchievementResponse.content).toEqual('내용');
+        expect(groupAchievementResponse.category.id).toEqual(groupCategory.id);
+        expect(groupAchievementResponse.category.achieveCount).toEqual(1);
+        expect(groupAchievementResponse.category.name).toEqual('category');
+        expect(groupAchievementResponse.userCode).toEqual(user.userCode);
+        expect(groupAchievementResponse.imageUrl).toEqual(image.imageUrl);
+        expect(groupAchievementResponse.createdAt).toBeDefined();
+      });
+    });
+
+    it('그룹에 속한 사용자는 그룹내 달성기록을 생성할 때 카테고리를 미설정하고 달성기록을 생성할 수 있다.', async () => {
+      await transactionTest(dataSource, async () => {
+        // given
+        const leader = await usersFixture.getUser('ABC');
+        const group = await groupFixture.createGroup('GROUP', leader);
+
+        const user = await usersFixture.getUser('DEF');
+        await groupFixture.addMember(group, user, UserGroupGrade.PARTICIPANT);
+        const image = await imageFixture.getImage(user, 'image');
+
+        const groupAchievementCreateRequest = new GroupAchievementCreateRequest(
+          '제목',
+          '내용',
+          -1,
+          image.id,
+        );
+
+        // when
+        const groupAchievementResponse = await groupAchievementService.create(
+          user,
+          group.id,
+          groupAchievementCreateRequest,
+        );
+
+        // then
+        expect(groupAchievementResponse.id).toBeDefined();
+        expect(groupAchievementResponse.title).toEqual('제목');
+        expect(groupAchievementResponse.content).toEqual('내용');
+        expect(groupAchievementResponse.category.id).toEqual(-1);
+        expect(groupAchievementResponse.category.achieveCount).toEqual(1);
+        expect(groupAchievementResponse.category.name).toEqual('미설정');
+        expect(groupAchievementResponse.userCode).toEqual(user.userCode);
+        expect(groupAchievementResponse.imageUrl).toEqual(image.imageUrl);
+        expect(groupAchievementResponse.createdAt).toBeDefined();
+      });
+    });
+
+    it('그룹에 속한 관리자는 그룹내 달성기록을 생성할 수 있다.', async () => {
+      await transactionTest(dataSource, async () => {
+        // given
+        const leader = await usersFixture.getUser('ABC');
+        const group = await groupFixture.createGroup('GROUP', leader);
+        const groupCategory = await groupCategoryFixture.createCategory(
+          leader,
+          group,
+          'category',
+        );
+
+        const user = await usersFixture.getUser('DEF');
+        await groupFixture.addMember(group, user, UserGroupGrade.MANAGER);
+        const image = await imageFixture.getImage(user, 'image');
+
+        const groupAchievementCreateRequest = new GroupAchievementCreateRequest(
+          '제목',
+          '내용',
+          groupCategory.id,
+          image.id,
+        );
+
+        // when
+        const groupAchievementResponse = await groupAchievementService.create(
+          user,
+          group.id,
+          groupAchievementCreateRequest,
+        );
+
+        // then
+        expect(groupAchievementResponse.id).toBeDefined();
+        expect(groupAchievementResponse.title).toEqual('제목');
+        expect(groupAchievementResponse.content).toEqual('내용');
+        expect(groupAchievementResponse.category.id).toEqual(groupCategory.id);
+        expect(groupAchievementResponse.category.achieveCount).toEqual(1);
+        expect(groupAchievementResponse.category.name).toEqual('category');
+        expect(groupAchievementResponse.userCode).toEqual(user.userCode);
+        expect(groupAchievementResponse.imageUrl).toEqual(image.imageUrl);
+        expect(groupAchievementResponse.createdAt).toBeDefined();
+      });
+    });
+
+    it('그룹에 속한 관리자는 그룹내 달성기록을 생성할 때 카테고리를 미설정하고 달성기록을 생성할 수 있다.', async () => {
+      await transactionTest(dataSource, async () => {
+        // given
+        const leader = await usersFixture.getUser('ABC');
+        const group = await groupFixture.createGroup('GROUP', leader);
+
+        const user = await usersFixture.getUser('DEF');
+        await groupFixture.addMember(group, user, UserGroupGrade.MANAGER);
+        const image = await imageFixture.getImage(user, 'image');
+
+        const groupAchievementCreateRequest = new GroupAchievementCreateRequest(
+          '제목',
+          '내용',
+          -1,
+          image.id,
+        );
+
+        // when
+        const groupAchievementResponse = await groupAchievementService.create(
+          user,
+          group.id,
+          groupAchievementCreateRequest,
+        );
+
+        // then
+        expect(groupAchievementResponse.id).toBeDefined();
+        expect(groupAchievementResponse.title).toEqual('제목');
+        expect(groupAchievementResponse.content).toEqual('내용');
+        expect(groupAchievementResponse.category.id).toEqual(-1);
+        expect(groupAchievementResponse.category.achieveCount).toEqual(1);
+        expect(groupAchievementResponse.category.name).toEqual('미설정');
+        expect(groupAchievementResponse.userCode).toEqual(user.userCode);
+        expect(groupAchievementResponse.imageUrl).toEqual(image.imageUrl);
+        expect(groupAchievementResponse.createdAt).toBeDefined();
+      });
+    });
   });
 
   describe('getAchievementDetail은 그룹내 특정 달성기록을 조회할 수 있다.', () => {
@@ -304,6 +462,7 @@ describe('GroupAchievementService Test', () => {
         const groupAchievementDetail =
           await groupAchievementService.getAchievementDetail(
             user,
+            group.id,
             groupAchievement.id,
           );
 
@@ -339,6 +498,7 @@ describe('GroupAchievementService Test', () => {
         const groupAchievementDetail =
           await groupAchievementService.getAchievementDetail(
             reader,
+            group.id,
             groupAchievement.id,
           );
 
@@ -348,6 +508,40 @@ describe('GroupAchievementService Test', () => {
         expect(groupAchievementDetail.content).toEqual(
           groupAchievement.content,
         );
+      });
+    });
+
+    it('작성자와 같은 그룹 유저는 달성기록을 조회할 수 있다.', async () => {
+      await transactionTest(dataSource, async () => {
+        // given
+        const writer = await usersFixture.getUser('ABC');
+        const group = await groupFixture.createGroup('GROUP', writer);
+        const groupCtg = await groupCategoryFixture.createCategory(
+          writer,
+          group,
+        );
+        const groupAchievement =
+          await groupAchievementFixture.createGroupAchievement(
+            writer,
+            group,
+            groupCtg,
+          );
+
+        const reader = await usersFixture.getUser('DEF');
+        await groupFixture.addMember(group, reader, UserGroupGrade.PARTICIPANT);
+
+        const otherUser = await usersFixture.getUser('GHI');
+        const otherGroup = await groupFixture.createGroup('GROUP2', otherUser);
+
+        // when
+        // then
+        await expect(
+          groupAchievementService.getAchievementDetail(
+            reader,
+            otherGroup.id,
+            groupAchievement.id,
+          ),
+        ).rejects.toThrow(UnauthorizedAchievementException);
       });
     });
 
@@ -374,6 +568,7 @@ describe('GroupAchievementService Test', () => {
         await expect(
           groupAchievementService.getAchievementDetail(
             reader,
+            group.id,
             groupAchievement.id,
           ),
         ).rejects.toThrow(UnauthorizedAchievementException);

--- a/BE/src/group/achievement/application/group-achievement.service.ts
+++ b/BE/src/group/achievement/application/group-achievement.service.ts
@@ -47,10 +47,15 @@ export class GroupAchievementService {
   }
 
   @Transactional({ readonly: true })
-  async getAchievementDetail(user: User, achievementId: number) {
+  async getAchievementDetail(
+    user: User,
+    groupId: number,
+    achievementId: number,
+  ) {
     const groupAchievementDetailResponse =
       await this.groupAchievementRepository.findAchievementDetailByIdAndBelongingGroup(
         achievementId,
+        groupId,
         user.id,
       );
 
@@ -65,9 +70,9 @@ export class GroupAchievementService {
     groupId: number,
     achieveCreate: GroupAchievementCreateRequest,
   ) {
-    const category = await this.getCategory(user.id, achieveCreate.categoryId);
-    const image = await this.getUserImage(achieveCreate.photoId, user);
     const group = await this.getGroup(groupId, user);
+    const category = await this.getCategory(group.id, achieveCreate.categoryId);
+    const image = await this.getUserImage(achieveCreate.photoId, user);
     const achievement = achieveCreate.toModel(user, group, category, image);
     const saved =
       await this.groupAchievementRepository.saveAchievement(achievement);
@@ -92,11 +97,11 @@ export class GroupAchievementService {
       ),
     );
   }
-  private async getCategory(userId: number, ctgId: number) {
+  private async getCategory(groupId: number, ctgId: number) {
     if (ctgId === -1) return null;
 
-    const ctg = await this.groupCategoryRepository.findByIdAndUser(
-      userId,
+    const ctg = await this.groupCategoryRepository.findByIdAndGroupUser(
+      groupId,
       ctgId,
     );
     if (!ctg) throw new InvalidCategoryException();

--- a/BE/src/group/achievement/controller/group-achievement.controller.spec.ts
+++ b/BE/src/group/achievement/controller/group-achievement.controller.spec.ts
@@ -470,7 +470,7 @@ describe('GroupAchievementController', () => {
       });
 
       when(
-        mockGroupAchievementService.getAchievementDetail(anything(), 1004),
+        mockGroupAchievementService.getAchievementDetail(anything(), 1, 1004),
       ).thenResolve(achievementDetail);
 
       // when
@@ -490,7 +490,7 @@ describe('GroupAchievementController', () => {
       const { accessToken } = await authFixture.getAuthenticatedUser('ABC');
 
       when(
-        mockGroupAchievementService.getAchievementDetail(anything(), 1005),
+        mockGroupAchievementService.getAchievementDetail(anything(), 1, 1005),
       ).thenThrow(new UnauthorizedAchievementException());
 
       // when

--- a/BE/src/group/achievement/controller/group-achievement.controller.ts
+++ b/BE/src/group/achievement/controller/group-achievement.controller.ts
@@ -96,10 +96,12 @@ export class GroupAchievementController {
   @UseGuards(AccessTokenGuard)
   async getAchievement(
     @AuthenticatedUser() user: User,
+    @Param('groupId', ParseIntPipe) groupId: number,
     @Param('achievementId', ParseIntPipe) id: number,
   ) {
     const response = await this.groupAchievementService.getAchievementDetail(
       user,
+      groupId,
       id,
     );
     return ApiData.success(response);

--- a/BE/src/group/achievement/entities/group-achievement.repository.spec.ts
+++ b/BE/src/group/achievement/entities/group-achievement.repository.spec.ts
@@ -285,6 +285,7 @@ describe('GroupRepository Test', () => {
         const groupAchievementDetailResponse =
           await groupAchievementRepository.findAchievementDetailByIdAndBelongingGroup(
             groupAchievement.id,
+            group.id,
             user.id,
           );
 
@@ -335,6 +336,7 @@ describe('GroupRepository Test', () => {
         const groupAchievementDetailResponse =
           await groupAchievementRepository.findAchievementDetailByIdAndBelongingGroup(
             groupAchievement.id,
+            group.id,
             reader.id,
           );
 
@@ -384,6 +386,7 @@ describe('GroupRepository Test', () => {
         const groupAchievementDetailResponse =
           await groupAchievementRepository.findAchievementDetailByIdAndBelongingGroup(
             groupAchievement.id,
+            group.id,
             reader.id,
           );
 

--- a/BE/src/group/achievement/entities/group-achievement.repository.spec.ts
+++ b/BE/src/group/achievement/entities/group-achievement.repository.spec.ts
@@ -491,10 +491,7 @@ describe('GroupRepository Test', () => {
       const group = await groupFixture.createGroup('GROUP', user1);
       await groupFixture.addMember(group, user2, UserGroupGrade.PARTICIPANT);
 
-      const groupCategory1 = await groupCategoryFixture.createCategory(
-        user1,
-        group,
-      );
+      await groupCategoryFixture.createCategory(user1, group);
       const groupCategory2 = await groupCategoryFixture.createCategory(
         user1,
         group,

--- a/BE/src/group/achievement/entities/group-achievement.repository.ts
+++ b/BE/src/group/achievement/entities/group-achievement.repository.ts
@@ -34,14 +34,15 @@ export class GroupAchievementRepository extends TransactionalRepository<GroupAch
 
   async findAchievementDetailByIdAndBelongingGroup(
     achievementId: number,
+    groupId: number,
     userId: number,
   ) {
     const groupAchievementEntitySelectQueryBuilder =
       await this.achievementDetailQuery(achievementId);
     const result = await groupAchievementEntitySelectQueryBuilder
       .andWhere(
-        'groupAchievement.group_id in (select group_id from user_group where user_id = :userId)',
-        { userId },
+        'groupAchievement.group_id in (select group_id from user_group where user_id = :userId and group_id = :groupId)',
+        { userId, groupId },
       )
       .getRawOne<IGroupAchievementDetail>();
 

--- a/BE/src/group/category/entities/group-category.repository.spec.ts
+++ b/BE/src/group/category/entities/group-category.repository.spec.ts
@@ -229,4 +229,68 @@ describe('GroupCategoryRepository test', () => {
       expect(retrievedCategory.achievementCount).toEqual(4);
     });
   });
+
+  describe('findGroupCategoryByIdAndUser는 그룹 카테고리를 조회할 수 있다.', () => {
+    it('그룹과 카테고리 아이디를 이용해 알맞은 카테고리를 조회할 수 있다.', async () => {
+      await transactionTest(dataSource, async () => {
+        // given
+        const user = await userFixture.getUser('ABC');
+        const group = await groupFixture.createGroups(user);
+        const groupCategory = await groupCategoryFixture.createCategory(
+          user,
+          group,
+          '카테고리',
+        );
+        await groupAchievementFixture.createGroupAchievements(
+          4,
+          user,
+          group,
+          null,
+        );
+
+        // when
+        const retrievedCategory =
+          await groupCategoryRepository.findByIdAndGroupUser(
+            group.id,
+            groupCategory.id,
+          );
+
+        // then
+        expect(retrievedCategory.id).toEqual(groupCategory.id);
+        expect(retrievedCategory.name).toEqual(groupCategory.name);
+      });
+    });
+
+    it('그룹과 카테고리 아이디가 일치하지 않으면 카테고리를 조회할 수 없다.', async () => {
+      await transactionTest(dataSource, async () => {
+        // given
+        const user = await userFixture.getUser('ABC');
+        const group = await groupFixture.createGroups(user);
+        const groupCategory = await groupCategoryFixture.createCategory(
+          user,
+          group,
+          '카테고리',
+        );
+        await groupAchievementFixture.createGroupAchievements(
+          4,
+          user,
+          group,
+          null,
+        );
+
+        const otherGroup = await groupFixture.createGroups(user);
+
+
+        // when
+        const retrievedCategory =
+          await groupCategoryRepository.findByIdAndGroupUser(
+            otherGroup.id,
+            groupCategory.id,
+          );
+
+        // then
+        expect(retrievedCategory).toBeUndefined();
+      });
+    });
+  });
 });

--- a/BE/src/group/category/entities/group-category.repository.spec.ts
+++ b/BE/src/group/category/entities/group-category.repository.spec.ts
@@ -280,7 +280,6 @@ describe('GroupCategoryRepository test', () => {
 
         const otherGroup = await groupFixture.createGroups(user);
 
-
         // when
         const retrievedCategory =
           await groupCategoryRepository.findByIdAndGroupUser(

--- a/BE/src/group/category/entities/group-category.repository.ts
+++ b/BE/src/group/category/entities/group-category.repository.ts
@@ -26,6 +26,13 @@ export class GroupCategoryRepository extends TransactionalRepository<GroupCatego
     });
     return groupCategoryEntity?.toModel();
   }
+  async findByIdAndGroupUser(groupId: number, ctgId: number) {
+    const groupCategoryEntity = await this.repository.findOneBy({
+      group: { id: groupId },
+      id: ctgId,
+    });
+    return groupCategoryEntity?.toModel();
+  }
 
   async findGroupCategoriesByUser(
     user: User,


### PR DESCRIPTION
## PR 요약
그룹의 달성기록 생성 및 조회 이슈

#### 변경 사항
변경사항 및 주의 사항 (모듈 설치 등)을 적어주세요.

##### 스크린샷

* 사용자의 소유가 아닌 카테고리에 달성기록 생성

![image](https://github.com/boostcampwm2023/iOS02-moti/assets/75921696/08f38362-803d-4fd0-949a-3be28db6726a)

* 그룹 아이디랑, 그룹 도전기록 아이디가 매칭되어야 조회 가능
  * 달성기록 id는 같고, 그룹 아이디만 다르게 해서 요청한 상황 

![image](https://github.com/boostcampwm2023/iOS02-moti/assets/75921696/0b04746c-968a-4a6c-b3db-75ad03753a73)

![image](https://github.com/boostcampwm2023/iOS02-moti/assets/75921696/a086af08-0291-4b49-97b9-2bf3ba41db20)


#### Linked Issue
close #490
