### PR TITLE
여러 기기에서 촬영버튼 바닥 여백 대응, 촬영 화면의 촬영 버튼 애니메이션 추가

### DIFF
--- a/iOS/moti/moti/Presentation/Sources/Presentation/Capture/CaptureCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Capture/CaptureCoordinator.swift
@@ -46,14 +46,6 @@ final class CaptureCoordinator: Coordinator {
         let captureVC = CaptureViewController(group: group)
         captureVC.delegate = self
         captureVC.coordinator = self
-        
-        captureVC.navigationItem.leftBarButtonItem = UIBarButtonItem(
-            title: "취소", style: .plain, target: self,
-            action: #selector(cancelButtonAction)
-        )
-        
-        captureVC.navigationItem.rightBarButtonItem = nil
-        
         navigationController.pushViewController(captureVC, animated: true)
     }
     
@@ -62,10 +54,6 @@ final class CaptureCoordinator: Coordinator {
         editAchievementCoordinator.delegate = self
         editAchievementCoordinator.startAfterCapture(image: image, group: group)
         childCoordinators.append(editAchievementCoordinator)
-    }
-    
-    @objc func cancelButtonAction() {
-        finish()
     }
 }
 

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Capture/CaptureView.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Capture/CaptureView.swift
@@ -57,6 +57,27 @@ final class CaptureView: UIView {
     }
     
     // MARK: - Methods
+    func showToolItem() {
+        albumButton.isHidden = false
+        captureButton.isHidden = false
+        cameraSwitchingButton.isHidden = false
+        
+        albumButton.transform = .identity
+        captureButton.transform = .identity
+        cameraSwitchingButton.transform = .identity
+    }
+    
+    func hideToolItem(translationY: CGFloat) {
+        let transform = CGAffineTransform(translationX: 0, y: translationY)
+        albumButton.transform = transform
+        captureButton.transform = transform
+        cameraSwitchingButton.transform = transform
+        
+        albumButton.isHidden = true
+        captureButton.isHidden = true
+        cameraSwitchingButton.isHidden = true
+    }
+    
     func updatePreviewLayer(session: AVCaptureSession) {
         previewLayer.session = session
     }
@@ -115,7 +136,7 @@ private extension CaptureView {
         captureButton.atl
             .size(width: CaptureButton.defaultSize, height: CaptureButton.defaultSize)
             .centerX(equalTo: centerXAnchor)
-            .bottom(equalTo: bottomAnchor, constant: -36)
+            .bottom(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -5)
     }
 
     func setupPhotoButton() {

--- a/iOS/moti/moti/Presentation/Sources/Presentation/TabBar/TabBarViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/TabBar/TabBarViewController.swift
@@ -15,7 +15,7 @@ final class TabBarViewController: UITabBarController, VibrationViewController {
     private let borderView = UIView()
     
     // MARK: - Properties
-    private var tabBarHeight: CGFloat {
+    var tabBarHeight: CGFloat {
         return tabBar.frame.height
     }
     private var isShowing = true
@@ -148,6 +148,6 @@ private extension TabBarViewController {
         captureButton.atl
             .size(width: CaptureButton.defaultSize, height: CaptureButton.defaultSize)
             .centerX(equalTo: view.centerXAnchor)
-            .bottom(equalTo: view.bottomAnchor, constant: -36)
+            .bottom(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -5)
     }
 }


### PR DESCRIPTION
## PR 요약
- 여러 기기에서 촬영 버튼의 바닥 여백 대응
    - 기존에는 -36을 상수로 박아서 이상하게 보이는 기기가 존재했음 (아이폰 SE, 아이패드)
    - safeAreaGuide를 이용해 오토 레이아웃 적용
- 촬영 화면의 촬영버튼 애니메이션 추가
    - safeAreaGuide를 사용하니 촬영 화면에 들어갈 때 Preview 덜컹거리는 것과 같은 증상이 생김
    - 홈 화면 -> 촬영 화면으로 이동될 때만 발생하기 떄문에 애니메이션 추가
    - 홈 화면 -> 촬영 화면일 때 탭바가 내려가므로, 촬영 버튼이 위로 올라오는 애니메이션으로 적용함

## 스크린샷
### bottomAnchor 수정 전
- 아이폰 15 프로 / 아이폰 SE 3
<img src = "https://github.com/boostcampwm2023/iOS02-moti/assets/89075274/a46af447-0aa5-40f6-ab6d-5c6b7fcc4add" width = "30%">
<img src = "https://github.com/boostcampwm2023/iOS02-moti/assets/89075274/3dead7e1-b4ef-4e22-b36d-a5e106080431" width = "30%">

### 수정 후
- 아이폰 15 프로 / 아이폰 SE 3
<img src = "https://github.com/boostcampwm2023/iOS02-moti/assets/89075274/90510434-1f7c-450c-9289-2905db0252ef" width = "30%">
<img src = "https://github.com/boostcampwm2023/iOS02-moti/assets/89075274/ffd215f1-1621-47cf-b81a-d0a4a42afd77" width = "30%">

### 촬영 버튼 애니메이션
![Simulator Screen Recording - iPhone 15 Pro - 2023-12-09 at 14 42 12](https://github.com/boostcampwm2023/iOS02-moti/assets/89075274/bb37e714-e336-4aa8-b926-a26cd1e1f31c)



#### Linked Issue
close #543 
