### PR TITLE
촬영 화면으로 들어갈 때 카메라 프리뷰의 위치가 아래로 살짝 내려가는 버그 픽스

### DIFF
--- a/iOS/moti/moti/Presentation/Sources/Presentation/Capture/CaptureView.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Capture/CaptureView.swift
@@ -148,14 +148,14 @@ private extension CaptureView {
     }
     
     private func updatePreviewConstraint() {
-        if let bounds = window?.windowScene?.screen.bounds {
+        if let bounds = window?.windowScene?.screen.bounds, let window {
             NSLayoutConstraint.deactivate(preview.constraints)
             
             let minSize = min(400, bounds.width, bounds.height)
             preview.atl
                 .size(width: minSize, height: minSize)
                 .centerX(equalTo: safeAreaLayoutGuide.centerXAnchor)
-                .centerY(equalTo: safeAreaLayoutGuide.centerYAnchor, constant: -50)
+                .centerY(equalTo: window.centerYAnchor, constant: -20)
         }
     }
 }


### PR DESCRIPTION
## PR 요약
- 촬영 화면으로 들어갈 때 카메라 프리뷰의 위치가 아래로 살짝 내려가는 버그 픽스


### 문제 원인 (실험적 증명이기 때문에 우리 앱에서 오토레이아웃을 잘못 잡아서일 가능성을 배제할 수 없다.)

CaptureView가 (init(frame:) 될 때 safeAreaLayoutGuide의 centerYAnchor) 와 (layoutSubviews() 될 때 safeAreaLayoutGuide의 centerYAnchor) 가 다르다. 그래서 init -> layoutSubviews 순서로 불리면서 centerY 앵커도 달라지면서 살짝 내려가는 것이다. centerYAnchor 뿐만 아니라 bottomAnchor도 달라지기 때문에 일단 safeAreaLayoutGuide가 바뀐다고 보면 된다.

### 시도
1. safeAreaLayoutGuide.centerYAnchor가 아니라 기본 centerYAnchor로 오토레이아웃을 잡았으나 프리뷰가 잘 자리 잡지 못하여 카메라가 나오지 않았다. 
2. 기본 topAnchor를 주고 기본 bottomAnchor를 줘도 마찬가지로 잡히지 않았다.
3. 기본 topAnchor를 주고 safeAreaLayoutGuide.bottomAnchor를 주면 프리뷰가 잘 나왔다. 

=> 시도로 얻은 결론: 기본 topAnchor는 문제 없지만, 기본 bottomAnchor를 찾을 수 없기 때문에 기본 centerYAnchor도 찾을 수 없다. 그래서 기본 centerYAnchor를 사용할 수 없었다.
(4. 프리뷰에 size가 있고, centerX가 있는 상태에서 top만 주면 잘 나와야 하는데 안 나온다. bottom까지 잡아줘야 나온다. 이유는 ..?)

### 해결
프리뷰를 top, bottom으로 잡으면 우리 앱에서 원하는 정사각형을 중앙 쯤에 배치하는 것이 어려워 진다. centerYAnchor가 꼭 필요한데, 그래서 찾을 수 없는 기본 centerYAnchor 대신 window의 centerYAnchor를 사용했다. 다만, window는 safeArea에 비해 위아래로 더 크기 때문에 centerY도 위로 더 올라간다. 그래서 기존의 -50을 조금 내려서 -20정도로 수정하면 된다. 결론적으로 프리뷰가 아래로 움직이지 않고 잘 고정되어 자리 잡힌다.



#### Linked Issue
close #539
