### PR TITLE
그룹 카테고리에서 전체 카테고리 정보 조회 이슈

### DIFF
--- a/BE/src/group/category/application/group-category.service.ts
+++ b/BE/src/group/category/application/group-category.service.ts
@@ -39,7 +39,12 @@ export class GroupCategoryService {
     categoryId: number,
   ) {
     const group = await this.getGroup(user, groupId);
-    return this.groupCategoryRepository.findGroupCategory(group, categoryId);
+    const categoryMetaData =
+      await this.groupCategoryRepository.findGroupCategory(group, categoryId);
+    if (!categoryMetaData)
+      throw new UnauthorizedApproachGroupCategoryException();
+
+    return categoryMetaData;
   }
 
   private async getGroupByLeader(user: User, groupId: number) {


### PR DESCRIPTION
## PR 요약
그룹 카테고리에서 전체 카테고리 정보 조회 이슈 해결

#### 변경 사항
- 접근할 수 없는 카테고리에 대한 예외 처리
- 전체 카테고리 조회

##### 스크린샷

![image](https://github.com/boostcampwm2023/iOS02-moti/assets/75921696/9b15a309-9df3-4709-9928-4c232689cb66)

![image](https://github.com/boostcampwm2023/iOS02-moti/assets/75921696/77d0b4d6-b066-444c-9b4f-0e63959fa61a)

#### Linked Issue
close #499
