### PR TITLE
[iOS] feat: 캡처 버튼 버그 수정, 편집화면 버그 수정

### DIFF
--- a/iOS/moti/moti/Design/Sources/Design/CaptureButton.swift
+++ b/iOS/moti/moti/Design/Sources/Design/CaptureButton.swift
@@ -24,6 +24,9 @@ public final class CaptureButton: UIButton {
         
         setupUI()
         addTarget()
+        
+        let size = min(Self.defaultSize, Self.defaultSize)
+        applyCorenrRadius(size: size)
     }
     
     required init?(coder: NSCoder) {
@@ -34,13 +37,6 @@ public final class CaptureButton: UIButton {
         addTarget(self, action: #selector(captureButtonTouchDown), for: .touchDown)
         addTarget(self, action: #selector(captureButtonTouchUpInside), for: .touchUpInside)
         addTarget(self, action: #selector(captureButtonTouchUpOutside), for: .touchUpOutside)
-    }
-    
-    public override func layoutSubviews() {
-        super.layoutSubviews()
-        
-        let size = min(frame.width, frame.height)
-        applyCorenrRadius(size: size)
     }
     
     // MARK: - Setup

--- a/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementViewController.swift
@@ -178,8 +178,6 @@ extension EditAchievementViewController: UIPickerViewDataSource {
 private extension EditAchievementViewController {
     func setupNavigationBar() {
         navigationItem.rightBarButtonItems = [doneButton]
-        doneButton.isEnabled = false
-        doneButton.title = "로딩 중"
     }
     
     func showDoneButton() {
@@ -276,7 +274,8 @@ private extension EditAchievementViewController {
                 guard let self else { return }
                 print("Save Image: \(state)")
                 switch state {
-                case .none, .loading:
+                case .none: break
+                case .loading:
                     doneButton.isEnabled = false
                     doneButton.title = "로딩 중"
                 case .finish:

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupDetailAchievement/GroupDetailAchievementViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupDetailAchievement/GroupDetailAchievementViewController.swift
@@ -110,13 +110,25 @@ final class GroupDetailAchievementViewController: BaseViewController<GroupDetail
         })
         // 작성자가 아닌 유저에게만 표시
         let blockingAchievementAction = UIAction(title: "도전기록 차단", attributes: .destructive, handler: { _ in
-            self.viewModel.action(.blockingAchievement)
-            self.delegate?.blockingAchievementMenuDidClicked(achievementId: self.viewModel.achievement.id)
+            self.showDestructiveTwoButtonAlert(
+                title: "도전기록 차단",
+                message: "더이상 해당 도전기록을 볼 수 없습니다.\n정말 차단하시겠습니까?",
+                okTitle: "차단",
+                okAction: {
+                    self.viewModel.action(.blockingAchievement)
+                    self.delegate?.blockingAchievementMenuDidClicked(achievementId: self.viewModel.achievement.id)
+            })
         })
         // 작성자가 아닌 유저에게만 표시
         let blockingUserAction = UIAction(title: "사용자 차단", attributes: .destructive, handler: { _ in
-            self.viewModel.action(.blockingUser)
-            self.delegate?.blockingUserMenuDidClicked(userCode: self.viewModel.achievement.userCode)
+            self.showDestructiveTwoButtonAlert(
+                title: "사용자 차단",
+                message: "더이상 해당 사용자의 모든 도전기록을 볼 수 없습니다.\n정말 차단하시겠습니까?",
+                okTitle: "차단",
+                okAction: {
+                    self.viewModel.action(.blockingUser)
+                    self.delegate?.blockingUserMenuDidClicked(userCode: self.viewModel.achievement.userCode)
+            })
         })
         
         var children: [UIAction] = []

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeViewController.swift
@@ -344,11 +344,23 @@ extension GroupHomeViewController: UICollectionViewDelegate {
             })
             // 작성자가 아닌 유저에게만 표시
             let blockingAchievementAction = UIAction(title: "도전기록 차단", attributes: .destructive, handler: { _ in
-                self?.viewModel.action(.blockingAchievement(achievementId: selectedItem.id))
+                self?.showDestructiveTwoButtonAlert(
+                    title: "도전기록 차단",
+                    message: "더이상 해당 도전기록을 볼 수 없습니다.\n정말 차단하시겠습니까?",
+                    okTitle: "차단",
+                    okAction: {
+                        self?.viewModel.action(.blockingAchievement(achievementId: selectedItem.id))
+                })
             })
             // 작성자가 아닌 유저에게만 표시
             let blockingUserAction = UIAction(title: "사용자 차단", attributes: .destructive, handler: { _ in
-                self?.viewModel.action(.blockingUser(userCode: selectedItem.userCode))
+                self?.showDestructiveTwoButtonAlert(
+                    title: "사용자 차단",
+                    message: "더이상 해당 사용자의 모든 도전기록을 볼 수 없습니다.\n정말 차단하시겠습니까?",
+                    okTitle: "차단",
+                    okAction: {
+                        self?.viewModel.action(.blockingUser(userCode: selectedItem.userCode))
+                })
             })
             
             var children: [UIAction] = []


### PR DESCRIPTION
## PR 요약
- 캡처 버튼이 사각형으로 변하는 버그
- 편집화면에서 로딩중이라고 뜨는 버그
- 차단 액션에 확인 Alert 추가
    - 더이상 해당 도전기록을 볼 수 없습니다. 정말 차단하시겠습니까?
    - 더이상 해당 사용자의 모든 도전기록을 볼 수 없습니다. 정말 차단하시겠습니까?
