### PR TITLE
redis option 수정

### DIFF
--- a/BE/src/config/redis/index.ts
+++ b/BE/src/config/redis/index.ts
@@ -1,18 +1,29 @@
 import { ConfigModule, ConfigService } from '@nestjs/config';
-import { redisStore } from 'cache-manager-redis-store';
 import { memoryStore } from 'cache-manager';
+import { redisStore } from 'cache-manager-redis-store';
+import { CacheStore } from '@nestjs/cache-manager';
+import { CacheManagerOptions } from '@nestjs/cache-manager/dist/interfaces/cache-manager.interface';
 
 export const redisModuleOptions = {
   imports: [ConfigModule],
   inject: [ConfigService],
-  useFactory: async (configService: ConfigService) => {
-    return configService.get('NODE_ENV') === 'production'
-      ? {
-          store: redisStore,
+  useFactory: async (
+    configService: ConfigService,
+  ): Promise<CacheManagerOptions> => {
+    if (configService.get('NODE_ENV') === 'production') {
+      const store = await redisStore({
+        socket: {
           host: configService.get('REDIS_HOST'),
           port: configService.get('REDIS_PORT'),
-          ttl: configService.get('CACHE_TTL'),
-        }
-      : { store: memoryStore };
+        },
+        ttl: configService.get('CACHE_TTL'),
+      });
+      return {
+        store: {
+          create: () => store as unknown as CacheStore,
+        },
+      };
+    }
+    return { store: memoryStore, ttl: configService.get('CACHE_TTL') };
   },
 };


### PR DESCRIPTION
## PR 요약
- redis option 수정
- host, post, ttl 모두 적용되는지 확인
- production에서만 redis 그외는 in memory store 를 사용한다.
- 참조
  - https://github.com/dabroek/node-cache-manager-redis-store/issues/40 
#### Linked Issue
close #533
