### PR TITLE
다운 샘플링 이미지로 업로드, 사진 업로드에 실패하면 다시 시도

### DIFF
--- a/iOS/moti/moti/Presentation/Sources/Presentation/Capture/CaptureView.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Capture/CaptureView.swift
@@ -22,7 +22,7 @@ final class CaptureView: UIView {
     let captureButton = CaptureButton()
 
     // Video Preview
-    private let preview = {
+    let preview = {
         let view = UIView()
         view.backgroundColor = .primaryGray
         return view

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Capture/CaptureViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Capture/CaptureViewController.swift
@@ -11,6 +11,7 @@ import AVFoundation
 import Design
 import PhotosUI
 import Domain
+import Jeongfisher
 
 protocol CaptureViewControllerDelegate: AnyObject {
     func didCapture(image: UIImage)
@@ -69,7 +70,18 @@ final class CaptureViewController: BaseViewController<CaptureView> {
     
     private func capturedPicture(image: UIImage) {
         guard let croppedImage = image.cropToSquare() else { return }
-        delegate?.didCapture(image: croppedImage)
+        
+        // 앨범에서 선택도 가능하기 때문에 해당 위치에서 다운샘플링 진행
+        let size = layoutView.preview.frame.size
+        guard let data = croppedImage.jpegData(compressionQuality: 1.0),
+              let downsampledImage = data.downsampling(to: size, scale: 3) else { return }
+        
+        #if DEBUG
+        Logger.debug("프리뷰 사이즈: \(size)")
+        Logger.debug("다운샘플링 이미지 사이즈: \(downsampledImage.size)")
+        #endif
+        
+        delegate?.didCapture(image: downsampledImage)
     }
 }
 

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Common/BaseViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Common/BaseViewController.swift
@@ -61,14 +61,16 @@ extension BaseViewController {
         title: String? = nil,
         message: String? = nil,
         okTitle: String? = "확인",
-        okAction: (() -> Void)? = nil
+        okAction: (() -> Void)? = nil,
+        cancelAction: (() -> Void)? = nil
     ) {
         let alertVC = AlertFactory.makeTwoButtonAlert(
             title: title,
             message: message,
             okTitle: okTitle,
             okAction: okAction,
-            cancelTitle: "취소"
+            cancelTitle: "취소",
+            cancelAction: cancelAction
         )
         present(alertVC, animated: true)
     }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementViewController.swift
@@ -129,8 +129,8 @@ private extension EditAchievementViewController {
         present(bottomSheet, animated: true)
     }
 
-    func hideBottomSheet() {
-        bottomSheet.dismiss(animated: true)
+    func hideBottomSheet(completion: (() -> Void)? = nil) {
+        bottomSheet.dismiss(animated: true, completion: completion)
     }
 }
 
@@ -288,9 +288,8 @@ private extension EditAchievementViewController {
                     doneButton.isEnabled = false
                     doneButton.title = "실패"
                     
-                    hideBottomSheet()
                     // Bottom Sheet이 띄워져 있으면 Alert이 안 나옴
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
+                    hideBottomSheet(completion: {
                         self.showTwoButtonAlert(
                             title: "사진 업로드 실패",
                             message: "네트워크가 불안정하여 사진 업로드를 실패했습니다. 다시 시도해 주세요.",
@@ -305,7 +304,7 @@ private extension EditAchievementViewController {
                                 self.showUploadButton()
                             }
                         )
-                    }
+                    })
                 }
             }
             .store(in: &cancellables)

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Extension/UIImage+Extension.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Extension/UIImage+Extension.swift
@@ -31,8 +31,8 @@ extension UIImage {
         return UIImage(cgImage: croppedCGImage)
     }
     
-    /// 이미지의 방향을 up으로 고정하는 메서드
     // https://gist.github.com/schickling/b5d86cb070130f80bb40?permalink_comment_id=3500925#gistcomment-3500925
+    /// 이미지의 방향을 up으로 고정하는 메서드
     func fixedOrientation() -> UIImage? {
         guard imageOrientation != .up else { return self }
         


### PR DESCRIPTION
## PR 요약
- 다운 샘플링 이미지로 업로드
- 사진 업로드에 실패하면 다시 시도할 수 있도록 구현

##### 스크린샷

![Simulator Screen Recording - iPhone 15 Pro - 2023-12-07 at 15 16 05](https://github.com/boostcampwm2023/iOS02-moti/assets/89075274/70f5a036-e222-44d1-99e4-d21b567770c3)

#### Linked Issue
close #507 
