### PR TITLE
홈 뷰를 매우 조금 스크롤할 때 탭바가 없어지는 문제 픽스

### DIFF
--- a/iOS/moti/moti/Presentation/Sources/Presentation/TabBar/TabBarViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/TabBar/TabBarViewController.swift
@@ -65,6 +65,7 @@ final class TabBarViewController: UITabBarController {
         UIView.animate(withDuration: 0.3, animations: {
             self.moveDownTabBar()
         }, completion: { _ in
+            if self.isShowing { return }
             self.tabBar.isHidden = true
             self.captureButton.isHidden = true
             self.borderView.isHidden = true


### PR DESCRIPTION
## PR 요약
- 드래그가 끝나면 탭바가 올라와서 보여야 하는데, 매우 조금 스크롤하면 안 보임
- 원인: 0.3초 애니메이션이 completion되면 히든처리가 되기 때문에, 그 사이에 show를 하면 0.3초가 끝나고 히든 처리 되어버림
- completion이 시작할 때 isShowing 이면 히든 처리를 안 하도록 조건 추가로 해결

#### 스크린샷
<img width="33%" src="https://github.com/boostcampwm2023/iOS02-moti/assets/60506170/bbea7332-61c9-4336-b1e8-77d1c10e6e0c">

#### Linked Issue
close #508 
