### PR TITLE
아이패드 셀 개수 수정 & 그룹 리스트 최근 달성일로 정렬하기

### DIFF
--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupList/GroupListViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupList/GroupListViewModel.swift
@@ -104,7 +104,8 @@ extension GroupListViewModel {
         Task {
             groupListState = .loading
             do {
-                groups = try await fetchGroupListUseCase.execute()
+                let groups = try await fetchGroupListUseCase.execute()
+                self.groups = groups.sorted { $0.lastChallenged ?? .distantPast > $1.lastChallenged ?? .distantPast }
                 groupListState = .finish
             } catch {
                 Logger.error("\(#function) error: \(error.localizedDescription)")
@@ -134,7 +135,8 @@ extension GroupListViewModel {
                 } else {
                     refetchGroupListState.send(.finishDecreased)
                 }
-                groups = newGroups
+                
+                groups = newGroups.sorted { $0.lastChallenged ?? .distantPast > $1.lastChallenged ?? .distantPast }
             } catch {
                 Logger.error("\(#function) error: \(error.localizedDescription)")
                 refetchGroupListState.send(.error(message: error.localizedDescription))

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeView.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeView.swift
@@ -157,7 +157,7 @@ private extension HomeView {
 
 private extension HomeView {
     func makeAchievementCollectionView() -> UICollectionViewLayout {
-        let count: CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 9 : 3
+        let count: CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 7 : 3
         let itemPadding: CGFloat = 1
         let itemSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1.0 / count),


### PR DESCRIPTION
## PR 요약
- 아이패드 셀 개수 수정
- 그룹 리스트 최근 달성일로 정렬하기

#### 변경 사항
변경사항 및 주의 사항 (모듈 설치 등)을 적어주세요.

##### 스크린샷
- iPad(10th) 세로
<img width="50%" src="https://github.com/boostcampwm2023/iOS02-moti/assets/60506170/593c6807-cbde-4e78-874d-260f8aafeb25">

- iPad(10th) 가로
<img width="70%" src="https://github.com/boostcampwm2023/iOS02-moti/assets/60506170/059f6f0c-12cc-4c8c-91ab-1c195dfcc9df">

- 최근 달성일 기준 정렬
<img width="33%" src="https://github.com/boostcampwm2023/iOS02-moti/assets/60506170/3f36d836-52cc-42cd-a5a8-823c732861e3">

#### Linked Issue
close #551
