### PR TITLE
회원탈퇴 버튼 추가 / 촬영, 편집 화면 오토레이아웃 수정 / 아이패드 대응 오토레이아웃 추가

### DIFF
--- a/iOS/moti/moti/Core/Sources/Core/Logger.swift
+++ b/iOS/moti/moti/Core/Sources/Core/Logger.swift
@@ -26,6 +26,6 @@ public enum Logger {
     
     public static func network<T>(_ object: T?) {
         let message = object != nil ? "\(object!)" : "nil"
-        os_log(.debug, "[Network] %@", message)
+//        os_log(.debug, "[Network] %@", message)
     }
 }

--- a/iOS/moti/moti/Core/Sources/Core/Logger.swift
+++ b/iOS/moti/moti/Core/Sources/Core/Logger.swift
@@ -26,6 +26,6 @@ public enum Logger {
     
     public static func network<T>(_ object: T?) {
         let message = object != nil ? "\(object!)" : "nil"
-//        os_log(.debug, "[Network] %@", message)
+        os_log(.debug, "[Network] %@", message)
     }
 }

--- a/iOS/moti/moti/Data/Sources/Data/Network/DTO/UpdateAchievementDTO.swift
+++ b/iOS/moti/moti/Data/Sources/Data/Network/DTO/UpdateAchievementDTO.swift
@@ -17,4 +17,3 @@ struct UpdateAchievementResponseDTO: ResponseDTO {
 struct UpdateAchievementDataDTO: Codable {
     let id: Int
 }
-

--- a/iOS/moti/moti/Data/Tests/DataTests/Repository/AchievementListRepositoryTests.swift
+++ b/iOS/moti/moti/Data/Tests/DataTests/Repository/AchievementListRepositoryTests.swift
@@ -134,7 +134,6 @@ final class AchievementListRepositoryTests: XCTestCase {
             XCTAssertEqual(achievements, emptyAchievementList)
             XCTAssertNil(next)
             
-            
             expectation.fulfill()
         }
         

--- a/iOS/moti/moti/Domain/Sources/Domain/Entity/Achievement.swift
+++ b/iOS/moti/moti/Domain/Sources/Domain/Entity/Achievement.swift
@@ -83,7 +83,8 @@ public struct Achievement: Hashable {
 }
 
 public extension Achievement {
-    static func makeSkeleton() -> Achievement {
-        return .init(id: -(UUID().hashValue), title: "", imageURL: nil, categoryId: 0, user: nil)
+    static func makeSkeleton(id: Int) -> Achievement {
+        let id = id < 0 ? id : -id
+        return .init(id: id, title: "", imageURL: nil, categoryId: 0, user: nil)
     }
 }

--- a/iOS/moti/moti/Domain/Sources/Domain/UseCase/FetchDetailAchievementUseCase.swift
+++ b/iOS/moti/moti/Domain/Sources/Domain/UseCase/FetchDetailAchievementUseCase.swift
@@ -26,4 +26,3 @@ public struct FetchDetailAchievementUseCase {
         return try await repository.fetchDetailAchievement(requestValue: requestValue)
     }
 }
-

--- a/iOS/moti/moti/JKImageCache/Package.swift
+++ b/iOS/moti/moti/JKImageCache/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         // Products define the executables and libraries a package produces, making them visible to other packages.
         .library(
             name: "JKImageCache",
-            targets: ["JKImageCache"]),
+            targets: ["JKImageCache"])
     ],
     dependencies: [
         .package(url: "https://github.com/jeongju9216/Jeongfisher.git", from: "2.5.0")
@@ -26,6 +26,6 @@ let package = Package(
             path: "Sources"),
         .testTarget(
             name: "JKImageCacheTests",
-            dependencies: ["JKImageCache"]),
+            dependencies: ["JKImageCache"])
     ]
 )

--- a/iOS/moti/moti/Presentation/Sources/Presentation/AppInfo/AppInfoView.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/AppInfo/AppInfoView.swift
@@ -51,6 +51,16 @@ final class AppInfoView: UIView {
         button.titleLabel?.font = .medium
         return button
     }()
+    private(set) var revokeButton = {
+        let button = UIButton(type: .system)
+        button.clipsToBounds = true
+        button.layer.cornerRadius = CornerRadius.big
+        button.titleLabel?.font = .medium
+        button.setTitle("회원 탈퇴", for: .normal)
+        button.setTitleColor(.label, for: .normal)
+        button.backgroundColor = .primaryDarkGray
+        return button
+    }()
     
     // MARK: - Init
     override init(frame: CGRect) {
@@ -92,6 +102,7 @@ private extension AppInfoView {
         setupTitleLabel()
         setupVersionLabel()
         
+        setupRevokeButton()
         setupUpdateButton()
         setupPolicyButton()
     }
@@ -125,12 +136,21 @@ private extension AppInfoView {
             .top(equalTo: titleLabel.bottomAnchor, constant: 20)
     }
     
+    func setupRevokeButton() {
+        addSubview(revokeButton)
+        revokeButton.atl
+            .height(constant: 40)
+            .centerX(equalTo: centerXAnchor)
+            .bottom(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -20)
+            .horizontal(equalTo: safeAreaLayoutGuide, constant: 40)
+    }
+    
     func setupUpdateButton() {
         addSubview(updateButton)
         updateButton.atl
             .height(constant: 40)
             .centerX(equalTo: centerXAnchor)
-            .bottom(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -20)
+            .bottom(equalTo: revokeButton.topAnchor, constant: -10)
             .horizontal(equalTo: safeAreaLayoutGuide, constant: 40)
     }
     

--- a/iOS/moti/moti/Presentation/Sources/Presentation/AutoLayout/AutoLayoutWrapper+UIView.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/AutoLayout/AutoLayoutWrapper+UIView.swift
@@ -59,6 +59,16 @@ extension AutoLayoutWrapper {
     }
     
     @discardableResult
+    func centerY(
+        greaterThanOrEqualTo anchor: NSLayoutAnchor<NSLayoutYAxisAnchor>,
+        constant: CGFloat = 0
+    ) -> Self {
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.centerYAnchor.constraint(greaterThanOrEqualTo: anchor, constant: constant).isActive = true
+        return self
+    }
+    
+    @discardableResult
     func top(
         equalTo anchor: NSLayoutAnchor<NSLayoutYAxisAnchor>,
         constant: CGFloat = 0
@@ -75,6 +85,46 @@ extension AutoLayoutWrapper {
     ) -> Self {
         view.translatesAutoresizingMaskIntoConstraints = false
         view.bottomAnchor.constraint(equalTo: anchor, constant: constant).isActive = true
+        return self
+    }
+    
+    @discardableResult
+    func top(
+        greaterThanOrEqualTo anchor: NSLayoutAnchor<NSLayoutYAxisAnchor>,
+        constant: CGFloat = 0
+    ) -> Self {
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.topAnchor.constraint(greaterThanOrEqualTo: anchor, constant: constant).isActive = true
+        return self
+    }
+    
+    @discardableResult
+    func bottom(
+        greaterThanOrEqualTo anchor: NSLayoutAnchor<NSLayoutYAxisAnchor>,
+        constant: CGFloat = 0
+    ) -> Self {
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.bottomAnchor.constraint(greaterThanOrEqualTo: anchor, constant: constant).isActive = true
+        return self
+    }
+    
+    @discardableResult
+    func top(
+        lessThanOrEqualTo anchor: NSLayoutAnchor<NSLayoutYAxisAnchor>,
+        constant: CGFloat = 0
+    ) -> Self {
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.topAnchor.constraint(lessThanOrEqualTo: anchor, constant: constant).isActive = true
+        return self
+    }
+    
+    @discardableResult
+    func bottom(
+        lessThanOrEqualTo anchor: NSLayoutAnchor<NSLayoutYAxisAnchor>,
+        constant: CGFloat = 0
+    ) -> Self {
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.bottomAnchor.constraint(lessThanOrEqualTo: anchor, constant: constant).isActive = true
         return self
     }
     

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Capture/CaptureView.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Capture/CaptureView.swift
@@ -54,6 +54,7 @@ final class CaptureView: UIView {
     override func layoutSubviews() {
         super.layoutSubviews()
         
+        debugPrint(safeAreaLayoutGuide)
         // 프리뷰 레이어 조정
         updatePreviewConstraint()
         previewLayer.frame = preview.bounds
@@ -148,14 +149,14 @@ private extension CaptureView {
     }
     
     private func updatePreviewConstraint() {
-        if let bounds = window?.windowScene?.screen.bounds, let window {
+        if let bounds = window?.windowScene?.screen.bounds {
             NSLayoutConstraint.deactivate(preview.constraints)
             
             let minSize = min(400, bounds.width, bounds.height)
             preview.atl
                 .size(width: minSize, height: minSize)
                 .centerX(equalTo: safeAreaLayoutGuide.centerXAnchor)
-                .centerY(equalTo: window.centerYAnchor, constant: -20)
+                .centerY(equalTo: centerYAnchor, constant: -20)
         }
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Capture/CaptureView.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Capture/CaptureView.swift
@@ -53,10 +53,6 @@ final class CaptureView: UIView {
     
     override func layoutSubviews() {
         super.layoutSubviews()
-        
-        debugPrint(safeAreaLayoutGuide)
-        // 프리뷰 레이어 조정
-        updatePreviewConstraint()
         previewLayer.frame = preview.bounds
     }
     
@@ -141,22 +137,21 @@ private extension CaptureView {
     func setupPreview() {
         // 카메라 Preview
         addSubview(preview)
+        preview.atl
+            .height(equalTo: preview.widthAnchor)
+            .centerX(equalTo: safeAreaLayoutGuide.centerXAnchor)
+            .centerY(greaterThanOrEqualTo: centerYAnchor, constant: -20)
         
+        let widthConstraint = preview.widthAnchor.constraint(equalTo: safeAreaLayoutGuide.widthAnchor)
+        widthConstraint.priority = .defaultHigh
+        NSLayoutConstraint.activate([
+            preview.widthAnchor.constraint(lessThanOrEqualToConstant: 400),
+            widthConstraint
+        ])
+
         // PreviewLayer를 Preview 에 넣기
         previewLayer.backgroundColor = UIColor.primaryGray.cgColor
         previewLayer.videoGravity = .resizeAspectFill
         preview.layer.addSublayer(previewLayer)
-    }
-    
-    private func updatePreviewConstraint() {
-        if let bounds = window?.windowScene?.screen.bounds {
-            NSLayoutConstraint.deactivate(preview.constraints)
-            
-            let minSize = min(400, bounds.width, bounds.height)
-            preview.atl
-                .size(width: minSize, height: minSize)
-                .centerX(equalTo: safeAreaLayoutGuide.centerXAnchor)
-                .centerY(equalTo: centerYAnchor, constant: -20)
-        }
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Capture/CaptureViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Capture/CaptureViewController.swift
@@ -50,6 +50,13 @@ final class CaptureViewController: BaseViewController<CaptureView>, VibrationVie
         checkCameraPermissions()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        if let tabBarController = tabBarController as? TabBarViewController {
+            tabBarController.hideTabBar()
+        }
+    }
+    
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         startSession()

--- a/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementView.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementView.swift
@@ -71,11 +71,6 @@ final class DetailAchievementView: UIView {
         setupUI()
     }
     
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        updateImageViewConstraint()
-    }
-    
     func configure(achievement: Achievement) {
         titleLabel.text = achievement.title
         categoryLabel.text = achievement.category?.name
@@ -148,18 +143,17 @@ private extension DetailAchievementView {
     
     private func setupImageView() {
         scrollView.addSubview(imageView)
-    }
-    
-    private func updateImageViewConstraint() {
-        if let bounds = window?.windowScene?.screen.bounds {
-            NSLayoutConstraint.deactivate(imageView.constraints)
-            
-            let minSize = min(400, bounds.width, bounds.height)
-            imageView.atl
-                .size(width: minSize, height: minSize)
-                .top(equalTo: titleLabel.bottomAnchor, constant: 10)
-                .centerX(equalTo: safeAreaLayoutGuide.centerXAnchor)
-        }
+        imageView.atl
+            .height(equalTo: imageView.widthAnchor)
+            .top(equalTo: titleLabel.bottomAnchor, constant: 10)
+            .centerX(equalTo: safeAreaLayoutGuide.centerXAnchor)
+        
+        let widthConstraint = imageView.widthAnchor.constraint(equalTo: safeAreaLayoutGuide.widthAnchor)
+        widthConstraint.priority = .defaultHigh
+        NSLayoutConstraint.activate([
+            imageView.widthAnchor.constraint(lessThanOrEqualToConstant: 400),
+            widthConstraint
+        ])
     }
     
     private func setupBodyTitleLabel() {

--- a/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementView.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementView.swift
@@ -121,15 +121,17 @@ extension EditAchievementView {
     private func setupCategoryButton() {
         addSubview(categoryButton)
         categoryButton.atl
+            .top(greaterThanOrEqualTo: safeAreaLayoutGuide.topAnchor)
+            .bottom(greaterThanOrEqualTo: titleTextField.topAnchor, constant: -5)
             .left(equalTo: safeAreaLayoutGuide.leftAnchor, constant: 20)
-            .bottom(equalTo: titleTextField.topAnchor, constant: -5)
     }
 
     private func setupTitleTextField() {
         addSubview(titleTextField)
         titleTextField.atl
             .horizontal(equalTo: safeAreaLayoutGuide, constant: 20)
-            .bottom(equalTo: resultImageView.topAnchor, constant: -10)
+            .bottom(greaterThanOrEqualTo: resultImageView.topAnchor, constant: -10)
+            .bottom(lessThanOrEqualTo: resultImageView.topAnchor, constant: 0)
     }
     
     private func setupResultImageView() {
@@ -144,7 +146,7 @@ extension EditAchievementView {
             resultImageView.atl
                 .size(width: minSize, height: minSize)
                 .centerX(equalTo: safeAreaLayoutGuide.centerXAnchor)
-                .centerY(equalTo: safeAreaLayoutGuide.centerYAnchor, constant: -50)
+                .centerY(greaterThanOrEqualTo: centerYAnchor, constant: -20)
         }
     }
         

--- a/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementView.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementView.swift
@@ -64,11 +64,6 @@ final class EditAchievementView: UIView {
         setupUI()
     }
     
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        updateImageViewConstraint()
-    }
-    
     func configure(image: UIImage?, category: String? = nil) {
         resultImageView.image = image
         
@@ -136,20 +131,19 @@ extension EditAchievementView {
     
     private func setupResultImageView() {
         addSubview(resultImageView)
+        resultImageView.atl
+            .height(equalTo: resultImageView.widthAnchor)
+            .centerX(equalTo: safeAreaLayoutGuide.centerXAnchor)
+            .centerY(greaterThanOrEqualTo: centerYAnchor, constant: -20)
+        
+        let widthConstraint = resultImageView.widthAnchor.constraint(equalTo: safeAreaLayoutGuide.widthAnchor)
+        widthConstraint.priority = .defaultHigh
+        NSLayoutConstraint.activate([
+            resultImageView.widthAnchor.constraint(lessThanOrEqualToConstant: 400),
+            widthConstraint
+        ])
     }
     
-    private func updateImageViewConstraint() {
-        if let bounds = window?.windowScene?.screen.bounds {
-            NSLayoutConstraint.deactivate(resultImageView.constraints)
-            
-            let minSize = min(400, bounds.width, bounds.height)
-            resultImageView.atl
-                .size(width: minSize, height: minSize)
-                .centerX(equalTo: safeAreaLayoutGuide.centerXAnchor)
-                .centerY(greaterThanOrEqualTo: centerYAnchor, constant: -20)
-        }
-    }
-        
     private func setupCategoryPickerView() {
         addSubview(categoryPickerView)
         addSubview(selectDoneButton)

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupDetailAchievement/GroupDetailAchievementView.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupDetailAchievement/GroupDetailAchievementView.swift
@@ -78,11 +78,6 @@ final class GroupDetailAchievementView: UIView {
         setupUI()
     }
     
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        updateImageViewConstraint()
-    }
-    
     func configure(achievement: Achievement) {
         titleLabel.text = achievement.title
         categoryLabel.text = achievement.category?.name
@@ -200,18 +195,17 @@ private extension GroupDetailAchievementView {
     
     private func setupImageView() {
         scrollView.addSubview(imageView)
-    }
-    
-    private func updateImageViewConstraint() {
-        if let bounds = window?.windowScene?.screen.bounds {
-            NSLayoutConstraint.deactivate(imageView.constraints)
-            
-            let minSize = min(400, bounds.width, bounds.height)
-            imageView.atl
-                .size(width: minSize, height: minSize)
-                .top(equalTo: titleLabel.bottomAnchor, constant: 10)
-                .centerX(equalTo: safeAreaLayoutGuide.centerXAnchor)
-        }
+        imageView.atl
+            .height(equalTo: imageView.widthAnchor)
+            .top(equalTo: titleLabel.bottomAnchor, constant: 10)
+            .centerX(equalTo: safeAreaLayoutGuide.centerXAnchor)
+        
+        let widthConstraint = imageView.widthAnchor.constraint(equalTo: safeAreaLayoutGuide.widthAnchor)
+        widthConstraint.priority = .defaultHigh
+        NSLayoutConstraint.activate([
+            imageView.widthAnchor.constraint(lessThanOrEqualToConstant: 400),
+            widthConstraint
+        ])
     }
     
     private func setupEmojiButtons() {

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeActionState.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeActionState.swift
@@ -49,6 +49,7 @@ extension GroupHomeViewModel {
     
     enum AchievementListState {
         case loading
+        case isEmpty
         case finish
         case error(message: String)
     }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeViewController.swift
@@ -268,9 +268,10 @@ extension GroupHomeViewController: UICollectionViewDelegate {
             // 카테고리 셀을 눌렀을 때
             categoryCellDidSelected(cell: cell, row: indexPath.row)
         } else if let _ = collectionView.cellForItem(at: indexPath) as? AchievementCollectionViewCell {
-            // 달성 기록 리스트 셀을 눌렀을 때
-            // 상세 정보 화면으로 이동
+            // 달성 기록 리스트 셀을 눌렀을 때 상세 정보 화면으로 이동
             let achievement = viewModel.findAchievement(at: indexPath.row)
+            // 스켈레톤 아이템 예외 처리
+            guard achievement.id >= 0 else { return }
             coordinator?.moveToGroupDetailAchievementViewController(
                 achievement: achievement,
                 group: viewModel.group

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeViewController.swift
@@ -440,11 +440,15 @@ private extension GroupHomeViewController {
                 switch state {
                 case .loading:
                     break
+                case .isEmpty:
+                    layoutView.showEmptyGuideLabel()
                 case .finish:
+                    layoutView.hideEmptyGuideLabel()
                     isFetchingNextPage = false
                     layoutView.endRefreshing()
                 case .error(let message):
                     Logger.error("Fetch Achievement Error: \(message)")
+                    layoutView.hideEmptyGuideLabel()
                     isFetchingNextPage = false
                     layoutView.endRefreshing()
                 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeViewModel.swift
@@ -343,6 +343,9 @@ private extension GroupHomeViewModel {
                 
                 nextRequestValue = achievementListItem.next
                 achievementListState.send(.finish)
+                if achievements.isEmpty {
+                    achievementListState.send(.isEmpty)
+                }
             } catch {
                 if let nextAchievementTask, nextAchievementTask.isCancelled {
                     Logger.debug("NextAchievementTask is Cancelled")

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeViewModel.swift
@@ -42,7 +42,7 @@ final class GroupHomeViewModel {
             achievementDataSource?.update(data: achievements)
         }
     }
-    private let skeletonAchievements: [Achievement] = (-20...(-1)).map { _ in Achievement.makeSkeleton() }
+    private let skeletonAchievements: [Achievement] = (-20...(-1)).map { Achievement.makeSkeleton(id: $0) }
     
     // Blocking
     private let blockingUserUseCase: BlockingUserUseCase

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeActionState.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeActionState.swift
@@ -47,6 +47,7 @@ extension HomeViewModel {
     enum AchievementListState {
         case initial
         case loading
+        case isEmpty
         case finish
         case error(message: String)
     }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeView.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeView.swift
@@ -58,6 +58,18 @@ final class HomeView: UIView {
         return refreshControl
     }()
     
+    // 아이템이 없을 때 표시하는 Label
+    private let emptyGuideLabel = {
+        let label = UILabel()
+        label.isHidden = true
+        label.text = "도전 기록이 없습니다.\n새로운 도전을 기록해 보세요."
+        label.numberOfLines = 2
+        label.textAlignment = .center
+        label.font = .systemFont(ofSize: 16)
+        label.alpha = 0.5
+        return label
+    }()
+    
     // MARK: - Init
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -85,6 +97,14 @@ final class HomeView: UIView {
             }
         }
     }
+    
+    func showEmptyGuideLabel() {
+        emptyGuideLabel.isHidden = false
+    }
+    
+    func hideEmptyGuideLabel() {
+        emptyGuideLabel.isHidden = true
+    }
 }
 
 // MARK: - SetUp
@@ -93,6 +113,7 @@ private extension HomeView {
         setupCategoryAddButton()
         setupCategoryCollectionView()
         setupAchievementCollectionView()
+        setupEmptyGuideLabel()
     }
     
     private func setupCategoryAddButton() {
@@ -122,9 +143,15 @@ private extension HomeView {
     private func setupAchievementCollectionView() {
         addSubview(achievementCollectionView)
         achievementCollectionView.atl
-            .width(equalTo: self.widthAnchor)
+            .horizontal(equalTo: safeAreaLayoutGuide)
             .top(equalTo: categoryCollectionView.bottomAnchor, constant: 10)
             .bottom(equalTo: self.bottomAnchor)
+    }
+    
+    private func setupEmptyGuideLabel() {
+        addSubview(emptyGuideLabel)
+        emptyGuideLabel.atl
+            .center(of: safeAreaLayoutGuide)
     }
 }
 

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewController.swift
@@ -386,10 +386,14 @@ private extension HomeViewController {
                 // state 에 따른 뷰 처리 - 스켈레톤 뷰, fetch 에러 뷰 등
                 Logger.debug(state)
                 switch state {
+                case .isEmpty:
+                    layoutView.showEmptyGuideLabel()
                 case .finish:
+                    layoutView.hideEmptyGuideLabel()
                     isFetchingNextPage = false
                     layoutView.endRefreshing()
                 case .error(let message):
+                    layoutView.hideEmptyGuideLabel()
                     isFetchingNextPage = false
                     layoutView.endRefreshing()
                     Logger.error("Fetch Achievement Error: \(message)")

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewController.swift
@@ -88,7 +88,6 @@ final class HomeViewController: BaseViewController<HomeView>, LoadingIndicator, 
         if let tabBarController = tabBarController as? TabBarViewController,
            tabBarController.selectedIndex == 0 {
             coordinator?.moveToCaptureViewController()
-            tabBarController.hideTabBar()
         }
     }
     
@@ -256,9 +255,10 @@ extension HomeViewController: UICollectionViewDelegate {
             // 카테고리 셀을 눌렀을 때
             categoryCellDidSelected(cell: cell, row: indexPath.row)
         } else if let _ = collectionView.cellForItem(at: indexPath) as? AchievementCollectionViewCell {
-            // 달성 기록 리스트 셀을 눌렀을 때
-            // 상세 정보 화면으로 이동
+            // 달성 기록 리스트 셀을 눌렀을 때 상세 정보 화면으로 이동
             let achievement = viewModel.findAchievement(at: indexPath.row)
+            // 스켈레톤 아이템 예외 처리
+            guard achievement.id >= 0 else { return }
             coordinator?.moveToDetailAchievementViewController(achievement: achievement)
         }
     }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewModel.swift
@@ -285,6 +285,9 @@ private extension HomeViewModel {
                 
                 nextRequestValue = achievementListItem.next
                 achievementListState = .finish
+                if achievements.isEmpty {
+                    achievementListState = .isEmpty
+                }
             } catch {
                 if let nextAchievementTask, nextAchievementTask.isCancelled {
                     Logger.debug("NextAchievementTask is Cancelled")

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewModel.swift
@@ -35,7 +35,7 @@ final class HomeViewModel {
     private let deleteAchievementUseCase: DeleteAchievementUseCase
     private let fetchDetailAchievementUseCase: FetchDetailAchievementUseCase
     
-    private let skeletonAchievements: [Achievement] = (-20...(-1)).map { _ in Achievement.makeSkeleton() }
+    private let skeletonAchievements: [Achievement] = (-20...(-1)).map { Achievement.makeSkeleton(id: $0) }
     private var achievements: [Achievement] = [] {
         didSet {
             achievementDataSource?.update(data: achievements)

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Login/LoginViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Login/LoginViewController.swift
@@ -102,11 +102,10 @@ final class LoginViewController: BaseViewController<LoginView> {
 
 extension LoginViewController: AppleLoginRequesterDelegate {
     func success(token: String) {
-        Logger.debug("애플에서 전달된 token: \(token)")
         viewModel.action(.login(identityToken: token))
     }
     
-    func failed(error: Error) {
+    func failed(message: String) {
         showOneButtonAlert(title: "로그인 실패", message: "다시 시도해 주세요.")
     }
 }


### PR DESCRIPTION
## PR 요약
- 도전기록 리스트 아이템이 하나도 없으면 도전기록이 없다는 Label 표시
- 앱 정보 화면에 회원탈퇴 버튼 추가 (아직 기능 구현 안 함)
- 촬영, 편집 화면 오토레이아웃 수정
    - 기현님께서 찾으신 원인을 토대로 수정함
    - window를 기준으로 centerY를 잡으면 탭바 애니메이션이 이상함
    - safeAreaGuide가 바뀌는 이유도 탭바 애니메이션 때문임
    - 탭바 애니메이션을 제거할 순 없기 때문에 오토레이아웃을 적절히 수정
- 아이패드 대응 오토레이아웃 추가
    - 아이패드 가로 모드에서는 이미지가 너무 커짐 -> 400 이상 커지지 않게 제약
    - 우선순위를 제공하지 않아서 제약 간 충돌이 발생함
    - 만약 둘이 충돌한다면 safeArea의 width를 우선으로 적용하도록 설정 -> 아이폰에서는 400보다 width가 우선되어야 하기 때문
    - 400 기준은 아이패드 미니에서 원할하게 사용할 수 있는 크기로 결정됨

#### 변경 사항
- ATL에 greaterThanEqualTo, lessThanEqualTo이 추가됨. 지금 필요한 것만 추가한거라서 다른 건 필요한 상황에 직접 추가하면 됩니다.

## 스크린샷
### 아이패드 미니 (가장 작은 아이패드)
- 상세 화면(세로)
![Simulator Screenshot - iPad mini (6th generation) - 2023-12-09 at 13 16 23](https://github.com/boostcampwm2023/iOS02-moti/assets/89075274/a5749836-533f-4080-8b50-896b6dea8c4b)
- 상세 화면(가로)
![Simulator Screenshot - iPad mini (6th generation) - 2023-12-09 at 13 16 26](https://github.com/boostcampwm2023/iOS02-moti/assets/89075274/b0400f03-2710-4d5c-abc5-0f7bd443ccca)
- 촬영 후 편집 화면
![Simulator Screenshot - iPad mini (6th generation) - 2023-12-09 at 13 16 59](https://github.com/boostcampwm2023/iOS02-moti/assets/89075274/57277577-2869-4a9c-9cf2-f779366d5b46)
- 편집 화면
![Simulator Screenshot - iPad mini (6th generation) - 2023-12-09 at 13 18 02](https://github.com/boostcampwm2023/iOS02-moti/assets/89075274/62fdc562-687a-4b04-b5c5-2aa9a812ab59)

### 아이패드 프로 12.9인치 (가장 큰 아이패드)
- 상세 화면(세로)
![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2023-12-09 at 13 20 00](https://github.com/boostcampwm2023/iOS02-moti/assets/89075274/e4be2f2f-5544-4d70-b7ab-337ad746355e)

- 상세 화면(가로)
![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2023-12-09 at 13 20 03](https://github.com/boostcampwm2023/iOS02-moti/assets/89075274/de25dee1-027f-4909-835f-d49d4cc21621)

- 촬영 후 편집 화면
![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2023-12-09 at 13 20 15](https://github.com/boostcampwm2023/iOS02-moti/assets/89075274/3df60adf-0170-4f28-9280-cf84478216fc)

- 편집 화면
![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2023-12-09 at 13 20 07](https://github.com/boostcampwm2023/iOS02-moti/assets/89075274/b86d02f5-9b49-4c1f-861e-be08ff513869)

#### Linked Issue
close #537 
close #541 
