### PR TITLE
Manager 권한 이상인 경우 그룹내 다른 멤버의 기록을 삭제할 수 있다. 

### DIFF
--- a/BE/src/group/achievement/controller/group-achievement.controller.spec.ts
+++ b/BE/src/group/achievement/controller/group-achievement.controller.spec.ts
@@ -614,6 +614,30 @@ describe('GroupAchievementController', () => {
         });
     });
 
+    it('삭제 권한이 없는 경우에는 403을 반환한다.', async () => {
+      // given
+      const { accessToken } = await authFixture.getAuthenticatedUser('ABC');
+
+      when(
+        mockGroupAchievementService.delete(
+          anyNumber(),
+          anyNumber(),
+          anyNumber(),
+        ),
+      ).thenThrow(new UnauthorizedAchievementException());
+
+      // when
+      // then
+      return request(app.getHttpServer())
+        .delete('/api/v1/groups/1/achievements/1')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(403)
+        .expect((res: request.Response) => {
+          expect(res.body.success).toBe(false);
+          expect(res.body.message).toBe('달성기록에 접근할 수 없습니다.');
+        });
+    });
+
     it('잘못된 인증시 401을 반환한다.', async () => {
       // given
       const accessToken = 'abcd.abcd.efgh';

--- a/BE/src/group/achievement/entities/group-achievement.repository.ts
+++ b/BE/src/group/achievement/entities/group-achievement.repository.ts
@@ -164,12 +164,12 @@ export class GroupAchievementRepository extends TransactionalRepository<GroupAch
   }
 
   async findOneByIdAndGroupId(achievementId: number, groupId: number) {
-    const findOne = await this.repository
-      .createQueryBuilder('ga')
-      .select('ga')
-      .where('ga.id = :achievementId', { achievementId })
-      .andWhere('ga.group_id = :groupId', { groupId })
-      .getOne();
+    const findOne = await this.repository.findOne({
+      where: { id: achievementId, group: { id: groupId } },
+      relations: {
+        user: true,
+      },
+    });
     return findOne?.toModel();
   }
 

--- a/BE/src/group/achievement/group-achievement.module.ts
+++ b/BE/src/group/achievement/group-achievement.module.ts
@@ -7,6 +7,7 @@ import { UserBlockedGroupAchievementRepository } from './entities/user-blocked-g
 import { GroupCategoryRepository } from '../category/entities/group-category.repository';
 import { GroupRepository } from '../group/entities/group.repository';
 import { ImageRepository } from '../../image/entities/image.repository';
+import { UserGroupRepository } from '../group/entities/user-group.repository';
 
 @Module({
   imports: [
@@ -16,6 +17,7 @@ import { ImageRepository } from '../../image/entities/image.repository';
       GroupRepository,
       ImageRepository,
       UserBlockedGroupAchievementRepository,
+      UserGroupRepository,
     ]),
   ],
   controllers: [GroupAchievementController],


### PR DESCRIPTION
## PR 요약
- Manager 권한 이상인 경우 그룹내 다른 멤버의 기록을 삭제할 수 있다. 


##### 스크린샷
- 삭제 성공 
<img width="930" alt="image" src="https://github.com/boostcampwm2023/iOS02-moti/assets/34297340/e7b69b0f-43e2-4017-b83d-6eaf659aba20">

- 권한 없는 경우
<img width="927" alt="image" src="https://github.com/boostcampwm2023/iOS02-moti/assets/34297340/8bfde85c-dbf3-48c3-8fb1-3370332c15ff">

- 가입되어있지 않은 타 그룹의 달성 기록 삭제시 
<img width="924" alt="image" src="https://github.com/boostcampwm2023/iOS02-moti/assets/34297340/3bf18ac1-cbcc-4665-8c4c-e0089e550d77">

#### Linked Issue
close #546 
