### PR TITLE
회원탈퇴 API 연결 / 신고버튼 구현

### DIFF
--- a/iOS/moti/moti/Core/Sources/Core/Logger.swift
+++ b/iOS/moti/moti/Core/Sources/Core/Logger.swift
@@ -10,22 +10,30 @@ import OSLog
 
 public enum Logger {
     public static func debug<T>(_ object: T?) {
+        #if DEBUG
         let message = object != nil ? "\(object!)" : "nil"
         os_log(.debug, "%@", message)
+        #endif
     }
     
     public static func info<T>(_ object: T?) {
+        #if DEBUG
         let message = object != nil ? "\(object!)" : "nil"
         os_log(.info, "%@", message)
+        #endif
     }
     
     public static func error<T>(_ object: T?) {
+        #if DEBUG
         let message = object != nil ? "\(object!)" : "nil"
         os_log(.error, "%@", message)
+        #endif
     }
     
     public static func network<T>(_ object: T?) {
+        #if DEBUG
         let message = object != nil ? "\(object!)" : "nil"
         os_log(.debug, "[Network] %@", message)
+        #endif
     }
 }

--- a/iOS/moti/moti/Data/Sources/Data/Network/Endpoint/MotiAPI.swift
+++ b/iOS/moti/moti/Data/Sources/Data/Network/Endpoint/MotiAPI.swift
@@ -13,6 +13,7 @@ enum MotiAPI: EndpointProtocol {
     case version
     case login(requestValue: LoginRequestValue)
     case autoLogin(requestValue: AutoLoginRequestValue)
+    case revoke(requestValue: RevokeRequestValue)
     case saveImage(requestValue: SaveImageRequestValue)
     // 개인
     case fetchAchievementList(requestValue: FetchAchievementListRequestValue?)
@@ -64,6 +65,7 @@ extension MotiAPI {
         case .version: return "/operate/policy"
         case .login: return "/auth/login"
         case .autoLogin: return "/auth/refresh"
+        case .revoke: return "/auth/revoke"
         case .fetchAchievementList: return "/achievements"
         case .fetchCategory(let categoryId): return "/categories/\(categoryId)"
         case .fetchCategoryList: return "/categories"
@@ -115,6 +117,7 @@ extension MotiAPI {
         case .version: return .get
         case .login: return .post
         case .autoLogin: return .post
+        case .revoke: return .delete
         case .fetchAchievementList: return .get
         case .fetchCategory: return .get
         case .fetchCategoryList: return .get
@@ -161,6 +164,8 @@ extension MotiAPI {
         case .login(let requestValue):
             return requestValue
         case .autoLogin(let requestValue):
+            return requestValue
+        case .revoke(let requestValue):
             return requestValue
         case .addCategory(let requestValue):
             return requestValue

--- a/iOS/moti/moti/Data/Sources/Repository/AuthRepository.swift
+++ b/iOS/moti/moti/Data/Sources/Repository/AuthRepository.swift
@@ -1,5 +1,5 @@
 //
-//  LoginRepository.swift
+//  AuthRepository.swift
 //
 //
 //  Created by 유정주 on 11/14/23.
@@ -9,7 +9,7 @@ import Foundation
 import Domain
 import Core
 
-public struct LoginRepository: LoginRepositoryProtocol {
+public struct AuthRepository: AuthRepositoryProtocol {
     private let provider: ProviderProtocol
     
     public init(provider: ProviderProtocol = Provider()) {
@@ -30,5 +30,12 @@ public struct LoginRepository: LoginRepositoryProtocol {
         
         guard let userTokenDTO = responseDTO.data else { throw NetworkError.decode }
         return UserToken(dto: userTokenDTO)
+    }
+    
+    public func revoke(requestValue: RevokeRequestValue) async throws -> Bool {
+        let endpoint = MotiAPI.revoke(requestValue: requestValue)
+        let responseDTO = try await provider.request(with: endpoint, type: SimpleResponseDTO.self)
+        
+        return responseDTO.success ?? false
     }
 }

--- a/iOS/moti/moti/Data/Tests/DataTests/Repository/Mock/MockLoginRepository.swift
+++ b/iOS/moti/moti/Data/Tests/DataTests/Repository/Mock/MockLoginRepository.swift
@@ -10,7 +10,7 @@ import Foundation
 @testable import Data
 @testable import Core
 
-public struct MockLoginRepository: LoginRepositoryProtocol {
+public struct MockLoginRepository: AuthRepositoryProtocol {
     private var json = """
         {
             "success": true,

--- a/iOS/moti/moti/Domain/Sources/Domain/RepositoryProtocol/AuthRepositoryProtocol.swift
+++ b/iOS/moti/moti/Domain/Sources/Domain/RepositoryProtocol/AuthRepositoryProtocol.swift
@@ -1,5 +1,5 @@
 //
-//  LoginRepositoryProtocol.swift
+//  AuthRepositoryProtocol.swift
 //
 //
 //  Created by 유정주 on 11/14/23.
@@ -7,7 +7,8 @@
 
 import Foundation
 
-public protocol LoginRepositoryProtocol {
+public protocol AuthRepositoryProtocol {
     func autoLogin(requestValue: AutoLoginRequestValue) async throws -> UserToken
     func login(requestValue: LoginRequestValue) async throws -> UserToken
+    func revoke(requestValue: RevokeRequestValue) async throws -> Bool
 }

--- a/iOS/moti/moti/Domain/Sources/Domain/UseCase/AutoLoginUseCase.swift
+++ b/iOS/moti/moti/Domain/Sources/Domain/UseCase/AutoLoginUseCase.swift
@@ -16,11 +16,11 @@ public struct AutoLoginRequestValue: RequestValue {
 }
 
 public struct AutoLoginUseCase {
-    private let repository: LoginRepositoryProtocol
+    private let repository: AuthRepositoryProtocol
     private let keychainStorage: KeychainStorageProtocol
     
     public init(
-        repository: LoginRepositoryProtocol,
+        repository: AuthRepositoryProtocol,
         keychainStorage: KeychainStorageProtocol
     ) {
         self.repository = repository

--- a/iOS/moti/moti/Domain/Sources/Domain/UseCase/LoginUseCase.swift
+++ b/iOS/moti/moti/Domain/Sources/Domain/UseCase/LoginUseCase.swift
@@ -16,11 +16,11 @@ public struct LoginRequestValue: RequestValue {
 }
 
 public struct LoginUseCase {
-    private let repository: LoginRepositoryProtocol
+    private let repository: AuthRepositoryProtocol
     private let keychainStorage: KeychainStorageProtocol
     
     public init(
-        repository: LoginRepositoryProtocol,
+        repository: AuthRepositoryProtocol,
         keychainStorage: KeychainStorageProtocol
     ) {
         self.repository = repository

--- a/iOS/moti/moti/Domain/Sources/Domain/UseCase/RevokeUseCase.swift
+++ b/iOS/moti/moti/Domain/Sources/Domain/UseCase/RevokeUseCase.swift
@@ -9,11 +9,11 @@ import Foundation
 
 public struct RevokeRequestValue: RequestValue {
     public let identityToken: String
-    public let authrizationCode: String
+    public let authorizationCode: String
     
-    public init(identityToken: String, authrizationCode: String) {
+    public init(identityToken: String, authorizationCode: String) {
         self.identityToken = identityToken
-        self.authrizationCode = authrizationCode
+        self.authorizationCode = authorizationCode
     }
 }
 

--- a/iOS/moti/moti/Domain/Sources/Domain/UseCase/RevokeUseCase.swift
+++ b/iOS/moti/moti/Domain/Sources/Domain/UseCase/RevokeUseCase.swift
@@ -24,7 +24,7 @@ public struct RevokeUseCase {
         self.repository = repository
     }
     
-    func execute(requestValue: RevokeRequestValue) async throws -> Bool {
+    public func execute(requestValue: RevokeRequestValue) async throws -> Bool {
         return try await repository.revoke(requestValue: requestValue)
     }
 }

--- a/iOS/moti/moti/Domain/Sources/Domain/UseCase/RevokeUseCase.swift
+++ b/iOS/moti/moti/Domain/Sources/Domain/UseCase/RevokeUseCase.swift
@@ -1,0 +1,30 @@
+//
+//  RevokeUseCase.swift
+//
+//
+//  Created by 유정주 on 12/9/23.
+//
+
+import Foundation
+
+public struct RevokeRequestValue: RequestValue {
+    public let identityToken: String
+    public let authrizationCode: String
+    
+    public init(identityToken: String, authrizationCode: String) {
+        self.identityToken = identityToken
+        self.authrizationCode = authrizationCode
+    }
+}
+
+public struct RevokeUseCase {
+    private let repository: AuthRepositoryProtocol
+    
+    public init(repository: AuthRepositoryProtocol) {
+        self.repository = repository
+    }
+    
+    func execute(requestValue: RevokeRequestValue) async throws -> Bool {
+        return try await repository.revoke(requestValue: requestValue)
+    }
+}

--- a/iOS/moti/moti/Presentation/Sources/Presentation/AppInfo/AppInfoCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/AppInfo/AppInfoCoordinator.swift
@@ -8,6 +8,7 @@
 import UIKit
 import Core
 import Domain
+import Data
 
 final class AppInfoCoordinator: Coordinator {
     var parentCoordinator: Coordinator?
@@ -28,7 +29,9 @@ final class AppInfoCoordinator: Coordinator {
               let privacyPolicy = UserDefaults.standard.readString(key: .privacyPolicy) else { return }
         
         let version = Version(latest: latest, required: required, privacyPolicy: privacyPolicy)
-        let appInfoVC = AppInfoViewController(version: version)
+        let revokeUseCase = RevokeUseCase(repository: AuthRepository())
+        let appInfoVM = AppInfoViewModel(revokeUseCase: revokeUseCase)
+        let appInfoVC = AppInfoViewController(viewModel: appInfoVM, version: version)
         appInfoVC.coordinator = self
         navigationController.present(appInfoVC, animated: true)
     }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/AppInfo/AppInfoViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/AppInfo/AppInfoViewController.swift
@@ -96,7 +96,13 @@ final class AppInfoViewController: BaseViewController<AppInfoView>, LoadingIndic
     }
     
     @objc private func revokeButtonDidClicked() {
-        appleLoginRequester?.request()
+        showTwoButtonAlert(
+            title: "정말 회원 탈퇴를 하시겠습니까?",
+            message: "회원 탈퇴 시 모든 기록이 삭제됩니다.",
+            okAction: {
+                self.appleLoginRequester?.request()
+            }
+        )
     }
     
     private func setupAppleLoginRequester() {

--- a/iOS/moti/moti/Presentation/Sources/Presentation/AppInfo/AppInfoViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/AppInfo/AppInfoViewController.swift
@@ -6,16 +6,20 @@
 //
 
 import UIKit
+import Combine
 import Domain
 
-final class AppInfoViewController: BaseViewController<AppInfoView> {
+final class AppInfoViewController: BaseViewController<AppInfoView>, LoadingIndicator {
 
     // MARK: - Properties
+    let viewModel: AppInfoViewModel
+    private var cancellables: Set<AnyCancellable> = []
     weak var coordinator: AppInfoCoordinator?
     private let version: Version
     
     // MARK: - Init
-    init(version: Version) {
+    init(viewModel: AppInfoViewModel, version: Version) {
+        self.viewModel = viewModel
         self.version = version
         super.init(nibName: nil, bundle: nil)
     }
@@ -28,10 +32,36 @@ final class AppInfoViewController: BaseViewController<AppInfoView> {
     override func viewDidLoad() {
         super.viewDidLoad()
         layoutView.configure(with: version)
+        bind()
         addTarget()
     }
     
+    private func bind() {
+        viewModel.revokeState
+            .receive(on: RunLoop.main)
+            .sink { [weak self] state in
+                guard let self else { return }
+                switch state {
+                case .loading:
+                    showLoadingIndicator()
+                case .finish:
+                    hideLoadingIndicator()
+                case .error(let message):
+                    hideLoadingIndicator()
+                    showErrorAlert(message: message)
+                }
+            }
+            .store(in: &cancellables)
+    }
+    
     // MARK: - Actions
+    private func addTarget() {
+        layoutView.closeButton.addTarget(self, action: #selector(closeButtonDidClicked), for: .touchUpInside)
+        layoutView.updateButton.addTarget(self, action: #selector(updateButtonDidClicked), for: .touchUpInside)
+        layoutView.policyButton.addTarget(self, action: #selector(policyButtonDidClicked), for: .touchUpInside)
+        layoutView.revokeButton.addTarget(self, action: #selector(revokeButtonDidClicked), for: .touchUpInside)
+    }
+    
     @objc private func closeButtonDidClicked() {
         coordinator?.finish()
     }
@@ -51,23 +81,14 @@ final class AppInfoViewController: BaseViewController<AppInfoView> {
     }
     
     // MARK: - Methods
-    private func addTarget() {
-        layoutView.closeButton.addTarget(
-            self,
-            action: #selector(closeButtonDidClicked),
-            for: .touchUpInside)
-        layoutView.updateButton.addTarget(
-            self,
-            action: #selector(updateButtonDidClicked),
-            for: .touchUpInside)
-        layoutView.policyButton.addTarget(
-            self,
-            action: #selector(policyButtonDidClicked),
-            for: .touchUpInside)
-    }
+    
     
     private func openURL(_ url: String) {
         guard let url = URL(string: url) else { return }
         UIApplication.shared.open(url)
+    }
+    
+    @objc private func revokeButtonDidClicked() {
+        
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/AppInfo/AppInfoViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/AppInfo/AppInfoViewModel.swift
@@ -45,7 +45,7 @@ private extension AppInfoViewModel {
             do {
                 revokeState.send(.loading)
                 
-                let requestValue = RevokeRequestValue(identityToken: identityToken, authrizationCode: authorizationCode)
+                let requestValue = RevokeRequestValue(identityToken: identityToken, authorizationCode: authorizationCode)
                 let isSuccess = try await revokeUseCase.execute(requestValue: requestValue)
                 revokeState.send(.finish)
                 

--- a/iOS/moti/moti/Presentation/Sources/Presentation/AppInfo/AppInfoViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/AppInfo/AppInfoViewModel.swift
@@ -1,0 +1,60 @@
+//
+//  AppInfoViewModel.swift
+//
+//
+//  Created by 유정주 on 12/9/23.
+//
+
+import Foundation
+import Domain
+import Data
+import Combine
+
+struct AppInfoViewModel {
+    enum AppInfoViewModelAction {
+        case revoke(identityToken: String, authorizationCode: String)
+    }
+    
+    enum RevokeState {
+        case loading
+        case finish
+        case error(message: String)
+    }
+    
+    // MARK: - Properties
+    private let revokeUseCase: RevokeUseCase
+    private(set) var revokeState = PassthroughSubject<RevokeState, Never>()
+    
+    // MARK: - Init
+    init(revokeUseCase: RevokeUseCase) {
+        self.revokeUseCase = revokeUseCase
+    }
+    
+    func action(_ actions: AppInfoViewModelAction) {
+        switch actions {
+        case .revoke(let identityToken, let authorizationCode):
+            revoke(identityToken: identityToken, authorizationCode: authorizationCode)
+        }
+    }
+}
+
+private extension AppInfoViewModel {
+    /// 회원 탈퇴 액션
+    func revoke(identityToken: String, authorizationCode: String) {
+        Task {
+            do {
+                revokeState.send(.loading)
+                
+                let requestValue = RevokeRequestValue(identityToken: identityToken, authrizationCode: authorizationCode)
+                let isSuccess = try await revokeUseCase.execute(requestValue: requestValue)
+                revokeState.send(.finish)
+                
+                NotificationCenter.default.post(name: .logout, object: nil)
+                KeychainStorage.shared.remove(key: .accessToken)
+                KeychainStorage.shared.remove(key: .refreshToken)
+            } catch {
+                revokeState.send(.error(message: error.localizedDescription))
+            }
+        }
+    }
+}

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Authorization/AppleLoginRequester.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Authorization/AppleLoginRequester.swift
@@ -51,7 +51,7 @@ extension AppleLoginRequester: ASAuthorizationControllerDelegate {
             return
         }
 
-        #if DEBUG        
+        #if DEBUG
         Logger.debug("identityToken: \(identityToken)")
         Logger.debug("authorizationCode: \(authorizationCode)")
         #endif

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Authorization/AppleLoginRequester.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Authorization/AppleLoginRequester.swift
@@ -45,13 +45,13 @@ extension AppleLoginRequester: ASAuthorizationControllerDelegate {
             return
         }
         
-        #if DEBUG
         guard let authorizationCodeData = appleIDCredential.authorizationCode,
               let authorizationCode = String(data: authorizationCodeData, encoding: .utf8) else {
             delegate?.failed(message: "로그인 실패")
             return
         }
 
+        #if DEBUG        
         Logger.debug("identityToken: \(identityToken)")
         Logger.debug("authorizationCode: \(authorizationCode)")
         #endif

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Authorization/AppleLoginRequester.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Authorization/AppleLoginRequester.swift
@@ -10,7 +10,7 @@ import AuthenticationServices
 import Core
 
 protocol AppleLoginRequesterDelegate: AnyObject {
-    func success(token: String)
+    func success(token: String, authorizationCode: String)
     func failed(message: String)
 }
 
@@ -56,7 +56,7 @@ extension AppleLoginRequester: ASAuthorizationControllerDelegate {
         Logger.debug("authorizationCode: \(authorizationCode)")
         #endif
         
-        delegate?.success(token: identityToken)
+        delegate?.success(token: identityToken, authorizationCode: authorizationCode)
     }
     
     // 인증 실패

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupDetailAchievement/GroupDetailAchievementViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupDetailAchievement/GroupDetailAchievementViewController.swift
@@ -136,6 +136,10 @@ final class GroupDetailAchievementViewController: BaseViewController<GroupDetail
                     self.delegate?.blockingUserMenuDidClicked(userCode: self.viewModel.achievement.userCode)
             })
         })
+        // 신고
+        let reportAction = UIAction(title: "신고", attributes: .destructive, handler: { _ in
+            self.showOneButtonAlert(title: "신고 완료", message: "신고 처리되었습니다.")
+        })
         
         var children: [UIAction] = []
         if isMyAchievement || grade == .leader || grade == .manager {
@@ -144,9 +148,8 @@ final class GroupDetailAchievementViewController: BaseViewController<GroupDetail
         
         // 그룹장, 관리자에게도 표시하기 위해 조건문 분리
         if !isMyAchievement {
-            children.append(contentsOf: [blockingAchievementAction, blockingUserAction])
+            children.append(contentsOf: [blockingAchievementAction, blockingUserAction, reportAction])
         }
-        
         moreItem.menu = UIMenu(children: children)
         
         if isMyAchievement {

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeViewController.swift
@@ -152,6 +152,7 @@ final class GroupHomeViewController: BaseViewController<HomeView>, LoadingIndica
     func postedAchievement(newAchievement: Achievement) {
         viewModel.action(.fetchCurrentCategoryInfo)
         viewModel.action(.postAchievement(newAchievement: newAchievement))
+        layoutView.hideEmptyGuideLabel()
         showCelebrate(with: newAchievement)
     }
     
@@ -481,6 +482,7 @@ private extension GroupHomeViewController {
                 case .loading:
                     showLoadingIndicator()
                 case .success:
+                    viewModel.action(.fetchCurrentCategoryInfo)
                     hideLoadingIndicator()
                 case .failed:
                     hideLoadingIndicator()

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewController.swift
@@ -70,6 +70,7 @@ final class HomeViewController: BaseViewController<HomeView>, LoadingIndicator, 
         if let tabBarController = tabBarController as? TabBarViewController {
             tabBarController.showTabBar()
         }
+        layoutView.hideEmptyGuideLabel()
         viewModel.action(.fetchCurrentCategoryInfo)
         viewModel.action(.postAchievement(newAchievement: newAchievement))
         showCelebrate(with: newAchievement)
@@ -430,6 +431,7 @@ private extension HomeViewController {
                 case .loading:
                     showLoadingIndicator()
                 case .success:
+                    viewModel.action(.fetchCurrentCategoryInfo)
                     hideLoadingIndicator()
                 case .failed:
                     hideLoadingIndicator()

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Launch/LaunchCoodinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Launch/LaunchCoodinator.swift
@@ -31,7 +31,7 @@ public final class LaunchCoodinator: Coordinator {
     
     public func start() {
         let autoLoginUseCase = AutoLoginUseCase(
-            repository: LoginRepository(),
+            repository: AuthRepository(),
             keychainStorage: KeychainStorage.shared
         )
         let launchVM = LaunchViewModel(

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Login/LoginCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Login/LoginCoordinator.swift
@@ -30,7 +30,7 @@ public final class LoginCoordinator: Coordinator {
     }
     
     public func start() {
-        let loginUseCase = LoginUseCase(repository: LoginRepository(), keychainStorage: KeychainStorage.shared)
+        let loginUseCase = LoginUseCase(repository: AuthRepository(), keychainStorage: KeychainStorage.shared)
         let loginVM = LoginViewModel(loginUseCase: loginUseCase)
         let loginVC = LoginViewController(viewModel: loginVM)
         loginVC.coordinator = self
@@ -40,7 +40,7 @@ public final class LoginCoordinator: Coordinator {
     }
     
     public func startWithAlert(message: String) {
-        let loginUseCase = LoginUseCase(repository: LoginRepository(), keychainStorage: KeychainStorage.shared)
+        let loginUseCase = LoginUseCase(repository: AuthRepository(), keychainStorage: KeychainStorage.shared)
         let loginVM = LoginViewModel(loginUseCase: loginUseCase)
         let loginVC = LoginViewController(viewModel: loginVM, alertMessage: message)
         loginVC.coordinator = self

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Login/LoginViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Login/LoginViewController.swift
@@ -101,7 +101,7 @@ final class LoginViewController: BaseViewController<LoginView> {
 }
 
 extension LoginViewController: AppleLoginRequesterDelegate {
-    func success(token: String) {
+    func success(token: String, authorizationCode: String) {
         viewModel.action(.login(identityToken: token))
     }
     

--- a/iOS/moti/moti/Resource/Info.plist
+++ b/iOS/moti/moti/Resource/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>BASE_URL</key>
 	<string>$(BASE_URL)</string>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
## PR 요약
- 회원탈퇴 API 연결
- 회원탈퇴 성공 시 로그인 화면으로 이동
- 신고 버튼 구현

##### 스크린샷
- 회원 탈퇴 확인 버튼
<img src = "https://github.com/boostcampwm2023/iOS02-moti/assets/89075274/bbb3904e-7375-487f-beed-0f1b3d76900a" width = "50%">

- 신고 버튼
<img src = "https://github.com/boostcampwm2023/iOS02-moti/assets/89075274/8e1a10c8-7e00-4c49-b3b1-fea04df0aa99" width = "30%">
<img src = "https://github.com/boostcampwm2023/iOS02-moti/assets/89075274/25f27e73-22b1-4307-bba0-8ceed7cc2834" width = "30%">


#### Linked Issue
close #548 
close #550 
