### PR TITLE
그룹 미설정 카테고리의 도전기록 도전회차 중첩 이슈

### DIFF
--- a/BE/src/achievement/entities/achievement.repository.spec.ts
+++ b/BE/src/achievement/entities/achievement.repository.spec.ts
@@ -17,7 +17,6 @@ import { CategoryTestModule } from '../../../test/category/category-test.module'
 import { Achievement } from '../domain/achievement.domain';
 import { PaginateAchievementRequest } from '../dto/paginate-achievement-request';
 import { ImageFixture } from '../../../test/image/image-fixture';
-import { Category } from '../../category/domain/category.domain';
 
 describe('AchievementRepository test', () => {
   let achievementRepository: AchievementRepository;
@@ -297,6 +296,31 @@ describe('AchievementRepository test', () => {
 
       // then
       expect(achievementDetail).toBeNull();
+    });
+  });
+
+  test('자신의 미설정 카테고리의 도전기록을 조회할 수 있다.', async () => {
+    await transactionTest(dataSource, async () => {
+      // given
+      const otherUser1 = await usersFixture.getUser('BCD');
+      const otherUser2 = await usersFixture.getUser('BCD');
+      await achievementFixture.getAchievements(10, otherUser1, null);
+      await achievementFixture.getAchievements(10, otherUser2, null);
+
+      const user = await usersFixture.getUser('ABC');
+
+      const achievements: Achievement[] =
+        await achievementFixture.getAchievements(10, user, null);
+
+      // when
+      const achievementDetail =
+        await achievementRepository.findAchievementDetail(
+          user.id,
+          achievements[9].id,
+        );
+
+      // then
+      expect(achievementDetail.category.achieveCount).toEqual(10);
     });
   });
 

--- a/BE/src/achievement/entities/achievement.repository.ts
+++ b/BE/src/achievement/entities/achievement.repository.ts
@@ -6,9 +6,6 @@ import { FindOptionsWhere, IsNull, LessThan } from 'typeorm';
 import { PaginateAchievementRequest } from '../dto/paginate-achievement-request';
 import { AchievementDetailResponse } from '../dto/achievement-detail-response';
 import { IAchievementDetail } from '../index';
-import { User } from '../../users/domain/user.domain';
-import { ICategoryMetaData } from '../../category';
-import { CategoryMetaData } from '../../category/dto/category-metadata';
 
 @CustomRepository(AchievementEntity)
 export class AchievementRepository extends TransactionalRepository<AchievementEntity> {
@@ -62,7 +59,7 @@ export class AchievementRepository extends TransactionalRepository<AchievementEn
       .leftJoin(
         'achievement',
         'a',
-        'COALESCE(a.category_id, -1) = COALESCE(achievement.category_id, -1) AND a.id <= achievement.id',
+        'COALESCE(a.category_id, -1) = COALESCE(achievement.category_id, -1) AND a.id <= achievement.id and a.user_id = achievement.user_id',
       )
       .leftJoin('image', 'i', 'i.achievement_id = achievement.id')
       .where('achievement.id = :achievementId', { achievementId })

--- a/BE/src/group/achievement/application/group-achievement.service.ts
+++ b/BE/src/group/achievement/application/group-achievement.service.ts
@@ -79,7 +79,7 @@ export class GroupAchievementService {
     const achievement = achieveCreate.toModel(user, group, category, image);
     const saved =
       await this.groupAchievementRepository.saveAchievement(achievement);
-    return this.getAchievementResponse(user.id, saved.id);
+    return this.getAchievementResponse(user.id, groupId, saved.id);
   }
 
   @Transactional({ readonly: true })
@@ -157,10 +157,15 @@ export class GroupAchievementService {
     return group;
   }
 
-  private async getAchievementResponse(userId: number, achieveId: number) {
+  private async getAchievementResponse(
+    userId: number,
+    groupId: number,
+    achieveId: number,
+  ) {
     const achievement =
       await this.groupAchievementRepository.findAchievementDetailByIdAndUser(
         userId,
+        groupId,
         achieveId,
       );
     if (!achievement) throw new NoSuchAchievementException();

--- a/BE/src/group/achievement/entities/group-achievement.repository.spec.ts
+++ b/BE/src/group/achievement/entities/group-achievement.repository.spec.ts
@@ -175,6 +175,7 @@ describe('GroupRepository Test', () => {
       const findGroupAchievement =
         await groupAchievementRepository.findAchievementDetailByIdAndUser(
           user.id,
+          group.id,
           groupAchievement.id,
         );
 
@@ -203,6 +204,7 @@ describe('GroupRepository Test', () => {
       const findGroupAchievement =
         await groupAchievementRepository.findAchievementDetailByIdAndUser(
           user.id,
+          1,
           2,
         );
 
@@ -232,11 +234,110 @@ describe('GroupRepository Test', () => {
       const findGroupAchievement =
         await groupAchievementRepository.findAchievementDetailByIdAndUser(
           user.id,
+          group.id,
           groupAchievements[9].id,
         );
 
       // then
       expect(findGroupAchievement.category.achieveCount).toEqual(10);
+    });
+  });
+
+  test('미설정 카테고리의 그룹 달성 기록을 조회할 수 있다.', async () => {
+    await transactionTest(dataSource, async () => {
+      // given
+      const otherLeader = await usersFixture.getUser('DEF');
+      const otherGroup = await groupFixture.createGroup('OTHER', otherLeader);
+      const otherGroupCategory = await groupCategoryFixture.createCategory(
+        otherLeader,
+        otherGroup,
+      );
+
+      await groupAchievementFixture.createGroupAchievements(
+        10,
+        otherLeader,
+        otherGroup,
+        otherGroupCategory,
+      );
+
+      await groupAchievementFixture.createGroupAchievements(
+        null,
+        otherLeader,
+        otherGroup,
+        otherGroupCategory,
+      );
+
+      const user = await usersFixture.getUser('ABC');
+      const group = await groupFixture.createGroup('GROUP', user);
+      const groupCategory = await groupCategoryFixture.createCategory(
+        user,
+        group,
+      );
+      const groupAchievements =
+        await groupAchievementFixture.createGroupAchievements(
+          12,
+          user,
+          group,
+          groupCategory,
+        );
+
+      // when
+      const findGroupAchievement =
+        await groupAchievementRepository.findAchievementDetailByIdAndUser(
+          user.id,
+          group.id,
+          groupAchievements[11].id,
+        );
+
+      // then
+      expect(findGroupAchievement.category.achieveCount).toEqual(12);
+    });
+  });
+
+  test('미설정 카테고리의 그룹 달성 기록을 조회할 수 있다.', async () => {
+    await transactionTest(dataSource, async () => {
+      // given
+      const otherLeader = await usersFixture.getUser('DEF');
+      const otherGroup = await groupFixture.createGroup('OTHER', otherLeader);
+      const otherGroupCategory = await groupCategoryFixture.createCategory(
+        otherLeader,
+        otherGroup,
+      );
+
+      await groupAchievementFixture.createGroupAchievements(
+        10,
+        otherLeader,
+        otherGroup,
+        otherGroupCategory,
+      );
+
+      await groupAchievementFixture.createGroupAchievements(
+        null,
+        otherLeader,
+        otherGroup,
+        otherGroupCategory,
+      );
+
+      const user = await usersFixture.getUser('ABC');
+      const group = await groupFixture.createGroup('GROUP', user);
+      const groupAchievements =
+        await groupAchievementFixture.createGroupAchievements(
+          12,
+          user,
+          group,
+          null,
+        );
+
+      // when
+      const findGroupAchievement =
+        await groupAchievementRepository.findAchievementDetailByIdAndUser(
+          user.id,
+          group.id,
+          groupAchievements[11].id,
+        );
+
+      // then
+      expect(findGroupAchievement.category.achieveCount).toEqual(12);
     });
   });
 


### PR DESCRIPTION


## PR 요약

그룹 미설정 카테고리의 도전기록 도전회차 중첩 이슈 해결

#### 변경 사항

```ts
  private async achievementDetailQuery(achievementId: number, groupId: number) {
    return this.repository
      .createQueryBuilder('groupAchievement')
      .leftJoinAndSelect('groupAchievement.groupCategory', 'gc')
      .select('groupAchievement.id', 'id')
      .addSelect('groupAchievement.title', 'title')
      .addSelect('groupAchievement.content', 'content')
      .addSelect('i.imageUrl', 'imageUrl')
      .addSelect('groupAchievement.createdAt', 'createdAt')
      .addSelect('gc.id', 'categoryId')
      .addSelect('gc.name', 'categoryName')
      .addSelect('COUNT(ga.id)', 'achieveCount')
      .addSelect('user.userCode', 'userCode')
      .leftJoin(
        'group_achievement',
        'ga',
        'COALESCE(ga.group_category_id, -1) = COALESCE(groupAchievement.group_category_id, -1) AND ga.id <= groupAchievement.id and ga.group_id = groupAchievement.group_id',
      )
      .leftJoin('image', 'i', 'i.group_achievement_id = groupAchievement.id')
      .leftJoin('groupAchievement.user', 'user')
      .where('groupAchievement.id = :achievementId', { achievementId })
      .andWhere('groupAchievement.group_id = :groupId', { groupId: groupId });
  }
```

##### 스크린샷

<img width="521" alt="image" src="https://github.com/boostcampwm2023/iOS02-moti/assets/75921696/f81b5876-cde5-4183-970e-6768ce4f87a1">

<img width="524" alt="image" src="https://github.com/boostcampwm2023/iOS02-moti/assets/75921696/3d52357a-e50e-49b8-8c5a-9e8115763b86">

중첩되지 않고 미설정 카테고리를 구분함

#### Linked Issue
close #555
