### PR TITLE
그룹 참여를 구현한다.

### DIFF
--- a/iOS/moti/moti/Data/Sources/Data/Network/DTO/FetchGroupListDTO.swift
+++ b/iOS/moti/moti/Data/Sources/Data/Network/DTO/FetchGroupListDTO.swift
@@ -20,6 +20,7 @@ struct FetchGroupListDataDTO: Codable {
 
 struct GroupDTO: Codable {
     let id: Int
+    let groupCode: String?
     let name: String?
     let avatarUrl: URL?
     let continued: Int?
@@ -31,6 +32,7 @@ extension Group {
     init(dto: GroupDTO) {
         self.init(
             id: dto.id,
+            code: dto.groupCode ?? "",
             name: dto.name ?? "",
             avatarUrl: dto.avatarUrl,
             continued: dto.continued ?? 0,
@@ -41,6 +43,7 @@ extension Group {
     init(dto: GroupDTO, grade: GroupGrade) {
         self.init(
             id: dto.id,
+            code: dto.groupCode ?? "",
             name: dto.name ?? "",
             avatarUrl: dto.avatarUrl,
             continued: dto.continued ?? 0,

--- a/iOS/moti/moti/Data/Sources/Data/Network/DTO/JoinGroupDTO.swift
+++ b/iOS/moti/moti/Data/Sources/Data/Network/DTO/JoinGroupDTO.swift
@@ -1,0 +1,19 @@
+//
+//  JoinGroupDTO.swift
+//
+//
+//  Created by Kihyun Lee on 12/10/23.
+//
+
+import Foundation
+
+struct JoinGroupDTO: ResponseDataDTO {
+    let success: Bool?
+    let message: String?
+    let data: JoinGroupDataDTO?
+}
+
+struct JoinGroupDataDTO: Codable {
+    let groupCode: String?
+    let userCode: String?
+}

--- a/iOS/moti/moti/Data/Sources/Data/Network/Endpoint/MotiAPI.swift
+++ b/iOS/moti/moti/Data/Sources/Data/Network/Endpoint/MotiAPI.swift
@@ -39,6 +39,7 @@ enum MotiAPI: EndpointProtocol {
     case updateGrade(groupId: Int, userCode: String, requestValue: UpdateGradeRequestValue)
     case invite(requestValue: InviteMemberRequestValue, groupId: Int)
     case dropGroup(groupId: Int)
+    case joinGroup(requestValue: JoinGroupRequestValue)
     // 차단
     case blockingUser(userCode: String)
     case blockingAchievement(achievementId: Int, groupId: Int)
@@ -109,6 +110,8 @@ extension MotiAPI {
             return "/groups/\(groupId)/achievements/\(achievementId)/emojis/\(emojiId)"
         case .dropGroup(let groupId):
             return "/groups/\(groupId)/participation"
+        case .joinGroup:
+            return "/groups/participation"
         }
     }
     
@@ -145,6 +148,7 @@ extension MotiAPI {
         case .fetchEmojis: return .get
         case .toggleEmoji: return .post
         case .dropGroup: return .delete
+        case .joinGroup: return .post
         }
     }
     
@@ -184,6 +188,8 @@ extension MotiAPI {
         case .invite(let requestValue, _):
             return requestValue
         case .updateGrade(_, _, let requestValue):
+            return requestValue
+        case .joinGroup(let requestValue):
             return requestValue
         default:
             return nil

--- a/iOS/moti/moti/Data/Sources/Repository/GroupRepository.swift
+++ b/iOS/moti/moti/Data/Sources/Repository/GroupRepository.swift
@@ -39,4 +39,12 @@ public struct GroupRepository: GroupRepositoryProtocol {
         
         return responseDTO.success ?? false
     }
+    
+    public func joinGroup(requestValue: JoinGroupRequestValue) async throws -> Bool {
+        let endpoint = MotiAPI.joinGroup(requestValue: requestValue)
+        let responseDTO = try await provider.request(with: endpoint, type: JoinGroupDTO.self)
+        guard let joinGroupDataDTO = responseDTO.data else { throw NetworkError.decode }
+        
+        return responseDTO.success ?? false
+    }
 }

--- a/iOS/moti/moti/Domain/Sources/Domain/Entity/Group.swift
+++ b/iOS/moti/moti/Domain/Sources/Domain/Entity/Group.swift
@@ -23,6 +23,7 @@ public enum GroupGrade: String, CustomStringConvertible {
 
 public struct Group: Hashable {
     public let id: Int
+    public let code: String
     public let name: String
     public var avatarUrl: URL?
     public var continued: Int
@@ -31,6 +32,7 @@ public struct Group: Hashable {
     
     public init(
         id: Int,
+        code: String,
         name: String,
         avatarUrl: URL?,
         continued: Int,
@@ -38,6 +40,7 @@ public struct Group: Hashable {
         grade: GroupGrade
     ) {
         self.id = id
+        self.code = code
         self.name = name
         self.avatarUrl = avatarUrl
         self.continued = continued
@@ -47,11 +50,13 @@ public struct Group: Hashable {
     
     public init(
         id: Int,
+        code: String,
         name: String,
         avatarUrl: URL?,
         grade: GroupGrade
     ) {
         self.id = id
+        self.code = code
         self.name = name
         self.avatarUrl = avatarUrl
         self.continued = 0

--- a/iOS/moti/moti/Domain/Sources/Domain/RepositoryProtocol/GroupRepositoryProtocol.swift
+++ b/iOS/moti/moti/Domain/Sources/Domain/RepositoryProtocol/GroupRepositoryProtocol.swift
@@ -11,4 +11,5 @@ public protocol GroupRepositoryProtocol {
     func fetchGroupList() async throws -> [Group]
     func createGroup(requestValue: CreateGroupRequestValue) async throws -> Group
     func dropGroup(groupId: Int) async throws -> Bool
+    func joinGroup(requestValue: JoinGroupRequestValue) async throws -> Bool
 }

--- a/iOS/moti/moti/Domain/Sources/Domain/UseCase/JoinGroupUseCase.swift
+++ b/iOS/moti/moti/Domain/Sources/Domain/UseCase/JoinGroupUseCase.swift
@@ -1,0 +1,28 @@
+//
+//  JoinGroupUseCase.swift
+//
+//
+//  Created by Kihyun Lee on 12/10/23.
+//
+
+import Foundation
+
+public struct JoinGroupRequestValue: RequestValue {
+    public let groupCode: String
+    
+    public init(groupCode: String) {
+        self.groupCode = groupCode
+    }
+}
+
+public struct JoinGroupUseCase {
+    private let groupRepository: GroupRepositoryProtocol
+    
+    public init(groupRepository: GroupRepositoryProtocol) {
+        self.groupRepository = groupRepository
+    }
+    
+    public func execute(requestValue: JoinGroupRequestValue) async throws -> Bool {
+        return try await groupRepository.joinGroup(requestValue: requestValue)
+    }
+}

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeViewController.swift
@@ -236,7 +236,7 @@ private extension GroupHomeViewController {
         showTextFieldAlert(
             title: "그룹원 초대",
             okTitle: "초대",
-            placeholder: "초대할 유저의 7자리 유저코드를 입력하세요.",
+            placeholder: "7자리 유저코드를 입력하세요.",
             okAction: { text in
                 guard let text = text else { return }
                 Logger.debug("초대할 유저코드: \(text)")

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupInfo/GroupInfoView.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupInfo/GroupInfoView.swift
@@ -42,7 +42,6 @@ final class GroupInfoView: UIView {
     
     private let groupCodeLabel: UILabel = {
         let label = UILabel()
-        label.text = "@ABCDEFG"
         label.font = .mediumBold
         return label
     }()

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupInfo/GroupInfoView.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupInfo/GroupInfoView.swift
@@ -40,6 +40,13 @@ final class GroupInfoView: UIView {
         return label
     }()
     
+    private let groupCodeLabel: UILabel = {
+        let label = UILabel()
+        label.text = "@ABCDEFG"
+        label.font = .mediumBold
+        return label
+    }()
+    
     private(set) var tableView: UITableView = {
         let tableView = UITableView()
         tableView.register(GroupInfoTableViewCell.self, forCellReuseIdentifier: GroupInfoTableViewCell.identifier)
@@ -68,6 +75,8 @@ final class GroupInfoView: UIView {
         if group.grade != .leader {
             cameraIcon.isHidden = true
         }
+        
+        groupCodeLabel.text = "@\(group.code)"
     }
     
     func cancelDownloadImage() {
@@ -92,6 +101,11 @@ extension GroupInfoView {
             .top(equalTo: imageView.bottomAnchor, constant: 20)
             .centerX(equalTo: safeAreaLayoutGuide.centerXAnchor)
         
+        addSubview(groupCodeLabel)
+        groupCodeLabel.atl
+            .top(equalTo: groupNameLabel.bottomAnchor, constant: 20)
+            .centerX(equalTo: safeAreaLayoutGuide.centerXAnchor)
+        
         addSubview(cameraIcon)
         cameraIcon.atl
             .size(width: cameraIconSize, height: cameraIconSize)
@@ -100,7 +114,7 @@ extension GroupInfoView {
         
         addSubview(tableView)
         tableView.atl
-            .top(equalTo: groupNameLabel.bottomAnchor, constant: 40)
+            .top(equalTo: groupCodeLabel.bottomAnchor, constant: 30)
             .bottom(equalTo: self.bottomAnchor)
             .horizontal(equalTo: safeAreaLayoutGuide)
     }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupInfo/GroupInfoView.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupInfo/GroupInfoView.swift
@@ -103,7 +103,7 @@ extension GroupInfoView {
         
         addSubview(groupCodeLabel)
         groupCodeLabel.atl
-            .top(equalTo: groupNameLabel.bottomAnchor, constant: 20)
+            .top(equalTo: groupNameLabel.bottomAnchor, constant: 5)
             .centerX(equalTo: safeAreaLayoutGuide.centerXAnchor)
         
         addSubview(cameraIcon)

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupList/GroupListCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupList/GroupListCoordinator.swift
@@ -29,7 +29,8 @@ final class GroupListCoordinator: Coordinator {
         let groupVM = GroupListViewModel(
             fetchGroupListUseCase: .init(groupRepository: groupRepository),
             createGroupUseCase: .init(groupRepository: groupRepository), 
-            dropGroupUseCase: .init(groupRepository: groupRepository)
+            dropGroupUseCase: .init(groupRepository: groupRepository), 
+            joinGroupUseCase: .init(groupRepository: groupRepository)
         )
         let groupListVC = GroupListViewController(viewModel: groupVM)
         groupListVC.coordinator = self

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupList/GroupListViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupList/GroupListViewController.swift
@@ -101,7 +101,7 @@ final class GroupListViewController: BaseViewController<GroupListView> {
     }
     
     @objc private func showJoinGroupTextFieldAlert() {
-        let textFieldAlertVC = AlertFactory.makeTextFieldAlert(
+        showTextFieldAlert(
             title: "그룹 참가",
             okTitle: "참가",
             placeholder: "7자리 그룹코드를 입력하세요.",
@@ -109,9 +109,8 @@ final class GroupListViewController: BaseViewController<GroupListView> {
                 guard let self, let text else { return }
                 Logger.debug("그룹 참가 입력: \(text)")
                 viewModel.action(.join(groupCode: text))
-            })
-        
-        present(textFieldAlertVC, animated: true)
+            }
+        )
     }
 }
 

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupList/GroupListViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupList/GroupListViewController.swift
@@ -248,7 +248,7 @@ extension GroupListViewController: LoadingIndicator {
                     showOneButtonAlert(title: "그룹에서 탈퇴되었습니다.")
                 case .finishIncreased:
                     hideLoadingIndicator()
-                    showOneButtonAlert(title: "새로운 그룹에 초대되었습니다!")
+                    showOneButtonAlert(title: "새로운 그룹이 었습니다!")
                 case .error(let message):
                     hideLoadingIndicator()
                     showErrorAlert(message: message)

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupList/GroupListViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupList/GroupListViewController.swift
@@ -240,7 +240,7 @@ extension GroupListViewController: LoadingIndicator {
                     showOneButtonAlert(title: "그룹에서 탈퇴되었습니다.")
                 case .finishIncreased:
                     hideLoadingIndicator()
-                    showOneButtonAlert(title: "새로운 그룹이 었습니다!")
+                    showOneButtonAlert(title: "새로운 그룹이 있습니다!")
                 case .error(let message):
                     hideLoadingIndicator()
                     showErrorAlert(message: message)

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupList/GroupListViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupList/GroupListViewController.swift
@@ -99,6 +99,20 @@ final class GroupListViewController: BaseViewController<GroupListView> {
         
         present(textFieldAlertVC, animated: true)
     }
+    
+    @objc private func showJoinGroupTextFieldAlert() {
+        let textFieldAlertVC = AlertFactory.makeTextFieldAlert(
+            title: "그룹 참가",
+            okTitle: "참가",
+            placeholder: "7자리 그룹코드를 입력하세요.",
+            okAction: { [weak self] text in
+                guard let self, let text else { return }
+                Logger.debug("그룹 참가 입력: \(text)")
+                viewModel.action(.join(groupCode: text))
+            })
+        
+        present(textFieldAlertVC, animated: true)
+    }
 }
 
 // MARK: - Setup
@@ -139,8 +153,13 @@ private extension GroupListViewController {
             title: "생성", style: .plain, target: self,
             action: #selector(showCreateGroupTextFieldAlert)
         )
+        
+        let joinGroupItem = UIBarButtonItem(
+            title: "참가", style: .plain, target: self,
+            action: #selector(showJoinGroupTextFieldAlert)
+        )
 
-        navigationItem.rightBarButtonItems = [profileItem, createGroupItem]
+        navigationItem.rightBarButtonItems = [profileItem, createGroupItem, joinGroupItem]
     }
     
     @objc func showUserCode() {
@@ -183,6 +202,11 @@ extension GroupListViewController: UITextFieldDelegate {
 // MARK: - Bind
 extension GroupListViewController: LoadingIndicator {
     func bind() {
+        bindGroupList()
+        bindGroup()
+    }
+    
+    func bindGroupList() {
         viewModel.$groupListState
             .receive(on: DispatchQueue.main)
             .sink { [weak self] state in
@@ -202,6 +226,31 @@ extension GroupListViewController: LoadingIndicator {
             }
             .store(in: &cancellables)
         
+        viewModel.refetchGroupListState
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] state in
+                guard let self else { return }
+                switch state {
+                case .loading:
+                    showLoadingIndicator()
+                case .finishSame:
+                    hideLoadingIndicator()
+                case .finishDecreased:
+                    hideLoadingIndicator()
+                    showOneButtonAlert(title: "그룹에서 탈퇴되었습니다.")
+                case .finishIncreased:
+                    hideLoadingIndicator()
+                    showOneButtonAlert(title: "새로운 그룹이 었습니다!")
+                case .error(let message):
+                    hideLoadingIndicator()
+                    showErrorAlert(message: message)
+                }
+            }
+            .store(in: &cancellables)
+        
+    }
+    
+    func bindGroup() {
         viewModel.createGroupState
             .receive(on: DispatchQueue.main)
             .sink { [weak self] state in
@@ -234,21 +283,16 @@ extension GroupListViewController: LoadingIndicator {
             }
             .store(in: &cancellables)
         
-        viewModel.refetchGroupListState
+        viewModel.joinGroupState
             .receive(on: DispatchQueue.main)
             .sink { [weak self] state in
                 guard let self else { return }
                 switch state {
                 case .loading:
                     showLoadingIndicator()
-                case .finishSame:
+                case .finish:
                     hideLoadingIndicator()
-                case .finishDecreased:
-                    hideLoadingIndicator()
-                    showOneButtonAlert(title: "그룹에서 탈퇴되었습니다.")
-                case .finishIncreased:
-                    hideLoadingIndicator()
-                    showOneButtonAlert(title: "새로운 그룹이 었습니다!")
+                    viewModel.action(.refetch)
                 case .error(let message):
                     hideLoadingIndicator()
                     showErrorAlert(message: message)

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupList/GroupListViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupList/GroupListViewModel.swift
@@ -199,7 +199,7 @@ extension GroupListViewModel {
                 if isSuccess {
                     joinGroupState.send(.finish)
                 } else {
-                    joinGroupState.send(.error(message: "그룹코드가 \(groupCode)인 그룹 참가에 실패했습니다."))
+                    joinGroupState.send(.error(message: "\(groupCode) 그룹 참가에 실패했습니다."))
                 }
             } catch {
                 Logger.error("\(#function) error: \(error.localizedDescription)")


### PR DESCRIPTION
## PR 요약
- 7자리 그룹 코드를 이용한 그룹 참가 구현
- 그룹 코드는 그룹 리스트 -> 그룹 홈 -> 그룹 정보 에서 확인

#### 주의 사항
- 그룹에 초대와 그룹에 참가가 둘 다 alert 메시지가 같음
- 현재 refetch 시에 개수 비교로 alert를 띄우고 있기 때문

##### 스크린샷
<img width="33%" src="https://github.com/boostcampwm2023/iOS02-moti/assets/60506170/0e725965-619b-47f5-8bb4-61195e9c3523">

#### Linked Issue
close #553
