### PR TITLE
단 건의 카테고리 조회 API를 작성한다.

### DIFF
--- a/BE/src/category/application/category.service.ts
+++ b/BE/src/category/application/category.service.ts
@@ -5,6 +5,7 @@ import { Transactional } from '../../config/transaction-manager';
 import { Category } from '../domain/category.domain';
 import { User } from '../../users/domain/user.domain';
 import { CategoryMetaData } from '../dto/category-metadata';
+import { NotFoundCategoryException } from '../exception/not-found-category.exception';
 
 @Injectable()
 export class CategoryService {
@@ -22,5 +23,16 @@ export class CategoryService {
   @Transactional({ readonly: true })
   async getCategoriesByUser(user: User): Promise<CategoryMetaData[]> {
     return this.categoryRepository.findCategoriesByUser(user);
+  }
+
+  @Transactional({ readonly: true })
+  async getCategory(user: User, categoryId: number): Promise<CategoryMetaData> {
+    const categoryMetaData = await this.categoryRepository.findCategory(
+      user,
+      categoryId,
+    );
+    if (!categoryMetaData) throw new NotFoundCategoryException();
+
+    return categoryMetaData;
   }
 }

--- a/BE/src/category/controller/category.controller.spec.ts
+++ b/BE/src/category/controller/category.controller.spec.ts
@@ -1,0 +1,347 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { AuthFixture } from '../../../test/auth/auth-fixture';
+import { anyOfClass, instance, mock, when } from 'ts-mockito';
+import { Test, TestingModule } from '@nestjs/testing';
+import { AppModule } from '../../app.module';
+import { AuthTestModule } from '../../../test/auth/auth-test.module';
+import { validationPipeOptions } from '../../config/validation';
+import { UnexpectedExceptionFilter } from '../../common/filter/unexpected-exception.filter';
+import { MotimateExceptionFilter } from '../../common/filter/exception.filter';
+import { CategoryService } from '../application/category.service';
+import { User } from '../../users/domain/user.domain';
+import * as request from 'supertest';
+import { Category } from '../domain/category.domain';
+import { CategoryCreate } from '../dto/category-create';
+import { CategoryMetaData } from '../dto/category-metadata';
+import { GroupCategoryMetadata } from '../../group/category/dto/group-category-metadata';
+import { NotFoundCategoryException } from '../exception/not-found-category.exception';
+
+describe('CategoryController Test', () => {
+  let app: INestApplication;
+  let authFixture: AuthFixture;
+  let mockCategoryService: CategoryService;
+
+  beforeAll(async () => {
+    mockCategoryService = mock<CategoryService>(CategoryService);
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule, AuthTestModule],
+      controllers: [],
+      providers: [],
+    })
+      .overrideProvider(CategoryService)
+      .useValue(instance<CategoryService>(mockCategoryService))
+      .compile();
+
+    authFixture = moduleFixture.get<AuthFixture>(AuthFixture);
+    app = moduleFixture.createNestApplication();
+
+    app.useGlobalPipes(new ValidationPipe(validationPipeOptions));
+    app.useGlobalFilters(
+      new UnexpectedExceptionFilter(),
+      new MotimateExceptionFilter(),
+    );
+
+    await app.init();
+  });
+
+  describe('테스트 환경 확인', () => {
+    it('app이 정의되어 있어야 한다.', () => {
+      expect(app).toBeDefined();
+    });
+  });
+
+  describe('그룹 카테고리를 생성할 수 있다.', () => {
+    it('사용자가 카테고리 생성 요청시 카테고리와 201을 반환한다.', async () => {
+      // given
+      const { accessToken } = await authFixture.getAuthenticatedUser('ABC');
+
+      const category = new Category(undefined, '카테고리1004');
+      category.id = 1004;
+
+      when(
+        mockCategoryService.saveCategory(
+          anyOfClass(CategoryCreate),
+          anyOfClass(User),
+        ),
+      ).thenResolve(category);
+
+      // when
+      // then
+      return request(app.getHttpServer())
+        .post(`/api/v1/categories`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({
+          name: '카테고리1',
+        })
+        .expect(201)
+        .expect((res: request.Response) => {
+          expect(res.body.success).toEqual(true);
+          expect(res.body.data).toEqual({
+            id: 1004,
+            name: '카테고리1004',
+          });
+        });
+    });
+
+    it('잘못된 인증시 401을 반환한다.', async () => {
+      // given
+      const accessToken = 'abcd.abcd.efgh';
+
+      // when
+      // then
+      return request(app.getHttpServer())
+        .post(`/api/v1/categories`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({
+          name: '카테고리1',
+        })
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(401)
+        .expect((res: request.Response) => {
+          expect(res.body.success).toBe(false);
+          expect(res.body.message).toBe('잘못된 토큰입니다.');
+        });
+    });
+
+    it('잘못된 인증시 401을 반환한다.', async () => {
+      // given
+      const { accessToken } =
+        await authFixture.getExpiredAccessTokenUser('ABC');
+
+      // when
+      // then
+      return request(app.getHttpServer())
+        .post(`/api/v1/categories`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({
+          name: '카테고리1',
+        })
+        .expect(401)
+        .expect((res: request.Response) => {
+          expect(res.body.success).toBe(false);
+          expect(res.body.message).toBe('만료된 토큰입니다.');
+        });
+    });
+
+    it('잘못된 카테고리 이름으로 요청시 400을 반환한다.', async () => {
+      // given
+      const { accessToken } = await authFixture.getAuthenticatedUser('ABC');
+
+      // when
+      // then
+      return request(app.getHttpServer())
+        .post(`/api/v1/categories`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({
+          name: '',
+        })
+        .expect(400)
+        .expect((res: request.Response) => {
+          expect(res.body.success).toBe(false);
+          expect(res.body.data.name).toBe('잘못된 카테고리 이름입니다.');
+        });
+    });
+  });
+
+  describe('카테고리를 조회할 수 있다.', () => {
+    it('그룹에 속한 유저는 그룹 카테고리를 조회할 요청시 카테고리와 200을 반환한다.', async () => {
+      // given
+      const { accessToken } = await authFixture.getAuthenticatedUser('ABC');
+
+      const categoryMetadata = [
+        new CategoryMetaData({
+          categoryId: '-1',
+          categoryName: null,
+          insertedAt: '2021-08-01T00:00:00Z',
+          achievementCount: '1',
+        }),
+        new CategoryMetaData({
+          categoryId: '1007',
+          categoryName: '카테고리1007',
+          insertedAt: '2021-08-01T00:00:00Z',
+          achievementCount: '2',
+        }),
+        new CategoryMetaData({
+          categoryId: '1008',
+          categoryName: '카테고리1008',
+          insertedAt: '2021-08-01T00:00:00Z',
+          achievementCount: '3',
+        }),
+      ];
+
+      when(
+        mockCategoryService.getCategoriesByUser(anyOfClass(User)),
+      ).thenResolve(categoryMetadata);
+
+      // when
+      // then
+      return request(app.getHttpServer())
+        .get(`/api/v1/categories`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(200)
+        .expect((res: request.Response) => {
+          expect(res.body.success).toBe(true);
+          expect(res.body.data.length).toBe(4);
+          expect(res.body.data[0].id).toEqual(0);
+          expect(res.body.data[0].name).toEqual('전체');
+          expect(res.body.data[0].continued).toEqual(6);
+          expect(res.body.data[1].id).toEqual(-1);
+          expect(res.body.data[1].name).toEqual('미설정');
+          expect(res.body.data[1].continued).toEqual(1);
+          expect(res.body.data[2].id).toEqual(1007);
+          expect(res.body.data[2].name).toEqual('카테고리1007');
+          expect(res.body.data[2].continued).toEqual(2);
+          expect(res.body.data[3].id).toEqual(1008);
+          expect(res.body.data[3].name).toEqual('카테고리1008');
+          expect(res.body.data[3].continued).toEqual(3);
+        });
+    });
+
+    it('그룹에 속하지 않은 유저는 그룹 카테고리를 조회할 요청시 400을 반환한다.', async () => {
+      // given
+      const { accessToken } = await authFixture.getAuthenticatedUser('ABC');
+
+      const groupCategoryMetadata = [];
+
+      when(
+        mockCategoryService.getCategoriesByUser(anyOfClass(User)),
+      ).thenResolve(groupCategoryMetadata);
+
+      // when
+      // then
+      return request(app.getHttpServer())
+        .get(`/api/v1/categories`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(200)
+        .expect((res: request.Response) => {
+          expect(res.body.success).toBe(true);
+          expect(res.body.data.length).toBe(2);
+          expect(res.body.data[0].id).toEqual(0);
+          expect(res.body.data[0].name).toEqual('전체');
+          expect(res.body.data[0].continued).toEqual(0);
+          expect(res.body.data[1].id).toEqual(-1);
+          expect(res.body.data[1].name).toEqual('미설정');
+          expect(res.body.data[1].continued).toEqual(0);
+        });
+    });
+
+    it('잘못된 인증시 401을 반환한다.', async () => {
+      // given
+      const accessToken = 'abcd.abcd.efgh';
+
+      // when
+      // then
+      return request(app.getHttpServer())
+        .get(`/api/v1/categories`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(401)
+        .expect((res: request.Response) => {
+          expect(res.body.success).toBe(false);
+          expect(res.body.message).toBe('잘못된 토큰입니다.');
+        });
+    });
+
+    it('만료된 인증정보에 401을 반환한다.', async () => {
+      // given
+      const { accessToken } =
+        await authFixture.getExpiredAccessTokenUser('ABC');
+
+      // when
+      // then
+      return request(app.getHttpServer())
+        .get(`/api/v1/categories`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(401)
+        .expect((res: request.Response) => {
+          expect(res.body.success).toBe(false);
+          expect(res.body.message).toBe('만료된 토큰입니다.');
+        });
+    });
+  });
+
+  describe('단 건의 카테고리를 조회할 수 있다.', () => {
+    it('사용자는 자신의 카테고리를 조회할 요청시 카테고리와 200을 반환한다.', async () => {
+      // given
+      const { accessToken } = await authFixture.getAuthenticatedUser('ABC');
+
+      const category = new GroupCategoryMetadata({
+        categoryId: '1005',
+        categoryName: '카테고리',
+        insertedAt: '2021-08-01T00:00:00Z',
+        achievementCount: '1',
+      });
+
+      when(mockCategoryService.getCategory(anyOfClass(User), 1005)).thenResolve(
+        category,
+      );
+
+      // when
+      // then
+      return request(app.getHttpServer())
+        .get(`/api/v1/categories/1005`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(200)
+        .expect((res: request.Response) => {
+          expect(res.body.success).toBe(true);
+          expect(res.body.data.id).toBe(1005);
+          expect(res.body.data.name).toBe('카테고리');
+          expect(res.body.data.continued).toBe(1);
+          expect(res.body.data.lastChallenged).toBe('2021-08-01T00:00:00Z');
+        });
+    });
+
+    it('본인 소유의 카테고리가 아닌 조회 요청시 404를 반환한다.', async () => {
+      // given
+      const { accessToken } = await authFixture.getAuthenticatedUser('ABC');
+
+      when(mockCategoryService.getCategory(anyOfClass(User), 1006)).thenThrow(
+        new NotFoundCategoryException(),
+      );
+
+      // when
+      // then
+      return request(app.getHttpServer())
+        .get(`/api/v1/categories/1006`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(404)
+        .expect((res: request.Response) => {
+          expect(res.body.success).toBe(false);
+          expect(res.body.message).toBe('카테고리를 찾을 수 없습니다.');
+        });
+    });
+
+    it('잘못된 인증시 401을 반환한다.', async () => {
+      // given
+      const accessToken = 'abcd.abcd.efgh';
+
+      // when
+      // then
+      return request(app.getHttpServer())
+        .get(`/api/v1/categories/1006`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(401)
+        .expect((res: request.Response) => {
+          expect(res.body.success).toBe(false);
+          expect(res.body.message).toBe('잘못된 토큰입니다.');
+        });
+    });
+
+    it('만료된 인증정보에 401을 반환한다.', async () => {
+      // given
+      const { accessToken } =
+        await authFixture.getExpiredAccessTokenUser('ABC');
+
+      // when
+      // then
+      return request(app.getHttpServer())
+        .get(`/api/v1/categories/1006`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(401)
+        .expect((res: request.Response) => {
+          expect(res.body.success).toBe(false);
+          expect(res.body.message).toBe('만료된 토큰입니다.');
+        });
+    });
+  });
+});

--- a/BE/src/category/controller/category.controller.spec.ts
+++ b/BE/src/category/controller/category.controller.spec.ts
@@ -51,7 +51,7 @@ describe('CategoryController Test', () => {
     });
   });
 
-  describe('그룹 카테고리를 생성할 수 있다.', () => {
+  describe('카테고리를 생성할 수 있다.', () => {
     it('사용자가 카테고리 생성 요청시 카테고리와 201을 반환한다.', async () => {
       // given
       const { accessToken } = await authFixture.getAuthenticatedUser('ABC');
@@ -145,7 +145,7 @@ describe('CategoryController Test', () => {
   });
 
   describe('카테고리를 조회할 수 있다.', () => {
-    it('그룹에 속한 유저는 그룹 카테고리를 조회할 요청시 카테고리와 200을 반환한다.', async () => {
+    it('사용자 본인에 대한 카테고리를 조회할 요청시 카테고리와 200을 반환한다.', async () => {
       // given
       const { accessToken } = await authFixture.getAuthenticatedUser('ABC');
 
@@ -198,7 +198,7 @@ describe('CategoryController Test', () => {
         });
     });
 
-    it('그룹에 속하지 않은 유저는 그룹 카테고리를 조회할 요청시 400을 반환한다.', async () => {
+    it('사용자 본인이 아닌 카테고리를 조회할 요청시 400을 반환한다.', async () => {
       // given
       const { accessToken } = await authFixture.getAuthenticatedUser('ABC');
 

--- a/BE/src/category/controller/category.controller.ts
+++ b/BE/src/category/controller/category.controller.ts
@@ -4,6 +4,7 @@ import {
   Get,
   HttpCode,
   HttpStatus,
+  Param,
   Post,
   UseGuards,
 } from '@nestjs/common';
@@ -22,6 +23,8 @@ import { User } from '../../users/domain/user.domain';
 import { AccessTokenGuard } from '../../auth/guard/access-token.guard';
 import { CategoryResponse } from '../dto/category.response';
 import { CategoryListElementResponse } from '../dto/category-list-element.response';
+import { ParseIntPipe } from '../../common/pipe/parse-int.pipe';
+import { GroupCategoryListElementResponse } from '../../group/category/dto/group-category-list-element.response';
 
 @Controller('/api/v1/categories')
 @ApiTags('카테고리 API')
@@ -68,5 +71,25 @@ export class CategoryController {
   ): Promise<ApiData<CategoryListElementResponse[]>> {
     const categories = await this.categoryService.getCategoriesByUser(user);
     return ApiData.success(CategoryListElementResponse.build(categories));
+  }
+
+  @ApiBearerAuth('accessToken')
+  @ApiOperation({
+    summary: '카테고리 조회 API',
+    description: '사용자 본인에 대한 단 건의 카테고리를 조회합니다.',
+  })
+  @ApiResponse({
+    description: '카테고리 조회',
+    type: CategoryListElementResponse,
+  })
+  @Get('/:categoryId')
+  @UseGuards(AccessTokenGuard)
+  @HttpCode(HttpStatus.OK)
+  async getCategory(
+    @Param('categoryId', ParseIntPipe) categoryId: number,
+    @AuthenticatedUser() user: User,
+  ): Promise<ApiData<CategoryListElementResponse>> {
+    const category = await this.categoryService.getCategory(user, categoryId);
+    return ApiData.success(new GroupCategoryListElementResponse(category));
   }
 }

--- a/BE/src/category/controller/category.controller.ts
+++ b/BE/src/category/controller/category.controller.ts
@@ -24,7 +24,6 @@ import { AccessTokenGuard } from '../../auth/guard/access-token.guard';
 import { CategoryResponse } from '../dto/category.response';
 import { CategoryListElementResponse } from '../dto/category-list-element.response';
 import { ParseIntPipe } from '../../common/pipe/parse-int.pipe';
-import { GroupCategoryListElementResponse } from '../../group/category/dto/group-category-list-element.response';
 
 @Controller('/api/v1/categories')
 @ApiTags('카테고리 API')
@@ -90,6 +89,6 @@ export class CategoryController {
     @AuthenticatedUser() user: User,
   ): Promise<ApiData<CategoryListElementResponse>> {
     const category = await this.categoryService.getCategory(user, categoryId);
-    return ApiData.success(new GroupCategoryListElementResponse(category));
+    return ApiData.success(new CategoryListElementResponse(category));
   }
 }

--- a/BE/src/category/entities/category.repository.spec.ts
+++ b/BE/src/category/entities/category.repository.spec.ts
@@ -91,7 +91,7 @@ describe('CategoryRepository', () => {
       const user = await usersFixture.getUser(1);
 
       const retrievedCategories =
-        await categoryRepository.findByUserWithCount(user);
+        await categoryRepository.findAllByUserWithCount(user);
 
       expect(retrievedCategories).toBeDefined();
       expect(retrievedCategories.length).toBe(0);
@@ -112,7 +112,7 @@ describe('CategoryRepository', () => {
       await achievementFixture.getAchievements(10, user, categories[3]);
 
       const retrievedCategories =
-        await categoryRepository.findByUserWithCount(user);
+        await categoryRepository.findAllByUserWithCount(user);
 
       expect(retrievedCategories.length).toBe(5);
       expect(retrievedCategories[0].categoryId).toEqual(categories[0].id);
@@ -152,19 +152,107 @@ describe('CategoryRepository', () => {
   });
 
   it('findNotSpecifiedByUserAndId는 사용자의 미분류 카테고리를 조회할 수 있다.', async () => {
-    // given
-    const user = await usersFixture.getUser('ABC');
-    await categoryFixture.getCategory(user, '미분류');
-    await achievementFixture.getAchievements(4, user, null);
+    await transactionTest(dataSource, async () => {
+      // given
+      const user = await usersFixture.getUser('ABC');
+      await categoryFixture.getCategory(user, '미분류');
+      await achievementFixture.getAchievements(4, user, null);
 
-    // when
-    const retrievedCategory =
-      await categoryRepository.findNotSpecifiedByUserAndId(user);
+      // when
+      const retrievedCategory =
+        await categoryRepository.findNotSpecifiedByUserAndId(user);
 
-    // then
-    expect(retrievedCategory.categoryId).toEqual(-1);
-    expect(retrievedCategory.categoryName).toEqual('미설정');
-    expect(retrievedCategory.insertedAt).toBeInstanceOf(Date);
-    expect(retrievedCategory.achievementCount).toBe(4);
+      // then
+      expect(retrievedCategory.categoryId).toEqual(-1);
+      expect(retrievedCategory.categoryName).toEqual('미설정');
+      expect(retrievedCategory.insertedAt).toBeInstanceOf(Date);
+      expect(retrievedCategory.achievementCount).toBe(4);
+    });
+  });
+
+  describe('findByUserWithCount은 특정 카테고리의 메타데이터를 조회할 수 있다.', () => {
+    it('사용자가 소유한 카테고리가 없으면 null을 반환한다.', async () => {
+      await transactionTest(dataSource, async () => {
+        // given
+        const user = await usersFixture.getUser('ABC');
+        await categoryFixture.getCategory(user, '미분류');
+        await achievementFixture.getAchievements(4, user, null);
+
+        const other = await usersFixture.getUser('DEF');
+        const otherCategory = await categoryFixture.getCategory(
+          other,
+          '카테고리',
+        );
+
+        // when
+        const retrievedCategory = await categoryRepository.findByUserWithCount(
+          user,
+          otherCategory.id,
+        );
+
+        // then
+        expect(retrievedCategory).toBeNull();
+      });
+    });
+
+    it('사용자가 소유한 카테고리가 있으면 카테고리의 메타데이터를 반환한다.', async () => {
+      await transactionTest(dataSource, async () => {
+        // given
+        const user = await usersFixture.getUser('ABC');
+        const category = await categoryFixture.getCategory(user, '카테고리~');
+        await achievementFixture.getAchievements(7, user, category);
+
+        // when
+        const retrievedCategory = await categoryRepository.findByUserWithCount(
+          user,
+          category.id,
+        );
+
+        // then
+        expect(retrievedCategory.categoryId).toEqual(category.id);
+        expect(retrievedCategory.categoryName).toEqual('카테고리~');
+        expect(retrievedCategory.insertedAt).toBeInstanceOf(Date);
+        expect(retrievedCategory.achievementCount).toBe(7);
+      });
+    });
+  });
+
+  describe('findTotalCategoryMetadata는 사용자의 전체 카테고리 메타데이터를 조회할 수 있다.', () => {
+    it('사용자가 소유한 카테고리가 없어도 조회할 수 있다.', async () => {
+      await transactionTest(dataSource, async () => {
+        // given
+        const user = await usersFixture.getUser('ABC');
+
+        // when
+        const retrievedCategory =
+          await categoryRepository.findTotalCategoryMetadata(user);
+
+        // then
+        expect(retrievedCategory.categoryId).toEqual(0);
+        expect(retrievedCategory.categoryName).toEqual('전체');
+        expect(retrievedCategory.insertedAt).toBeNull();
+        expect(retrievedCategory.achievementCount).toBe(0);
+      });
+    });
+
+    it('사용자가 소유한 카테고리가 있으면 카테고리의 메타데이터를 반환한다.', async () => {
+      await transactionTest(dataSource, async () => {
+        // given
+        const user = await usersFixture.getUser('ABC');
+        const category = await categoryFixture.getCategory(user, '미분류');
+        await achievementFixture.getAchievements(10, user, category);
+        await achievementFixture.getAchievements(4, user, null);
+
+        // when
+        const retrievedCategory =
+          await categoryRepository.findTotalCategoryMetadata(user);
+
+        // then
+        expect(retrievedCategory.categoryId).toEqual(0);
+        expect(retrievedCategory.categoryName).toEqual('전체');
+        expect(retrievedCategory.insertedAt).toBeInstanceOf(Date);
+        expect(retrievedCategory.achievementCount).toBe(14);
+      });
+    });
   });
 });

--- a/BE/src/category/entities/category.repository.ts
+++ b/BE/src/category/entities/category.repository.ts
@@ -24,11 +24,20 @@ export class CategoryRepository extends TransactionalRepository<CategoryEntity> 
   async findCategoriesByUser(user: User): Promise<CategoryMetaData[]> {
     const notSpecifiedCategoryMetaData =
       await this.findNotSpecifiedByUserAndId(user);
-    const categoryMetaData = await this.findByUserWithCount(user);
+    const categoryMetaData = await this.findAllByUserWithCount(user);
     return [notSpecifiedCategoryMetaData, ...categoryMetaData];
   }
 
-  async findByUserWithCount(user: User): Promise<CategoryMetaData[]> {
+  async findCategory(
+    user: User,
+    categoryId: number,
+  ): Promise<CategoryMetaData> {
+    if (categoryId === -1) return this.findNotSpecifiedByUserAndId(user);
+    if (categoryId === 0) return this.findTotalCategoryMetadata(user);
+    return this.findByUserWithCount(user, categoryId);
+  }
+
+  async findAllByUserWithCount(user: User): Promise<CategoryMetaData[]> {
     const categories = await this.repository
       .createQueryBuilder('category')
       .select('category.id as categoryId')
@@ -42,6 +51,43 @@ export class CategoryRepository extends TransactionalRepository<CategoryEntity> 
       .getRawMany<ICategoryMetaData>();
 
     return categories.map((category) => new CategoryMetaData(category));
+  }
+
+  async findByUserWithCount(
+    user: User,
+    categoryId: number,
+  ): Promise<CategoryMetaData> {
+    const category = await this.repository
+      .createQueryBuilder('category')
+      .select('category.id as categoryId')
+      .addSelect('category.name', 'categoryName')
+      .addSelect('MAX(achievement.created_at)', 'insertedAt')
+      .addSelect('COUNT(achievement.id)', 'achievementCount')
+      .leftJoin('category.achievements', 'achievement')
+      .where('category.user_id = :user', { user: user.id })
+      .andWhere('category.id = :categoryId', { categoryId: categoryId })
+      .orderBy('category.id', 'ASC')
+      .groupBy('category.id')
+      .getRawOne<ICategoryMetaData>();
+
+    if (!category) return null;
+    return new CategoryMetaData(category);
+  }
+
+  async findTotalCategoryMetadata(user: User): Promise<CategoryMetaData> {
+    const achievementRepository: Repository<AchievementEntity> =
+      this.repository.manager.getRepository(AchievementEntity);
+
+    const category = await achievementRepository
+      .createQueryBuilder('achievement')
+      .select('0 as categoryId')
+      .addSelect(`'전체' as categoryName`)
+      .addSelect('MAX(achievement.created_at)', 'insertedAt')
+      .addSelect('COUNT(*)', 'achievementCount')
+      .where('achievement.user_id = :user', { user: user.id })
+      .getRawOne<ICategoryMetaData>();
+
+    return new CategoryMetaData(category);
   }
 
   async findNotSpecifiedByUserAndId(user: User): Promise<CategoryMetaData> {

--- a/BE/src/category/exception/not-found-category.exception.ts
+++ b/BE/src/category/exception/not-found-category.exception.ts
@@ -1,0 +1,8 @@
+import { MotimateException } from '../../common/exception/motimate.excpetion';
+import { ERROR_INFO } from '../../common/exception/error-code';
+
+export class NotFoundCategoryException extends MotimateException {
+  constructor() {
+    super(ERROR_INFO.NOT_FOUND_CATEGORY);
+  }
+}

--- a/BE/src/common/exception/error-code.ts
+++ b/BE/src/common/exception/error-code.ts
@@ -111,4 +111,8 @@ export const ERROR_INFO = {
     statusCode: 403,
     message: '달성기록에 접근할 수 없습니다.',
   },
+  NOT_FOUND_CATEGORY: {
+    statusCode: 404,
+    message: '카테고리를 찾을 수 없습니다.',
+  },
 } as const;


### PR DESCRIPTION
## PR 요약
단 건의 카테고리 조회 API를 작성한다.

#### 변경 사항
* 단 건 카테고리 조회 API
* 카테고리 컨트롤러 테스트 코드

##### 스크린샷

* 미설정 카테고리 조회

![image](https://github.com/boostcampwm2023/iOS02-moti/assets/75921696/f2bcdcff-d18f-4a8c-9cdc-d01f6584bdaa)

* 전체 카테고리 조회

![image](https://github.com/boostcampwm2023/iOS02-moti/assets/75921696/e62e2987-4e07-4fb6-b870-24b0db731bd8)

* 카테고리 조회

![image](https://github.com/boostcampwm2023/iOS02-moti/assets/75921696/31afe72e-eba2-44ca-b303-ac694afb5272)

* 다른 사용자 카테고리 조회

![image](https://github.com/boostcampwm2023/iOS02-moti/assets/75921696/1504f8c9-1946-447f-8b24-e90a2da0af5d)


#### Linked Issue
close #497
