### PR TITLE
그룹 가입 API를 추가한다.

### DIFF
--- a/BE/src/common/exception/error-code.ts
+++ b/BE/src/common/exception/error-code.ts
@@ -83,6 +83,10 @@ export const ERROR_INFO = {
     statusCode: 400,
     message: '그룹에 카테고리를 만들 수 없습니다.',
   },
+  NO_SUCH_GROUP: {
+    statusCode: 404,
+    message: '존재하지 않는 그룹 입니다.',
+  },
   NO_SUCH_USER_GROUP: {
     statusCode: 400,
     message: '그룹의 멤버가 아닙니다.',
@@ -106,6 +110,10 @@ export const ERROR_INFO = {
   DUPLICATED_INVITE: {
     statusCode: 400,
     message: '이미 초대된 그룹원 입니다.',
+  },
+  DUPLICATED_JOIN: {
+    statusCode: 400,
+    message: '이미 그룹의 그룹원 입니다.',
   },
   NO_SUCH_GROUP_USER: {
     statusCode: 400,

--- a/BE/src/group/group/application/group-code-generator.spec.ts
+++ b/BE/src/group/group/application/group-code-generator.spec.ts
@@ -1,0 +1,36 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigModule } from '@nestjs/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { GroupRepository } from '../entities/group.repository';
+import { GroupCodeGenerator } from './group-code-generator';
+import { configServiceModuleOptions } from '../../../config/config';
+import { typeOrmModuleOptions } from '../../../config/typeorm';
+import { CustomTypeOrmModule } from '../../../config/typeorm/custom-typeorm.module';
+
+describe('GroupCodeGenerator test', () => {
+  let groupRepository: GroupRepository;
+  let groupCodeGenerator: GroupCodeGenerator;
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot(configServiceModuleOptions),
+        TypeOrmModule.forRootAsync(typeOrmModuleOptions),
+        CustomTypeOrmModule.forCustomRepository([GroupRepository]),
+      ],
+    }).compile();
+
+    groupRepository = module.get<GroupRepository>(GroupRepository);
+    groupCodeGenerator = new GroupCodeGenerator(groupRepository);
+  });
+
+  it('사용할 모듈이 정의가 되어있어야한다.', () => {
+    expect(groupRepository).toBeDefined();
+    expect(groupCodeGenerator).toBeDefined();
+  });
+
+  test('영대문자, 숫자를 포함한 임의의 7글자 문자열을 생성한다.', async () => {
+    const groupCode = await groupCodeGenerator.generate();
+    expect(groupCode.length).toEqual(7);
+  });
+});

--- a/BE/src/group/group/application/group-code-generator.ts
+++ b/BE/src/group/group/application/group-code-generator.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@nestjs/common';
+import { GroupRepository } from '../entities/group.repository';
+
+@Injectable()
+export class GroupCodeGenerator {
+  private readonly CHARACTERS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+  constructor(private groupRepository: GroupRepository) {}
+
+  async generate() {
+    let groupCode = this.makeGroupCode();
+
+    while (await this.isDuplicate(groupCode)) {
+      groupCode = this.makeGroupCode();
+    }
+
+    return groupCode;
+  }
+
+  private isDuplicate(groupCode: string): Promise<boolean> {
+    return this.groupRepository.existByGroupCode(groupCode);
+  }
+
+  private makeGroupCode() {
+    let groupCode = '';
+    for (let i = 0; i < 7; i++) {
+      const randomIndex = Math.floor(Math.random() * this.CHARACTERS.length);
+      groupCode += this.CHARACTERS.charAt(randomIndex);
+    }
+    return groupCode;
+  }
+}

--- a/BE/src/group/group/application/group.service.spec.ts
+++ b/BE/src/group/group/application/group.service.spec.ts
@@ -34,6 +34,7 @@ import { DuplicatedJoinException } from '../exception/duplicated-join.exception'
 describe('GroupSerivce Test', () => {
   let groupService: GroupService;
   let userGroupRepository: UserGroupRepository;
+  let groupRepository: GroupRepository;
   let usersFixture: UsersFixture;
   let groupFixture: GroupFixture;
   let groupAchievementFixture: GroupAchievementFixture;
@@ -60,6 +61,7 @@ describe('GroupSerivce Test', () => {
 
     groupService = module.get<GroupService>(GroupService);
     userGroupRepository = module.get<UserGroupRepository>(UserGroupRepository);
+    groupRepository = module.get<GroupRepository>(GroupRepository);
     usersFixture = module.get<UsersFixture>(UsersFixture);
     groupFixture = module.get<GroupFixture>(GroupFixture);
     groupAchievementFixture = module.get<GroupAchievementFixture>(
@@ -85,6 +87,8 @@ describe('GroupSerivce Test', () => {
       );
       // when
       const groupResponse = await groupService.create(user, createGroupRequest);
+
+      // then
       const userGroup = await userGroupRepository.repository.findOne({
         where: { group: { id: groupResponse.id }, user: { id: user.id } },
         relations: {
@@ -92,13 +96,13 @@ describe('GroupSerivce Test', () => {
           user: true,
         },
       });
-
-      // then
+      const group = await groupRepository.findById(groupResponse.id);
       expect(groupResponse.name).toEqual('Group Name');
       expect(groupResponse.avatarUrl).toEqual('avatarUrl');
       expect(userGroup.group.id).toEqual(groupResponse.id);
       expect(userGroup.user.id).toEqual(user.id);
       expect(userGroup.grade).toEqual(UserGroupGrade.LEADER);
+      expect(group.groupCode.length).toEqual(7);
     });
   });
 

--- a/BE/src/group/group/application/group.service.ts
+++ b/BE/src/group/group/application/group.service.ts
@@ -21,6 +21,10 @@ import { GroupUserListResponse } from '../dto/group-user-list-response';
 import { AssignGradeRequest } from '../dto/assign-grade-request.dto';
 import { AssignGradeResponse } from '../dto/assign-grade-response.dto';
 import { OnlyLeaderAllowedAssignGradeException } from '../exception/only-leader-allowed-assign-grade.exception';
+import { NoSucGroupException } from '../exception/no-such-group.exception';
+import { JoinGroupRequest } from '../dto/join-group-request.dto';
+import { JoinGroupResponse } from '../dto/join-group-response.dto';
+import { DuplicatedJoinException } from '../exception/duplicated-join.exception';
 
 @Injectable()
 export class GroupService {
@@ -107,6 +111,20 @@ export class GroupService {
       await this.userGroupRepository.saveUserGroup(userGroup),
     );
   }
+  @Transactional()
+  async join(user: User, joinGroupRequest: JoinGroupRequest) {
+    const group = await this.groupRepository.findByGroupCode(
+      joinGroupRequest.groupCode,
+    );
+    if (!group) throw new NoSucGroupException();
+    await this.checkDuplicatedJoin(user.userCode, group.id);
+
+    const saved = await this.userGroupRepository.saveUserGroup(
+      new UserGroup(user, group, UserGroupGrade.PARTICIPANT),
+    );
+
+    return new JoinGroupResponse(saved.group.groupCode, saved.user.userCode);
+  }
 
   private async getUserGroup(userId: number, groupId: number) {
     const userGroup = await this.userGroupRepository.findOneByUserIdAndGroupId(
@@ -124,6 +142,15 @@ export class GroupService {
         groupId,
       );
     if (userGroup) throw new DuplicatedInviteException();
+  }
+
+  private async checkDuplicatedJoin(userCode: string, groupId: number) {
+    const userGroup =
+      await this.userGroupRepository.findOneByUserCodeAndGroupId(
+        userCode,
+        groupId,
+      );
+    if (userGroup) throw new DuplicatedJoinException();
   }
 
   private checkPermission(userGroup: UserGroup) {

--- a/BE/src/group/group/application/group.service.ts
+++ b/BE/src/group/group/application/group.service.ts
@@ -25,6 +25,7 @@ import { NoSucGroupException } from '../exception/no-such-group.exception';
 import { JoinGroupRequest } from '../dto/join-group-request.dto';
 import { JoinGroupResponse } from '../dto/join-group-response.dto';
 import { DuplicatedJoinException } from '../exception/duplicated-join.exception';
+import { GroupCodeGenerator } from './group-code-generator';
 
 @Injectable()
 export class GroupService {
@@ -33,6 +34,7 @@ export class GroupService {
     private readonly userRepository: UserRepository,
     private readonly userGroupRepository: UserGroupRepository,
     private readonly groupAvatarHolder: GroupAvatarHolder,
+    private readonly groupCodeGenerator: GroupCodeGenerator,
   ) {}
 
   @Transactional()
@@ -41,6 +43,8 @@ export class GroupService {
     group.addMember(user, UserGroupGrade.LEADER);
     if (!group.avatarUrl)
       group.assignAvatarUrl(this.groupAvatarHolder.getUrl());
+    const groupCode = await this.groupCodeGenerator.generate();
+    group.assignGroupCode(groupCode);
     return GroupResponse.from(await this.groupRepository.saveGroup(group));
   }
 

--- a/BE/src/group/group/controller/group.controller.spec.ts
+++ b/BE/src/group/group/controller/group.controller.spec.ts
@@ -157,6 +157,7 @@ describe('GroupController', () => {
           id: 1,
           name: 'Test Group1',
           avatarUrl: 'avatarUrl1',
+          groupCode: 'GABACD1',
           continued: 2,
           lastChallenged: '2023-11-29T21:58:402Z',
           grade: UserGroupGrade.LEADER,
@@ -165,6 +166,7 @@ describe('GroupController', () => {
           id: 2,
           name: 'Test Group2',
           avatarUrl: 'avatarUrl2',
+          groupCode: 'GABACD2',
           continued: 3,
           lastChallenged: null,
           grade: UserGroupGrade.PARTICIPANT,
@@ -187,6 +189,7 @@ describe('GroupController', () => {
             data: [
               {
                 avatarUrl: 'avatarUrl1',
+                groupCode: 'GABACD1',
                 continued: 2,
                 id: 1,
                 lastChallenged: '2023-11-29T21:58:402Z',
@@ -195,6 +198,7 @@ describe('GroupController', () => {
               },
               {
                 avatarUrl: 'avatarUrl2',
+                groupCode: 'GABACD2',
                 continued: 3,
                 id: 2,
                 lastChallenged: null,

--- a/BE/src/group/group/controller/group.controller.ts
+++ b/BE/src/group/group/controller/group.controller.ts
@@ -31,6 +31,8 @@ import { InviteGroupResponse } from '../dto/invite-group-response';
 import { GroupUserListResponse } from '../dto/group-user-list-response';
 import { AssignGradeRequest } from '../dto/assign-grade-request.dto';
 import { AssignGradeResponse } from '../dto/assign-grade-response.dto';
+import { JoinGroupRequest } from '../dto/join-group-request.dto';
+import { JoinGroupResponse } from '../dto/join-group-response.dto';
 
 @Controller('/api/v1/groups')
 @ApiTags('그룹 API')
@@ -92,6 +94,27 @@ export class GroupController {
   ) {
     return ApiData.success(
       await this.groupService.removeUser(user.id, groupId),
+    );
+  }
+
+  @ApiOperation({
+    summary: '그룹 가입 API',
+    description: '그룹 코드를 입력해서 그룹에 가입한다.',
+  })
+  @ApiOkResponse({
+    description: '그룹 가입',
+    type: JoinGroupResponse,
+  })
+  @ApiBearerAuth('accessToken')
+  @Post('participation')
+  @UseGuards(AccessTokenGuard)
+  @HttpCode(HttpStatus.OK)
+  async join(
+    @AuthenticatedUser() user: User,
+    @Body() joinGroupRequest: JoinGroupRequest,
+  ) {
+    return ApiData.success(
+      await this.groupService.join(user, joinGroupRequest),
     );
   }
 

--- a/BE/src/group/group/domain/group.domain.ts
+++ b/BE/src/group/group/domain/group.domain.ts
@@ -6,6 +6,7 @@ export class Group {
   id: number;
   name: string;
   avatarUrl: string;
+  groupCode: string;
   userGroups: UserGroup[];
 
   constructor(name: string, avatarUrl: string) {
@@ -20,5 +21,9 @@ export class Group {
 
   assignAvatarUrl(url: string) {
     this.avatarUrl = url;
+  }
+
+  assignGroupCode(groupCode: string) {
+    this.groupCode = groupCode;
   }
 }

--- a/BE/src/group/group/dto/group-preview.dto.ts
+++ b/BE/src/group/group/dto/group-preview.dto.ts
@@ -10,6 +10,8 @@ export class GroupPreview {
   name: string;
   @ApiProperty({ description: '그룹 로고 Url' })
   avatarUrl: string;
+  @ApiProperty({ description: '그룹 그룹코드' })
+  groupCode: string;
   @ApiProperty({ description: '그룹 달성기록 총 회수' })
   continued: number;
   @ApiProperty({ description: '그룹 달성기록 최근 등록 일자' })
@@ -25,6 +27,7 @@ export class GroupPreview {
     this.id = groupPreview.id;
     this.name = groupPreview.name;
     this.avatarUrl = groupPreview.avatarUrl;
+    this.groupCode = groupPreview.groupCode;
     this.continued = parseInt(groupPreview.continued);
     this.lastChallenged = dateFormat(groupPreview.lastChallenged);
     this.grade = UserGroupGrade[groupPreview.grade];

--- a/BE/src/group/group/dto/join-group-request.dto.ts
+++ b/BE/src/group/group/dto/join-group-request.dto.ts
@@ -1,0 +1,12 @@
+import { IsNotEmptyString } from '../../../config/config/validation-decorator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class JoinGroupRequest {
+  @IsNotEmptyString({ message: '잘못된 유저 코드입니다.' })
+  @ApiProperty({ description: '가입할 그룹의 그룹코드' })
+  groupCode: string;
+
+  constructor(groupCode: string) {
+    this.groupCode = groupCode;
+  }
+}

--- a/BE/src/group/group/dto/join-group-response.dto.ts
+++ b/BE/src/group/group/dto/join-group-response.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class JoinGroupResponse {
+  @ApiProperty({ description: '그룹 코드' })
+  groupCode: string;
+  @ApiProperty({ description: '초대된 유저의 유저 코드' })
+  userCode: string;
+
+  constructor(groupCode: string, userCode: string) {
+    this.groupCode = groupCode;
+    this.userCode = userCode;
+  }
+}

--- a/BE/src/group/group/entities/group.entity.spec.ts
+++ b/BE/src/group/group/entities/group.entity.spec.ts
@@ -10,6 +10,7 @@ describe('GroupEntity Test', () => {
     it('userGroups를 가지고 있지 않은 경우에 변환이 가능하다.', () => {
       // given
       const group = new Group('group', 'avatarUrl');
+      group.assignGroupCode('ABCDEF1');
 
       // when
       const groupEntity = GroupEntity.from(group);
@@ -18,6 +19,7 @@ describe('GroupEntity Test', () => {
       expect(groupEntity).toBeInstanceOf(GroupEntity);
       expect(groupEntity.name).toEqual('group');
       expect(groupEntity.avatarUrl).toEqual('avatarUrl');
+      expect(groupEntity.groupCode).toEqual('ABCDEF1');
       expect(groupEntity.userGroups).toEqual(undefined);
     });
 
@@ -45,16 +47,19 @@ describe('GroupEntity Test', () => {
   describe('toModel으로 GroupEntity를 Group 도메인 객체로 변환할 수 있다.', () => {
     it('userGroups를 가지고 있지 않은 경우에 변환이 가능하다.', () => {
       // given
-      const groupEntity = GroupEntity.from(new Group('group', 'avatarUrl'));
+      const group = new Group('group', 'avatarUrl');
+      group.assignGroupCode('ABCDEF1');
+      const groupEntity = GroupEntity.from(group);
 
       // when
-      const group = groupEntity.toModel();
+      const domain = groupEntity.toModel();
 
       // then
-      expect(group).toBeInstanceOf(Group);
-      expect(group.name).toEqual('group');
-      expect(group.avatarUrl).toEqual('avatarUrl');
-      expect(group.userGroups.length).toEqual(0);
+      expect(domain).toBeInstanceOf(Group);
+      expect(domain.name).toEqual('group');
+      expect(domain.groupCode).toEqual('ABCDEF1');
+      expect(domain.avatarUrl).toEqual('avatarUrl');
+      expect(domain.userGroups.length).toEqual(0);
     });
 
     it('userGroups를 가지고 있는 경우에 변환이 가능하다.', () => {

--- a/BE/src/group/group/entities/group.entity.ts
+++ b/BE/src/group/group/entities/group.entity.ts
@@ -16,6 +16,9 @@ export class GroupEntity extends BaseTimeEntity {
   @Column({ type: 'varchar', length: 100, nullable: true })
   avatarUrl: string;
 
+  @Column({ type: 'varchar', length: 7, nullable: true })
+  groupCode: string;
+
   @OneToMany(() => UserGroupEntity, (userGroup) => userGroup.group, {
     cascade: true,
   })
@@ -30,6 +33,7 @@ export class GroupEntity extends BaseTimeEntity {
   toModel(): Group {
     const group = new Group(this.name, this.avatarUrl);
     group.id = this.id;
+    group.groupCode = this.groupCode;
     group.userGroups = this.userGroups
       ? this.userGroups.map((ug) => ug.toModel())
       : [];
@@ -41,6 +45,7 @@ export class GroupEntity extends BaseTimeEntity {
     const groupEntity = new GroupEntity();
     groupEntity.id = group.id;
     groupEntity.name = group.name;
+    groupEntity.groupCode = group.groupCode;
     groupEntity.userGroups = group.userGroups.length
       ? group.userGroups.map((ug) => UserGroupEntity.strictFrom(ug))
       : undefined;
@@ -53,6 +58,7 @@ export class GroupEntity extends BaseTimeEntity {
     const groupEntity = new GroupEntity();
     groupEntity.id = group.id;
     groupEntity.name = group.name;
+    groupEntity.groupCode = group.groupCode;
     groupEntity.avatarUrl = group.avatarUrl;
     return groupEntity;
   }

--- a/BE/src/group/group/entities/group.repository.spec.ts
+++ b/BE/src/group/group/entities/group.repository.spec.ts
@@ -54,7 +54,7 @@ describe('GroupRepository Test', () => {
     });
   });
 
-  test('그룹 단건 조회를 할 수 있다.', async () => {
+  test('id로 그룹 단건 조회를 할 수 있다.', async () => {
     await transactionTest(dataSource, async () => {
       // given
       const user = await usersFixture.getUser('ABC');
@@ -62,6 +62,21 @@ describe('GroupRepository Test', () => {
 
       // when
       const savedGroup = await groupRepository.findById(group.id);
+
+      // then
+      expect(savedGroup.name).toEqual('Test Group');
+      expect(savedGroup.id).toEqual(group.id);
+    });
+  });
+
+  test('groupCode로 그룹 단건 조회를 할 수 있다.', async () => {
+    await transactionTest(dataSource, async () => {
+      // given
+      const user = await usersFixture.getUser('ABC');
+      const group = await groupFixture.createGroup('Test Group', user);
+
+      // when
+      const savedGroup = await groupRepository.findByGroupCode(group.groupCode);
 
       // then
       expect(savedGroup.name).toEqual('Test Group');

--- a/BE/src/group/group/entities/group.repository.spec.ts
+++ b/BE/src/group/group/entities/group.repository.spec.ts
@@ -131,9 +131,9 @@ describe('GroupRepository Test', () => {
     await transactionTest(dataSource, async () => {
       // given
       const user = await usersFixture.getUser('ABC');
-      await groupFixture.createGroup('Test Group1', user);
-      await groupFixture.createGroup('Test Group2', user);
-      await groupFixture.createGroup('Test Group3', user);
+      const group1 = await groupFixture.createGroup('Test Group1', user);
+      const group2 = await groupFixture.createGroup('Test Group2', user);
+      const group3 = await groupFixture.createGroup('Test Group3', user);
 
       // when
       const groups = await groupRepository.findByUserId(user.id);
@@ -142,10 +142,13 @@ describe('GroupRepository Test', () => {
       expect(groups.length).toEqual(3);
       expect(groups[0].name).toEqual('Test Group1');
       expect(groups[0].grade).toEqual(UserGroupGrade.LEADER);
+      expect(groups[0].groupCode).toEqual(group1.groupCode);
       expect(groups[1].name).toEqual('Test Group2');
       expect(groups[1].grade).toEqual(UserGroupGrade.LEADER);
+      expect(groups[1].groupCode).toEqual(group2.groupCode);
       expect(groups[2].name).toEqual('Test Group3');
       expect(groups[2].grade).toEqual(UserGroupGrade.LEADER);
+      expect(groups[2].groupCode).toEqual(group3.groupCode);
     });
   });
 

--- a/BE/src/group/group/entities/group.repository.spec.ts
+++ b/BE/src/group/group/entities/group.repository.spec.ts
@@ -84,6 +84,25 @@ describe('GroupRepository Test', () => {
     });
   });
 
+  test('groupCode로 group 존재 유뮤를 알 수 있다.', async () => {
+    await transactionTest(dataSource, async () => {
+      // given
+      const user = await usersFixture.getUser('ABC');
+      const group = await groupFixture.createGroup('Test Group', user);
+
+      // when
+      const existByGroupCode = await groupRepository.existByGroupCode(
+        group.groupCode,
+      );
+      const nonExistByGroupCode =
+        await groupRepository.existByGroupCode('INVALID');
+
+      // then
+      expect(existByGroupCode).toBe(true);
+      expect(nonExistByGroupCode).toBe(false);
+    });
+  });
+
   test('그룹을 생성하면 생성한 유저가 리더가 된다.', async () => {
     await transactionTest(dataSource, async () => {
       // given

--- a/BE/src/group/group/entities/group.repository.ts
+++ b/BE/src/group/group/entities/group.repository.ts
@@ -84,4 +84,8 @@ export class GroupRepository extends TransactionalRepository<GroupEntity> {
     });
     return group?.toModel();
   }
+
+  async existByGroupCode(groupCode: string) {
+    return await this.repository.exist({ where: { groupCode: groupCode } });
+  }
 }

--- a/BE/src/group/group/entities/group.repository.ts
+++ b/BE/src/group/group/entities/group.repository.ts
@@ -24,6 +24,7 @@ export class GroupRepository extends TransactionalRepository<GroupEntity> {
         'group.id as id',
         'group.name as name',
         'group.avatarUrl as avatarUrl',
+        'group.groupCode as groupCode',
         'user_group.grade as grade',
       ])
       .addSelect('COUNT(achievements.id)', 'continued')

--- a/BE/src/group/group/entities/group.repository.ts
+++ b/BE/src/group/group/entities/group.repository.ts
@@ -75,4 +75,13 @@ export class GroupRepository extends TransactionalRepository<GroupEntity> {
     });
     return group?.toModel();
   }
+
+  async findByGroupCode(groupCode: string) {
+    const group = await this.repository.findOne({
+      where: {
+        groupCode: groupCode,
+      },
+    });
+    return group?.toModel();
+  }
 }

--- a/BE/src/group/group/exception/duplicated-join.exception.ts
+++ b/BE/src/group/group/exception/duplicated-join.exception.ts
@@ -1,0 +1,8 @@
+import { MotimateException } from '../../../common/exception/motimate.excpetion';
+import { ERROR_INFO } from '../../../common/exception/error-code';
+
+export class DuplicatedJoinException extends MotimateException {
+  constructor() {
+    super(ERROR_INFO.DUPLICATED_JOIN);
+  }
+}

--- a/BE/src/group/group/exception/no-such-group.exception.ts
+++ b/BE/src/group/group/exception/no-such-group.exception.ts
@@ -1,0 +1,8 @@
+import { MotimateException } from '../../../common/exception/motimate.excpetion';
+import { ERROR_INFO } from '../../../common/exception/error-code';
+
+export class NoSucGroupException extends MotimateException {
+  constructor() {
+    super(ERROR_INFO.NO_SUCH_GROUP);
+  }
+}

--- a/BE/src/group/group/group.module.ts
+++ b/BE/src/group/group/group.module.ts
@@ -6,6 +6,7 @@ import { GroupService } from './application/group.service';
 import { UserGroupRepository } from './entities/user-group.repository';
 import { GroupAvatarHolder } from './application/group-avatar.holder';
 import { UserRepository } from '../../users/entities/user.repository';
+import { GroupCodeGenerator } from './application/group-code-generator';
 
 @Module({
   imports: [
@@ -16,6 +17,6 @@ import { UserRepository } from '../../users/entities/user.repository';
     ]),
   ],
   controllers: [GroupController],
-  providers: [GroupService, GroupAvatarHolder],
+  providers: [GroupService, GroupAvatarHolder, GroupCodeGenerator],
 })
 export class GroupModule {}

--- a/BE/src/group/group/index.ts
+++ b/BE/src/group/group/index.ts
@@ -2,6 +2,7 @@ export interface IGroupPreview {
   id: number;
   name: string;
   avatarUrl: string;
+  groupCode: string;
   continued: string;
   lastChallenged: Date;
   grade: string;

--- a/BE/test/group/group/group-fixture.ts
+++ b/BE/test/group/group/group-fixture.ts
@@ -36,6 +36,11 @@ export class GroupFixture {
   }
 
   static group(name?: string) {
+    const group = new Group(
+      name || `group${++GroupFixture.id}`,
+      'file://avatarUrl',
+    );
+    group.assignGroupCode(`GABCDE${++GroupFixture.id}`);
     return new Group(name || `group${++GroupFixture.id}`, 'file://avatarUrl');
   }
 }


### PR DESCRIPTION
## PR 요약
- 그룹 참여 API 개발
- 그룹 테이블에 groupCode 추가
- 그룹 리스트 API에 groupCode 추가
- 그룹 생성시 group code 부여 로직 추가

##### 스크린샷
- 성공
![image](https://github.com/boostcampwm2023/iOS02-moti/assets/34297340/5ebddc06-567c-4f89-9dc7-5d2740da4b96)

- 중복 가입 요청 시
![image](https://github.com/boostcampwm2023/iOS02-moti/assets/34297340/42e84fc5-109d-4aba-8a81-b8fed19eca99)

- 존재하지 않는 그룹인 경우
![image](https://github.com/boostcampwm2023/iOS02-moti/assets/34297340/46f6fe69-fa88-44e3-ae15-667511d1660b)


- 그룹 리스트 API에 group code를 추가한다.

<img width="740" alt="image" src="https://github.com/boostcampwm2023/iOS02-moti/assets/34297340/b5aa95d9-3d85-4eae-b994-f8d2709a45e6">

#### Linked Issue
close #554 
