### PR TITLE
차단한 유저 목록을 조회 및 차단 해제 할 수 있다.

### DIFF
--- a/BE/src/common/exception/error-code.ts
+++ b/BE/src/common/exception/error-code.ts
@@ -103,6 +103,10 @@ export const ERROR_INFO = {
     statusCode: 400,
     message: '유효하지 않은 차단 요청입니다.',
   },
+  INVALID_ALLOW_REQUEST: {
+    statusCode: 400,
+    message: '유효하지 않은 차단 해제 요청입니다.',
+  },
   INVITE_PERMISSION_DENIED: {
     statusCode: 400,
     message: '그룹원 초대 권한이 없습니다.',

--- a/BE/src/users/application/users.service.spec.ts
+++ b/BE/src/users/application/users.service.spec.ts
@@ -14,6 +14,7 @@ import { DataSource } from 'typeorm';
 import { UsersFixture } from '../../../test/user/users-fixture';
 import { UsersTestModule } from '../../../test/user/users-test.module';
 import { NoSuchUserException } from '../exception/no-such-user.exception';
+import { InvalidAllowRequestException } from '../exception/invalid-allow-request.exception';
 
 describe('UsersService Test', () => {
   let userService: UsersService;
@@ -35,6 +36,10 @@ describe('UsersService Test', () => {
     userRepository = module.get<UserRepository>(UserRepository);
     usersFixture = module.get<UsersFixture>(UsersFixture);
     dataSource = module.get<DataSource>(DataSource);
+  });
+
+  afterAll(async () => {
+    await dataSource.destroy();
   });
 
   test('userService, userRepository가 정의되어 있어야 한다. ', () => {
@@ -132,6 +137,50 @@ describe('UsersService Test', () => {
       const rejectUserListResponse = await userService.getRejectUserList(user1);
       // then
       expect(rejectUserListResponse.data.length).toEqual(2);
+    });
+  });
+
+  test('유저 차단 해제를 할 수 있다.', async () => {
+    await transactionTest(dataSource, async () => {
+      // given
+      const user1 = await usersFixture.getUser('ABC');
+      const user2 = await usersFixture.getUser('DEF');
+      await userService.reject(user1, user2.userCode);
+
+      // when
+      const allowUserResponse = await userService.allow(user1, user2.userCode);
+
+      // then
+      expect(allowUserResponse.userCode).toEqual(user1.userCode);
+      expect(allowUserResponse.blockedUserCode).toEqual(user2.userCode);
+    });
+  });
+
+  test('존재하지 않는 유저를 차단 해제하려고 하면 NoSuchUserException를 던진다.', async () => {
+    await transactionTest(dataSource, async () => {
+      // given
+      const user1 = await usersFixture.getUser('ABC');
+      const invalidUserCode = 'XYZ1234';
+
+      // when
+      // then
+      await expect(userService.allow(user1, invalidUserCode)).rejects.toThrow(
+        NoSuchUserException,
+      );
+    });
+  });
+
+  test('차단 되어있지 않은 유저를 차단 해제하려고 하면 InvalidAllowRequestException를 던진다.', async () => {
+    await transactionTest(dataSource, async () => {
+      // given
+      const user1 = await usersFixture.getUser('ABC');
+      const user2 = await usersFixture.getUser('DEF');
+
+      // when
+      // then
+      await expect(userService.allow(user1, user2.userCode)).rejects.toThrow(
+        InvalidAllowRequestException,
+      );
     });
   });
 });

--- a/BE/src/users/application/users.service.spec.ts
+++ b/BE/src/users/application/users.service.spec.ts
@@ -118,4 +118,20 @@ describe('UsersService Test', () => {
       );
     });
   });
+
+  test('차단한 유저 목록을 조회할 수 있다.', async () => {
+    await transactionTest(dataSource, async () => {
+      // given
+      const user1 = await usersFixture.getUser('ABC');
+      const user2 = await usersFixture.getUser('DEF');
+      const user3 = await usersFixture.getUser('GHI');
+      await userService.reject(user1, user2.userCode);
+      await userService.reject(user1, user3.userCode);
+
+      // when
+      const rejectUserListResponse = await userService.getRejectUserList(user1);
+      // then
+      expect(rejectUserListResponse.data.length).toEqual(2);
+    });
+  });
 });

--- a/BE/src/users/application/users.service.ts
+++ b/BE/src/users/application/users.service.ts
@@ -8,6 +8,7 @@ import { UserBlockedUserRepository } from '../entities/user-blocked-user.reposit
 import { UserBlockedUser } from '../domain/user-blocked-user.domain';
 import { NoSuchUserException } from '../exception/no-such-user.exception';
 import { RejectUserResponse } from '../dto/reject-user-response.dto';
+import { RejectUserListResponse } from '../dto/reject-user-list-response.dto';
 
 @Injectable()
 export class UsersService {
@@ -37,5 +38,12 @@ export class UsersService {
         new UserBlockedUser(user, blockedUser),
       );
     return RejectUserResponse.from(userBlockedUser);
+  }
+
+  @Transactional({ readonly: true })
+  async getRejectUserList(user: User) {
+    const userBlockedUsers =
+      await this.userBlockedUserRepository.findByUserIdWithBlockedUser(user.id);
+    return new RejectUserListResponse(userBlockedUsers);
   }
 }

--- a/BE/src/users/controller/users.controller.spec.ts
+++ b/BE/src/users/controller/users.controller.spec.ts
@@ -13,6 +13,9 @@ import { User } from '../domain/user.domain';
 import { NoSuchUserException } from '../exception/no-such-user.exception';
 import { InvalidRejectRequestException } from '../../group/achievement/exception/invalid-reject-request.exception';
 import * as request from 'supertest';
+import { RejectUserListResponse } from '../dto/reject-user-list-response.dto';
+import { UserBlockedUser } from '../domain/user-blocked-user.domain';
+import { UsersFixture } from '../../../test/user/users-fixture';
 
 describe('UserController Test', () => {
   let app: INestApplication;
@@ -139,6 +142,79 @@ describe('UserController Test', () => {
       // then
       return request(app.getHttpServer())
         .post('/api/v1/groups/1/achievements/1/reject')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(401)
+        .expect((res: request.Response) => {
+          expect(res.body.success).toBe(false);
+          expect(res.body.message).toBe('만료된 토큰입니다.');
+        });
+    });
+  });
+
+  describe('차단한 유저 리스트를 조회할 수 있다.', () => {
+    it('성공 시 200을 반환한다.', async () => {
+      // given
+      const { accessToken } = await authFixture.getAuthenticatedUser('ABC');
+      const user1 = UsersFixture.user('ABC');
+      const user2 = UsersFixture.user('DEF');
+      user2.avatarUrl = 'avatarUrl2';
+      const user3 = UsersFixture.user('GHI');
+      user3.avatarUrl = 'avatarUrl3';
+
+      const rejectUserListResponse = new RejectUserListResponse([
+        new UserBlockedUser(user1, user2),
+        new UserBlockedUser(user1, user3),
+      ]);
+
+      when(mockUsersService.getRejectUserList(anyOfClass(User))).thenResolve(
+        rejectUserListResponse,
+      );
+
+      // when
+      // then
+      return request(app.getHttpServer())
+        .get('/api/v1/users/reject')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect((res: request.Response) => {
+          expect(res.body.success).toEqual(true);
+          expect(res.body.data).toEqual({
+            data: [
+              {
+                avatarUrl: 'avatarUrl2',
+                userCode: 'ABCDDEF',
+              },
+              {
+                avatarUrl: 'avatarUrl3',
+                userCode: 'ABCDGHI',
+              },
+            ],
+          });
+        });
+    });
+    it('잘못된 인증시 401을 반환한다.', async () => {
+      // given
+      const accessToken = 'abcd.abcd.efgh';
+
+      // when
+      // then
+      return request(app.getHttpServer())
+        .get('/api/v1/users/reject')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(401)
+        .expect((res: request.Response) => {
+          expect(res.body.success).toBe(false);
+          expect(res.body.message).toBe('잘못된 토큰입니다.');
+        });
+    });
+    it('만료된 인증정보에 401을 반환한다.', async () => {
+      // given
+      const { accessToken } =
+        await authFixture.getExpiredAccessTokenUser('ABC');
+
+      // when
+      // then
+      return request(app.getHttpServer())
+        .get('/api/v1/users/reject')
         .set('Authorization', `Bearer ${accessToken}`)
         .expect(401)
         .expect((res: request.Response) => {

--- a/BE/src/users/controller/users.controller.spec.ts
+++ b/BE/src/users/controller/users.controller.spec.ts
@@ -159,7 +159,7 @@ describe('UserController Test', () => {
       const user3 = UsersFixture.user('GHI');
       user3.avatarUrl = 'avatarUrl3';
 
-      const rejectDate = new Date(2023, 11, 2, 12, 31, 10);
+      const rejectDate = new Date(Date.UTC(2023, 11, 2, 12, 31, 10));
 
       const rejectUserListResponse = new RejectUserListResponse([
         new UserBlockedUser(user1, user2, rejectDate),
@@ -182,12 +182,12 @@ describe('UserController Test', () => {
               {
                 avatarUrl: 'avatarUrl2',
                 userCode: 'ABCDDEF',
-                createdAt: '2023-12-02T03:31:10Z',
+                createdAt: '2023-12-02T12:31:10Z',
               },
               {
                 avatarUrl: 'avatarUrl3',
                 userCode: 'ABCDGHI',
-                createdAt: '2023-12-02T03:31:10Z',
+                createdAt: '2023-12-02T12:31:10Z',
               },
             ],
           });

--- a/BE/src/users/controller/users.controller.spec.ts
+++ b/BE/src/users/controller/users.controller.spec.ts
@@ -159,9 +159,11 @@ describe('UserController Test', () => {
       const user3 = UsersFixture.user('GHI');
       user3.avatarUrl = 'avatarUrl3';
 
+      const rejectDate = new Date(2023, 11, 2, 12, 31, 10);
+
       const rejectUserListResponse = new RejectUserListResponse([
-        new UserBlockedUser(user1, user2),
-        new UserBlockedUser(user1, user3),
+        new UserBlockedUser(user1, user2, rejectDate),
+        new UserBlockedUser(user1, user3, rejectDate),
       ]);
 
       when(mockUsersService.getRejectUserList(anyOfClass(User))).thenResolve(
@@ -180,10 +182,12 @@ describe('UserController Test', () => {
               {
                 avatarUrl: 'avatarUrl2',
                 userCode: 'ABCDDEF',
+                createdAt: '2023-12-02T03:31:10Z',
               },
               {
                 avatarUrl: 'avatarUrl3',
                 userCode: 'ABCDGHI',
+                createdAt: '2023-12-02T03:31:10Z',
               },
             ],
           });

--- a/BE/src/users/controller/users.controller.ts
+++ b/BE/src/users/controller/users.controller.ts
@@ -1,5 +1,6 @@
 import {
   Controller,
+  Delete,
   Get,
   HttpCode,
   HttpStatus,
@@ -20,6 +21,7 @@ import { User } from '../domain/user.domain';
 import { UsersService } from '../application/users.service';
 import { RejectUserResponse } from '../dto/reject-user-response.dto';
 import { RejectUserListResponse } from '../dto/reject-user-list-response.dto';
+import { AllowUserResponse } from '../dto/allow-user-response.dto';
 
 @Controller('/api/v1/users')
 @ApiTags('유저 API')
@@ -43,6 +45,25 @@ export class UserController {
     @Param('userCode') userCode: string,
   ) {
     return ApiData.success(await this.userService.reject(user, userCode));
+  }
+
+  @ApiOperation({
+    summary: '유저 차단 해제 API',
+    description: '유저 차단을 해제한다.',
+  })
+  @ApiResponse({
+    description: '유저 차단 해제',
+    type: AllowUserResponse,
+  })
+  @ApiBearerAuth('accessToken')
+  @Delete('/:userCode/reject')
+  @UseGuards(AccessTokenGuard)
+  @HttpCode(HttpStatus.OK)
+  async allow(
+    @AuthenticatedUser() user: User,
+    @Param('userCode') userCode: string,
+  ) {
+    return ApiData.success(await this.userService.allow(user, userCode));
   }
 
   @ApiOperation({

--- a/BE/src/users/controller/users.controller.ts
+++ b/BE/src/users/controller/users.controller.ts
@@ -1,5 +1,6 @@
 import {
   Controller,
+  Get,
   HttpCode,
   HttpStatus,
   Param,
@@ -18,6 +19,7 @@ import { AuthenticatedUser } from '../../auth/decorator/athenticated-user.decora
 import { User } from '../domain/user.domain';
 import { UsersService } from '../application/users.service';
 import { RejectUserResponse } from '../dto/reject-user-response.dto';
+import { RejectUserListResponse } from '../dto/reject-user-list-response.dto';
 
 @Controller('/api/v1/users')
 @ApiTags('유저 API')
@@ -36,10 +38,26 @@ export class UserController {
   @Post('/:userCode/reject')
   @UseGuards(AccessTokenGuard)
   @HttpCode(HttpStatus.OK)
-  async users(
+  async reject(
     @AuthenticatedUser() user: User,
     @Param('userCode') userCode: string,
   ) {
     return ApiData.success(await this.userService.reject(user, userCode));
+  }
+
+  @ApiOperation({
+    summary: '차단 유저 목록 API',
+    description: '차단한 유저를 조회한다.',
+  })
+  @ApiResponse({
+    description: '차단 유저 목록',
+    type: RejectUserListResponse,
+  })
+  @ApiBearerAuth('accessToken')
+  @Get('/reject')
+  @UseGuards(AccessTokenGuard)
+  @HttpCode(HttpStatus.OK)
+  async rejectUserList(@AuthenticatedUser() user: User) {
+    return ApiData.success(await this.userService.getRejectUserList(user));
   }
 }

--- a/BE/src/users/domain/user-blocked-user.domain.ts
+++ b/BE/src/users/domain/user-blocked-user.domain.ts
@@ -3,9 +3,11 @@ import { User } from './user.domain';
 export class UserBlockedUser {
   user: User;
   blockedUser: User;
+  createdAt: Date;
 
-  constructor(user: User, blockedUser: User) {
+  constructor(user: User, blockedUser: User, createdAt?: Date) {
     this.user = user;
     this.blockedUser = blockedUser;
+    this.createdAt = createdAt;
   }
 }

--- a/BE/src/users/dto/allow-user-response.dto.ts
+++ b/BE/src/users/dto/allow-user-response.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { UserBlockedUser } from '../domain/user-blocked-user.domain';
+
+export class AllowUserResponse {
+  @ApiProperty({ description: '유저 코드' })
+  userCode: string;
+  @ApiProperty({ description: '차단 유저 코드' })
+  blockedUserCode: string;
+
+  constructor(userCode: string, blockedUserCode: string) {
+    this.userCode = userCode;
+    this.blockedUserCode = blockedUserCode;
+  }
+
+  static from(userBlockedUser: UserBlockedUser) {
+    return new AllowUserResponse(
+      userBlockedUser.user.userCode,
+      userBlockedUser.blockedUser.userCode,
+    );
+  }
+}

--- a/BE/src/users/dto/reject-info.dto.ts
+++ b/BE/src/users/dto/reject-info.dto.ts
@@ -1,0 +1,25 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { dateFormat } from '../../common/utils/date-formatter';
+import { UserBlockedUser } from '../domain/user-blocked-user.domain';
+
+export class RejectedUser {
+  @ApiProperty({ description: 'avatarUrl' })
+  avatarUrl: string;
+  @ApiProperty({ description: 'userCode' })
+  userCode: string;
+  @ApiProperty({ description: '차단 일자' })
+  createdAt: string;
+  constructor(avatarUrl: string, userCode: string, createdAt: Date) {
+    this.avatarUrl = avatarUrl;
+    this.userCode = userCode;
+    this.createdAt = dateFormat(createdAt);
+  }
+
+  static from(userBlockedUser: UserBlockedUser) {
+    return new RejectedUser(
+      userBlockedUser.blockedUser.avatarUrl,
+      userBlockedUser.blockedUser.userCode,
+      userBlockedUser.createdAt,
+    );
+  }
+}

--- a/BE/src/users/dto/reject-user-list-response.dto.ts
+++ b/BE/src/users/dto/reject-user-list-response.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { UserDto } from './user.dto';
+import { UserBlockedUser } from '../domain/user-blocked-user.domain';
+
+export class RejectUserListResponse {
+  @ApiProperty({ description: '차단 유저 리스트', type: [UserDto] })
+  data: UserDto[];
+
+  constructor(userBlockedUsers: UserBlockedUser[]) {
+    this.data = userBlockedUsers.map((ub) => UserDto.from(ub.blockedUser));
+  }
+}

--- a/BE/src/users/dto/reject-user-list-response.dto.ts
+++ b/BE/src/users/dto/reject-user-list-response.dto.ts
@@ -1,12 +1,13 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { UserDto } from './user.dto';
 import { UserBlockedUser } from '../domain/user-blocked-user.domain';
+import { RejectedUser } from './reject-info.dto';
 
 export class RejectUserListResponse {
   @ApiProperty({ description: '차단 유저 리스트', type: [UserDto] })
-  data: UserDto[];
+  data: RejectedUser[];
 
   constructor(userBlockedUsers: UserBlockedUser[]) {
-    this.data = userBlockedUsers.map((ub) => UserDto.from(ub.blockedUser));
+    this.data = userBlockedUsers.map((ub) => RejectedUser.from(ub));
   }
 }

--- a/BE/src/users/entities/user-blocked-user.entity.ts
+++ b/BE/src/users/entities/user-blocked-user.entity.ts
@@ -24,6 +24,7 @@ export class UserBlockedUserEntity extends BaseTimeEntity {
     return new UserBlockedUser(
       this.user?.toModel() || null,
       this.blockedUser?.toModel() || null,
+      this.createdAt,
     );
   }
 

--- a/BE/src/users/entities/user-blocked-user.repository.spec.ts
+++ b/BE/src/users/entities/user-blocked-user.repository.spec.ts
@@ -77,4 +77,26 @@ describe('UserBlockedUserRepository Test', () => {
       expect(userBlockedUsers.length).toEqual(2);
     });
   });
+
+  test('차단 요청 userId, 차단 대상 userCode로 차단 정보를 조회할 수 있다.', async () => {
+    await transactionTest(dataSource, async () => {
+      // given
+      const user1 = await usersFixture.getUser('ABC');
+      const user2 = await usersFixture.getUser('DEF');
+      await userBlockedUserRepository.saveUserBlockedUser(
+        new UserBlockedUser(user1, user2),
+      );
+
+      // when
+      const userBlockedUser =
+        await userBlockedUserRepository.findByUserIdAndBlockedUserCode(
+          user1.id,
+          user2.userCode,
+        );
+
+      // then
+      expect(userBlockedUser.user.id).toEqual(user1.id);
+      expect(userBlockedUser.blockedUser.id).toEqual(user2.id);
+    });
+  });
 });

--- a/BE/src/users/entities/user-blocked-user.repository.spec.ts
+++ b/BE/src/users/entities/user-blocked-user.repository.spec.ts
@@ -55,4 +55,26 @@ describe('UserBlockedUserRepository Test', () => {
       expect(saved.blockedUser.id).toEqual(user2.id);
     });
   });
+
+  test('차단한 유저 목록을 조회한다.', async () => {
+    await transactionTest(dataSource, async () => {
+      // given
+      const user1 = await usersFixture.getUser('ABC');
+      const user2 = await usersFixture.getUser('DEF');
+      const user3 = await usersFixture.getUser('GHI');
+      await userBlockedUserRepository.saveUserBlockedUser(
+        new UserBlockedUser(user1, user2),
+      );
+      await userBlockedUserRepository.saveUserBlockedUser(
+        new UserBlockedUser(user1, user3),
+      );
+
+      // when
+      const userBlockedUsers =
+        await userBlockedUserRepository.findByUserIdWithBlockedUser(user1.id);
+
+      // then
+      expect(userBlockedUsers.length).toEqual(2);
+    });
+  });
 });

--- a/BE/src/users/entities/user-blocked-user.repository.ts
+++ b/BE/src/users/entities/user-blocked-user.repository.ts
@@ -21,4 +21,16 @@ export class UserBlockedUserRepository extends TransactionalRepository<UserBlock
       .getMany();
     return userBlockedUser.map((ub) => ub.toModel());
   }
+
+  async findByUserIdAndBlockedUserCode(userId: number, userCode: string) {
+    const userBlockedUserEntity = await this.repository
+      .createQueryBuilder('userBlockedUser')
+      .leftJoinAndSelect('userBlockedUser.user', 'user')
+      .leftJoinAndSelect('userBlockedUser.blockedUser', 'blockedUser')
+      .where('user.id = :userId', { userId })
+      .andWhere('blockedUser.userCode = :userCode', { userCode })
+      .getOne();
+
+    return userBlockedUserEntity?.toModel();
+  }
 }

--- a/BE/src/users/entities/user-blocked-user.repository.ts
+++ b/BE/src/users/entities/user-blocked-user.repository.ts
@@ -12,4 +12,13 @@ export class UserBlockedUserRepository extends TransactionalRepository<UserBlock
     const saved = await this.repository.save(userBlockedUserEntity);
     return saved.toModel();
   }
+
+  async findByUserIdWithBlockedUser(userId: number) {
+    const userBlockedUser = await this.repository
+      .createQueryBuilder('userBlockedUser')
+      .leftJoinAndSelect('userBlockedUser.blockedUser', 'blockedUser')
+      .where('userBlockedUser.userId = :userId', { userId })
+      .getMany();
+    return userBlockedUser.map((ub) => ub.toModel());
+  }
 }

--- a/BE/src/users/exception/invalid-allow-request.exception.ts
+++ b/BE/src/users/exception/invalid-allow-request.exception.ts
@@ -1,0 +1,8 @@
+import { ERROR_INFO } from '../../common/exception/error-code';
+import { MotimateException } from '../../common/exception/motimate.excpetion';
+
+export class InvalidAllowRequestException extends MotimateException {
+  constructor() {
+    super(ERROR_INFO.INVALID_ALLOW_REQUEST);
+  }
+}


### PR DESCRIPTION
## PR 요약
- 차단한 유저 목록을 조회할 수 있다.
- 차단 해제를 할 수 있다.
##### 스크린샷

- 차단 유저 목록 
![image](https://github.com/boostcampwm2023/iOS02-moti/assets/34297340/6d6d73e1-f48d-4877-a399-8565855f53ec)

- 차단 해제 성공 
![image](https://github.com/boostcampwm2023/iOS02-moti/assets/34297340/9db6fdc3-c25e-48b7-9bdb-d58370063571)

- 차단 해제 실패
![image](https://github.com/boostcampwm2023/iOS02-moti/assets/34297340/c00061ee-f63b-4188-ba9a-6a9d1b4bf2a1)

- 차단 해제 실패 
![image](https://github.com/boostcampwm2023/iOS02-moti/assets/34297340/702b42ba-b130-4a1b-aa19-53f2d15910d2)


#### Linked Issue
close #583
close #584 
