### PR TITLE
카테고리의 순서를 변경할 수 있다.

### DIFF
--- a/BE/src/category/application/category.service.spec.ts
+++ b/BE/src/category/application/category.service.spec.ts
@@ -56,19 +56,51 @@ describe('CategoryService', () => {
   });
 
   it('saveCategory는 카테고리를 생성할 수 있다.', async () => {
-    // given
-    const user = await usersFixture.getUser(1);
-    const categoryCreate = new CategoryCreate('카테고리1');
+    await transactionTest(dataSource, async () => {
+      // given
+      const user = await usersFixture.getUser(1);
+      const categoryCreate = new CategoryCreate('카테고리1');
 
-    // when
-    const savedCategory = await categoryService.saveCategory(
-      categoryCreate,
-      user,
-    );
+      // when
+      const savedCategory = await categoryService.saveCategory(
+        categoryCreate,
+        user,
+      );
 
-    // then
-    expect(savedCategory.name).toBe('카테고리1');
-    expect(savedCategory.user).toStrictEqual(user);
+      // then
+      expect(savedCategory.name).toBe('카테고리1');
+      expect(savedCategory.user).toStrictEqual(user);
+      expect(savedCategory.seq).toEqual(1);
+    });
+  });
+
+  it('saveCategory는 카테고리를 생성할 수 있다.', async () => {
+    await transactionTest(dataSource, async () => {
+      // given
+      const user = await usersFixture.getUser(1);
+      const categoryCreate = new CategoryCreate('카테고리1');
+
+      // when
+      const savedCategory1 = await categoryService.saveCategory(
+        categoryCreate,
+        user,
+      );
+
+      const savedCategory2 = await categoryService.saveCategory(
+        categoryCreate,
+        user,
+      );
+
+      const savedCategory3 = await categoryService.saveCategory(
+        categoryCreate,
+        user,
+      );
+
+      // then
+      expect(savedCategory1.seq).toEqual(1);
+      expect(savedCategory2.seq).toEqual(2);
+      expect(savedCategory3.seq).toEqual(3);
+    });
   });
 
   describe('getCategoriesByUsers는 카테고리를 조회할 수 있다', () => {

--- a/BE/src/category/application/category.service.ts
+++ b/BE/src/category/application/category.service.ts
@@ -9,14 +9,18 @@ import { NotFoundCategoryException } from '../exception/not-found-category.excep
 
 @Injectable()
 export class CategoryService {
-  constructor(private readonly categoryRepository: CategoryRepository) {}
+  constructor(
+    private readonly categoryRepository: CategoryRepository,
+    private readonly userRepository: UserRepository,
+  ) {}
 
   @Transactional()
   async saveCategory(
     categoryCreate: CategoryCreate,
     user: User,
   ): Promise<Category> {
-    const category = categoryCreate.toModel(user);
+    const category = user.newCategory(categoryCreate.name);
+    await this.userRepository.updateUser(user);
     return await this.categoryRepository.saveCategory(category);
   }
 

--- a/BE/src/category/category.module.ts
+++ b/BE/src/category/category.module.ts
@@ -4,14 +4,14 @@ import { CategoryService } from './application/category.service';
 import { CustomTypeOrmModule } from '../config/typeorm/custom-typeorm.module';
 import { CategoryRepository } from './entities/category.repository';
 import { CategoryLegacyController } from './controller/category-legacy.controller';
-import { AchievementRepository } from '../achievement/entities/achievement.repository';
+import { UserRepository } from '../users/entities/user.repository';
 
 @Module({
   controllers: [CategoryController, CategoryLegacyController],
   imports: [
     CustomTypeOrmModule.forCustomRepository([
       CategoryRepository,
-      AchievementRepository,
+      UserRepository,
     ]),
   ],
   providers: [CategoryService],

--- a/BE/src/category/controller/category.controller.ts
+++ b/BE/src/category/controller/category.controller.ts
@@ -6,6 +6,7 @@ import {
   HttpStatus,
   Param,
   Post,
+  Put,
   UseGuards,
 } from '@nestjs/common';
 import { CategoryService } from '../application/category.service';
@@ -24,6 +25,7 @@ import { AccessTokenGuard } from '../../auth/guard/access-token.guard';
 import { CategoryResponse } from '../dto/category.response';
 import { CategoryListElementResponse } from '../dto/category-list-element.response';
 import { ParseIntPipe } from '../../common/pipe/parse-int.pipe';
+import { CategoryRelocateRequest } from '../dto/category-relocate.request';
 
 @Controller('/api/v1/categories')
 @ApiTags('카테고리 API')
@@ -90,5 +92,21 @@ export class CategoryController {
   ): Promise<ApiData<CategoryListElementResponse>> {
     const category = await this.categoryService.getCategory(user, categoryId);
     return ApiData.success(new CategoryListElementResponse(category));
+  }
+
+  @ApiBearerAuth('accessToken')
+  @ApiOperation({
+    summary: '카테고리 순서 변경 API',
+    description:
+      '변경될 카테고리 순서로 카테고리 아이디를 배열의 형태로 요청한다.',
+  })
+  @Put()
+  @UseGuards(AccessTokenGuard)
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async relocateCategory(
+    @Body() categoryRelocateRequest: CategoryRelocateRequest,
+    @AuthenticatedUser() user: User,
+  ) {
+    return this.categoryService.relocateCategory(user, categoryRelocateRequest);
   }
 }

--- a/BE/src/category/domain/category.domain.ts
+++ b/BE/src/category/domain/category.domain.ts
@@ -4,9 +4,11 @@ export class Category {
   id: number;
   user: User;
   name: string;
+  seq: number;
 
-  constructor(user: User, name: string) {
+  constructor(user: User, name: string, seq: number) {
     this.user = user;
     this.name = name;
+    this.seq = seq;
   }
 }

--- a/BE/src/category/dto/category-create.ts
+++ b/BE/src/category/dto/category-create.ts
@@ -1,7 +1,5 @@
 import { IsNotEmptyString } from '../../config/config/validation-decorator';
 import { ApiProperty } from '@nestjs/swagger';
-import { Category } from '../domain/category.domain';
-import { User } from '../../users/domain/user.domain';
 
 export class CategoryCreate {
   @IsNotEmptyString({ message: '잘못된 카테고리 이름입니다.' })
@@ -10,9 +8,5 @@ export class CategoryCreate {
 
   constructor(name: string) {
     this.name = name;
-  }
-
-  toModel(user: User): Category {
-    return new Category(user, this.name);
   }
 }

--- a/BE/src/category/dto/category-relocate.request.ts
+++ b/BE/src/category/dto/category-relocate.request.ts
@@ -1,0 +1,16 @@
+import { IsArray } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CategoryRelocateRequest {
+  @IsArray({
+    message: '요청 형식이 잘 못 되었습니다.',
+  })
+  @ApiProperty({
+    description: '변경할 카테고리 아이디의 순서',
+  })
+  order: number[];
+
+  getCategoryCount() {
+    return this.order.length;
+  }
+}

--- a/BE/src/category/entities/category.entity.ts
+++ b/BE/src/category/entities/category.entity.ts
@@ -29,8 +29,11 @@ export class CategoryEntity extends BaseTimeEntity {
   @OneToMany(() => AchievementEntity, (achievement) => achievement.category)
   achievements: AchievementEntity[];
 
+  @Column()
+  seq: number;
+
   toModel(): Category {
-    const category = new Category(this.user?.toModel(), this.name);
+    const category = new Category(this.user?.toModel(), this.name, this.seq);
     category.id = this.id;
     return category;
   }
@@ -42,6 +45,7 @@ export class CategoryEntity extends BaseTimeEntity {
     categoryEntity.id = category.id;
     categoryEntity.user = UserEntity.from(category.user);
     categoryEntity.name = category.name;
+    categoryEntity.seq = category.seq;
     return categoryEntity;
   }
 }

--- a/BE/src/category/entities/category.repository.spec.ts
+++ b/BE/src/category/entities/category.repository.spec.ts
@@ -57,7 +57,7 @@ describe('CategoryRepository', () => {
     await transactionTest(dataSource, async () => {
       // given
       const user = await usersFixture.getUser('ABC');
-      const category = new Category(user, '카테고리1');
+      const category = new Category(user, '카테고리1', 0);
 
       // when
       const savedCategory = await categoryRepository.saveCategory(category);
@@ -72,7 +72,7 @@ describe('CategoryRepository', () => {
     await transactionTest(dataSource, async () => {
       // given
       const user = await usersFixture.getUser(1);
-      const category = new Category(user, '카테고리1');
+      const category = new Category(user, '카테고리1', 0);
       const savedCategory = await categoryRepository.saveCategory(category);
 
       // when

--- a/BE/src/category/entities/category.repository.ts
+++ b/BE/src/category/entities/category.repository.ts
@@ -46,7 +46,7 @@ export class CategoryRepository extends TransactionalRepository<CategoryEntity> 
       .addSelect('COUNT(achievement.id)', 'achievementCount')
       .leftJoin('category.achievements', 'achievement')
       .where('category.user_id = :user', { user: user.id })
-      .orderBy('category.id', 'ASC')
+      .orderBy('category.seq', 'ASC')
       .groupBy('category.id')
       .getRawMany<ICategoryMetaData>();
 
@@ -66,7 +66,7 @@ export class CategoryRepository extends TransactionalRepository<CategoryEntity> 
       .leftJoin('category.achievements', 'achievement')
       .where('category.user_id = :user', { user: user.id })
       .andWhere('category.id = :categoryId', { categoryId: categoryId })
-      .orderBy('category.id', 'ASC')
+      .orderBy('category.seq', 'ASC')
       .groupBy('category.id')
       .getRawOne<ICategoryMetaData>();
 

--- a/BE/src/category/entities/category.repository.ts
+++ b/BE/src/category/entities/category.repository.ts
@@ -6,7 +6,7 @@ import { User } from '../../users/domain/user.domain';
 import { ICategoryMetaData } from '../index';
 import { CategoryMetaData } from '../dto/category-metadata';
 import { AchievementEntity } from '../../achievement/entities/achievement.entity';
-import { Repository } from 'typeorm';
+import { In, Repository } from 'typeorm';
 
 @CustomRepository(CategoryEntity)
 export class CategoryRepository extends TransactionalRepository<CategoryEntity> {
@@ -113,5 +113,18 @@ export class CategoryRepository extends TransactionalRepository<CategoryEntity> 
       id: id,
     });
     return categoryEntity?.toModel();
+  }
+
+  async findAllByIdAndUser(userId: number, ids: number[]): Promise<Category[]> {
+    const categories = await this.repository
+      .createQueryBuilder('c')
+      .where('c.user_id = :userId')
+      .andWhere({ id: In(ids) })
+      .setParameter('userId', userId)
+      .orderBy(`FIELD(c.id, :...ids)`)
+      .setParameter('ids', ids)
+      .getMany();
+
+    return categories.map((c) => c.toModel());
   }
 }

--- a/BE/src/category/exception/Invalid-Category-Relocate.exception.ts
+++ b/BE/src/category/exception/Invalid-Category-Relocate.exception.ts
@@ -1,0 +1,8 @@
+import { MotimateException } from '../../common/exception/motimate.excpetion';
+import { ERROR_INFO } from '../../common/exception/error-code';
+
+export class InvalidCategoryRelocateException extends MotimateException {
+  constructor() {
+    super(ERROR_INFO.INVALID_CATEGORY_RELOCATE);
+  }
+}

--- a/BE/src/common/exception/error-code.ts
+++ b/BE/src/common/exception/error-code.ts
@@ -143,4 +143,8 @@ export const ERROR_INFO = {
     statusCode: 404,
     message: '카테고리를 찾을 수 없습니다.',
   },
+  INVALID_CATEGORY_RELOCATE: {
+    statusCode: 400,
+    message: '잘못된 카테고리 순서 변경 요청입니다.',
+  },
 } as const;

--- a/BE/src/group/emoji/entities/group-achievement-emoji.repository.spec.ts
+++ b/BE/src/group/emoji/entities/group-achievement-emoji.repository.spec.ts
@@ -646,7 +646,6 @@ describe('GroupAchievementEmojiRepository Test', () => {
           Emoji.FIRE,
         );
 
-        console.log(user);
         // when
         const groupAchievementEmojiListElement =
           await groupAchievementEmojiRepository.findAllGroupAchievementEmojiMetaData(

--- a/BE/src/users/domain/user.domain.ts
+++ b/BE/src/users/domain/user.domain.ts
@@ -1,4 +1,5 @@
 import { UserRole } from './user-role';
+import { Category } from '../../category/domain/category.domain';
 
 export class User {
   id: number;
@@ -10,6 +11,10 @@ export class User {
   userIdentifier: string;
 
   roles: UserRole[] = [UserRole.MEMBER];
+
+  categorySequence: number;
+
+  categoryCount: number;
 
   static from(userIdentifier: string) {
     const user = new User();
@@ -23,5 +28,14 @@ export class User {
 
   assignAvatar(avatarUrl: string) {
     this.avatarUrl = avatarUrl;
+  }
+
+  clearRelations() {
+    this.roles = undefined;
+  }
+
+  newCategory(categoryName: string): Category {
+    ++this.categoryCount;
+    return new Category(this, categoryName, ++this.categorySequence);
   }
 }

--- a/BE/src/users/entities/user.entity.ts
+++ b/BE/src/users/entities/user.entity.ts
@@ -20,6 +20,12 @@ export class UserEntity extends BaseTimeEntity {
   @Column({ type: 'varchar', length: 100, nullable: false })
   userIdentifier: string;
 
+  @Column({ default: 0 })
+  categorySequence: number;
+
+  @Column({ default: 0 })
+  categoryCount: number;
+
   @OneToMany(() => UsersRoleEntity, (userRole) => userRole.user, {
     cascade: ['insert'],
   })
@@ -42,6 +48,8 @@ export class UserEntity extends BaseTimeEntity {
     userEntity.userIdentifier = user.userIdentifier;
     userEntity.avatarUrl = user.avatarUrl;
     userEntity.userCode = user.userCode;
+    userEntity.categorySequence = user.categorySequence;
+    userEntity.categoryCount = user.categoryCount;
     userEntity.userRoles = user.roles?.map((role) => {
       return new UsersRoleEntity(userEntity, role);
     });
@@ -55,6 +63,8 @@ export class UserEntity extends BaseTimeEntity {
     user.userIdentifier = this.userIdentifier;
     user.userCode = this.userCode;
     user.id = this.id;
+    user.categorySequence = this.categorySequence;
+    user.categoryCount = this.categoryCount;
     user.roles = this.userRoles?.map((userRole) => userRole.role);
     return user;
   }

--- a/BE/src/users/entities/user.repository.ts
+++ b/BE/src/users/entities/user.repository.ts
@@ -27,6 +27,13 @@ export class UserRepository extends TransactionalRepository<UserEntity> {
     return saved.toModel();
   }
 
+  async updateUser(user: User): Promise<User> {
+    user.clearRelations();
+    const userEntity = UserEntity.from(user);
+    const saved = await this.repository.save(userEntity);
+    return saved.toModel();
+  }
+
   async existByUserCode(userCode: string) {
     return await this.repository.exist({ where: { userCode: userCode } });
   }

--- a/BE/test/category/category-fixture.ts
+++ b/BE/test/category/category-fixture.ts
@@ -10,10 +10,13 @@ export class CategoryFixture {
   constructor(private readonly categoryRepository: CategoryRepository) {}
 
   async getCategory(user: User, name?: string): Promise<Category> {
+    user.categoryCount++;
+    user.categorySequence++;
     const category = CategoryFixture.category(
       user,
       name || CategoryFixture.getDummyCategoryName(),
     );
+
     return await this.categoryRepository.saveCategory(category);
   }
 
@@ -31,7 +34,7 @@ export class CategoryFixture {
   }
 
   static category(user: User, name: string) {
-    return new Category(user, name);
+    return new Category(user, name, 0);
   }
 
   static getDummyCategoryName() {


### PR DESCRIPTION
## PR 요약
카테고리의 순서를 변경할 수 있다.

#### 변경 사항
* db 스키마가 변경됨에 따라 기존 레코드에 마이그레이션 작업이 필요한데
  이 쿼리는 코드에 올려놓지는 않고 그냥 따로 적용시킬 생각입니다.

```sql
update user u
set u.category_count = (
    select count(*)
    from category c
    where c.user_id = u.id
);

update user u
set u.category_sequence = (
    select count(*)
    from category c
    where c.user_id = u.id
);
```

##### 스크린샷
<img width="430" alt="image" src="https://github.com/boostcampwm2023/iOS02-moti/assets/75921696/4fd00cfc-d334-433c-8e33-adb78e981ca8">

#### Linked Issue
close #590
