### PR TITLE
카테고리 화살표 이미지 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 ## iOS
 
 <details>
-<summary>Interaction Animation</summary>
+<summary>⭐️Interaction Animation</summary>
 <div markdown="1">      
 
 ### Interaction Animation
@@ -57,7 +57,7 @@
 </details>
 
 <details>
-<summary>이미지 메모리 최적화</summary>
+<summary>⭐️이미지 메모리 최적화</summary>
 <div markdown="1">      
 
 ### 이미지 메모리 최적화
@@ -200,7 +200,7 @@
 </details>
 
 <details>
-<summary>서버리스</summary>
+<summary>⭐️서버리스</summary>
 <div markdown="1">      
     
 ### 서버리스
@@ -223,7 +223,7 @@
 
 
 <details>
-<summary>테스트 코드</summary>
+<summary>⭐️테스트 코드</summary>
 <div markdown="1">
     
 ### 테스트 코드

--- a/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementView.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementView.swift
@@ -37,6 +37,7 @@ final class EditAchievementView: UIView {
         button.setImage(image, for: .normal)
         button.tintColor = .label
         button.configuration?.imagePlacement = .trailing
+        button.configuration?.imagePadding = 3
         
         button.setTitle("카테고리", for: .normal)
         button.setTitleColor(.primaryDarkGray, for: .normal)

--- a/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementView.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/EditAchievement/EditAchievementView.swift
@@ -31,6 +31,12 @@ final class EditAchievementView: UIView {
     
     let categoryButton = {
         let button = UIButton(type: .system)
+        button.configuration = .plain()
+        let config = UIImage.SymbolConfiguration(font: .small)
+        let image = UIImage(systemName: "chevron.up.chevron.down", withConfiguration: config)
+        button.setImage(image, for: .normal)
+        button.tintColor = .label
+        button.configuration?.imagePlacement = .trailing
         
         button.setTitle("카테고리", for: .normal)
         button.setTitleColor(.primaryDarkGray, for: .normal)
@@ -120,7 +126,7 @@ extension EditAchievementView {
         categoryButton.atl
             .top(greaterThanOrEqualTo: safeAreaLayoutGuide.topAnchor)
             .bottom(greaterThanOrEqualTo: titleTextField.topAnchor, constant: -5)
-            .left(equalTo: safeAreaLayoutGuide.leftAnchor, constant: 20)
+            .left(equalTo: safeAreaLayoutGuide.leftAnchor, constant: 10)
     }
 
     private func setupTitleTextField() {


### PR DESCRIPTION
## PR 요약
- 카테고리 화살표 이미지 추가
- 사용자가 궁금해서 한 번이라도 눌러 볼 수 있음

##### 스크린샷
<img width="33%" src="https://github.com/boostcampwm2023/iOS02-moti/assets/60506170/b2bea7fb-32b7-429c-bb03-6ea8052d8163">

#### Linked Issue
close #579 
