### PR TITLE
운영정책 변경은 관리 계정만 가능하도록 제한한다.

### DIFF
--- a/BE/src/operate/controller/operate.controller.spec.ts
+++ b/BE/src/operate/controller/operate.controller.spec.ts
@@ -1,0 +1,386 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { AuthFixture } from '../../../test/auth/auth-fixture';
+import { anyOfClass, instance, mock, when } from 'ts-mockito';
+import { AppModule } from '../../app.module';
+import { AuthTestModule } from '../../../test/auth/auth-test.module';
+import { Test, TestingModule } from '@nestjs/testing';
+import { validationPipeOptions } from '../../config/validation';
+import { UnexpectedExceptionFilter } from '../../common/filter/unexpected-exception.filter';
+import { MotimateExceptionFilter } from '../../common/filter/exception.filter';
+import * as request from 'supertest';
+import { OperateService } from '../application/operate.service';
+import { MotiPolicyCreate } from '../dto/moti-policy-create';
+import { MotiPolicy } from '../domain/moti-policy.domain';
+import { PolicyAlreadyExistsException } from '../exception/policy-already-exists.exception';
+import { transactionTest } from '../../../test/common/transaction-test';
+import { DataSource } from 'typeorm';
+import { MotiPolicyIdempotentUpdate } from '../dto/moti-policy-idempotent-update';
+import { PolicyNotFoundException } from '../exception/policy-not-found.exception';
+import { MotiPolicyPartialUpdate } from '../dto/moti-policy-partitial-update';
+
+describe('UserController Test', () => {
+  let app: INestApplication;
+  let authFixture: AuthFixture;
+  let mockOperateService: OperateService;
+  let dataSource: DataSource;
+
+  beforeAll(async () => {
+    mockOperateService = mock<OperateService>(OperateService);
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule, AuthTestModule],
+      controllers: [],
+      providers: [],
+    })
+      .overrideProvider(OperateService)
+      .useValue(instance<OperateService>(mockOperateService))
+      .compile();
+
+    authFixture = moduleFixture.get<AuthFixture>(AuthFixture);
+    dataSource = moduleFixture.get<DataSource>(DataSource);
+    app = moduleFixture.createNestApplication();
+
+    app.useGlobalPipes(new ValidationPipe(validationPipeOptions));
+    app.useGlobalFilters(
+      new UnexpectedExceptionFilter(),
+      new MotimateExceptionFilter(),
+    );
+
+    await app.init();
+  });
+
+  describe('테스트 환경 확인', () => {
+    it('app가 정의되어 있어야 한다.', () => {
+      expect(app).toBeDefined();
+    });
+  });
+
+  describe('initPolicy는 운영정책을 초기화할 수 있다.', () => {
+    it('성공 시 200을 반환한다.', async () => {
+      await transactionTest(dataSource, async () => {
+        // given
+        const { accessToken } = await authFixture.getAuthenticatedAdmin('ABC');
+
+        const motiPolicy = new MotiPolicy(
+          '0.0.1',
+          '0.0.1',
+          'https://wwww.a.b.com/policy',
+        );
+
+        when(
+          mockOperateService.initMotiPolicy(anyOfClass(MotiPolicyCreate)),
+        ).thenResolve(motiPolicy);
+
+        // when
+        // then
+        return request(app.getHttpServer())
+          .post('/api/v1/operate/policy')
+          .set('Authorization', `Bearer ${accessToken}`)
+          .send({
+            latest: '0.0.1',
+            required: '0.0.1',
+            privacyPolicy: 'https://wwww.a.b.com/policy',
+          })
+          .expect(201)
+          .expect((res: request.Response) => {
+            expect(res.body.success).toEqual(true);
+            expect(res.body.data).toEqual({
+              latest: '0.0.1',
+              required: '0.0.1',
+              privacyPolicy: 'https://wwww.a.b.com/policy',
+            });
+          });
+      });
+    });
+
+    it('어드민 계정이 아니라면 초기화할 수 없다.', async () => {
+      await transactionTest(dataSource, async () => {
+        // given
+        const { accessToken } = await authFixture.getAuthenticatedUser('ABC');
+
+        // when
+        // then
+        return request(app.getHttpServer())
+          .post('/api/v1/operate/policy')
+          .set('Authorization', `Bearer ${accessToken}`)
+          .send({
+            latest: '0.0.1',
+            required: '0.0.1',
+            privacyPolicy: 'https://wwww.a.b.com/policy',
+          })
+          .expect(403)
+          .expect((res: request.Response) => {
+            expect(res.body.success).toEqual(false);
+            expect(res.body.message).toEqual('제한된 요청입니다.');
+          });
+      });
+    });
+
+    it('이미 초기화된 경우 500을 반환한다.', async () => {
+      await transactionTest(dataSource, async () => {
+        // given
+        const { accessToken } = await authFixture.getAuthenticatedAdmin('ABC');
+
+        when(
+          mockOperateService.initMotiPolicy(anyOfClass(MotiPolicyCreate)),
+        ).thenThrow(new PolicyAlreadyExistsException());
+
+        // when
+        // then
+        return request(app.getHttpServer())
+          .post('/api/v1/operate/policy')
+          .set('Authorization', `Bearer ${accessToken}`)
+          .send({
+            latest: '0.0.1',
+            required: '0.0.1',
+            privacyPolicy: 'https://wwww.a.b.com/policy',
+          })
+          .expect(500)
+          .expect((res: request.Response) => {
+            expect(res.body.success).toEqual(false);
+            expect(res.body.message).toEqual(
+              '이미 초기화된 모티메이트 운영정책입니다.',
+            );
+          });
+      });
+    });
+
+    it('잘못된 인증시 401을 반환한다.', async () => {
+      // given
+      const accessToken = 'abcd.abcd.efgh';
+
+      // when
+      // then
+      return request(app.getHttpServer())
+        .post('/api/v1/operate/policy')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({
+          latest: '0.0.1',
+          required: '0.0.1',
+          privacyPolicy: 'https://wwww.a.b.com/policy',
+        })
+        .expect(401)
+        .expect((res: request.Response) => {
+          expect(res.body.success).toBe(false);
+          expect(res.body.message).toBe('잘못된 토큰입니다.');
+        });
+    });
+
+    it('만료된 인증정보에 401을 반환한다.', async () => {
+      // given
+      const { accessToken } =
+        await authFixture.getExpiredAccessTokenUser('ABC');
+
+      // when
+      // then
+      return request(app.getHttpServer())
+        .post('/api/v1/operate/policy')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({
+          latest: '0.0.1',
+          required: '0.0.1',
+          privacyPolicy: 'https://wwww.a.b.com/policy',
+        })
+        .expect(401)
+        .expect((res: request.Response) => {
+          expect(res.body.success).toBe(false);
+          expect(res.body.message).toBe('만료된 토큰입니다.');
+        });
+    });
+  });
+
+  describe('운영정책을 업데이트할 수 있다.', () => {
+    it('성공 시 200을 반환한다.', async () => {
+      await transactionTest(dataSource, async () => {
+        // given
+        const { accessToken } = await authFixture.getAuthenticatedAdmin('ABC');
+
+        const motiPolicy = new MotiPolicy(
+          '0.0.1',
+          '0.0.1',
+          'https://wwww.a.b.com/policy',
+        );
+
+        when(
+          mockOperateService.updateMotiPolicy(
+            anyOfClass(MotiPolicyIdempotentUpdate),
+          ),
+        ).thenResolve(motiPolicy);
+
+        // when
+        // then
+        return request(app.getHttpServer())
+          .put('/api/v1/operate/policy')
+          .set('Authorization', `Bearer ${accessToken}`)
+          .send({
+            latest: '0.0.1',
+            required: '0.0.1',
+            privacyPolicy: 'https://wwww.a.b.com/policy',
+          })
+          .expect(200)
+          .expect((res: request.Response) => {
+            expect(res.body.success).toEqual(true);
+            expect(res.body.data).toEqual({
+              latest: '0.0.1',
+              required: '0.0.1',
+              privacyPolicy: 'https://wwww.a.b.com/policy',
+            });
+          });
+      });
+    });
+
+    it('성공 시 200을 반환한다.', async () => {
+      await transactionTest(dataSource, async () => {
+        // given
+        const { accessToken } = await authFixture.getAuthenticatedAdmin('ABC');
+
+        const motiPolicy = new MotiPolicy(
+          '0.0.2',
+          '0.0.1',
+          'https://wwww.a.b.com/policy',
+        );
+
+        when(
+          mockOperateService.updateMotiPolicy(
+            anyOfClass(MotiPolicyPartialUpdate),
+          ),
+        ).thenResolve(motiPolicy);
+
+        // when
+        // then
+        return request(app.getHttpServer())
+          .patch('/api/v1/operate/policy')
+          .set('Authorization', `Bearer ${accessToken}`)
+          .send({
+            latest: '0.0.2',
+          })
+          .expect(200)
+          .expect((res: request.Response) => {
+            expect(res.body.success).toEqual(true);
+            expect(res.body.data).toEqual({
+              latest: '0.0.2',
+              required: '0.0.1',
+              privacyPolicy: 'https://wwww.a.b.com/policy',
+            });
+          });
+      });
+    });
+
+    it('어드민 계정이 아니라면 초기화할 수 없다.', async () => {
+      await transactionTest(dataSource, async () => {
+        // given
+        const { accessToken } = await authFixture.getAuthenticatedUser('ABC');
+
+        // when
+        // then
+        return request(app.getHttpServer())
+          .put('/api/v1/operate/policy')
+          .set('Authorization', `Bearer ${accessToken}`)
+          .send({
+            latest: '0.0.1',
+            required: '0.0.1',
+            privacyPolicy: 'https://wwww.a.b.com/policy',
+          })
+          .expect(403)
+          .expect((res: request.Response) => {
+            expect(res.body.success).toEqual(false);
+            expect(res.body.message).toEqual('제한된 요청입니다.');
+          });
+      });
+    });
+
+    it('잘못된 인증시 401을 반환한다.', async () => {
+      // given
+      const accessToken = 'abcd.abcd.efgh';
+
+      // when
+      // then
+      return request(app.getHttpServer())
+        .put('/api/v1/operate/policy')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({
+          latest: '0.0.1',
+          required: '0.0.1',
+          privacyPolicy: 'https://wwww.a.b.com/policy',
+        })
+        .expect(401)
+        .expect((res: request.Response) => {
+          expect(res.body.success).toBe(false);
+          expect(res.body.message).toBe('잘못된 토큰입니다.');
+        });
+    });
+
+    it('만료된 인증정보에 401을 반환한다.', async () => {
+      // given
+      const { accessToken } =
+        await authFixture.getExpiredAccessTokenUser('ABC');
+
+      // when
+      // then
+      return request(app.getHttpServer())
+        .put('/api/v1/operate/policy')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({
+          latest: '0.0.1',
+          required: '0.0.1',
+          privacyPolicy: 'https://wwww.a.b.com/policy',
+        })
+        .expect(401)
+        .expect((res: request.Response) => {
+          expect(res.body.success).toBe(false);
+          expect(res.body.message).toBe('만료된 토큰입니다.');
+        });
+    });
+  });
+
+  describe('getPolicy는 운영정책을 조회할 수 있다.', () => {
+    it('성공 시 200을 반환한다.', async () => {
+      await transactionTest(dataSource, async () => {
+        // given
+        const motiPolicy = new MotiPolicy(
+          '0.0.1',
+          '0.0.1',
+          'https://wwww.a.b.com/policy',
+        );
+
+        when(mockOperateService.retrieveMotimateOperation()).thenResolve(
+          motiPolicy,
+        );
+
+        // when
+        // then
+        return request(app.getHttpServer())
+          .get('/api/v1/operate/policy')
+          .expect(200)
+          .expect((res: request.Response) => {
+            expect(res.body.success).toEqual(true);
+            expect(res.body.data).toEqual({
+              latest: '0.0.1',
+              required: '0.0.1',
+              privacyPolicy: 'https://wwww.a.b.com/policy',
+            });
+          });
+      });
+    });
+
+    it('운영정책이 초기화되지 않았다면 500을 반환한다.', async () => {
+      await transactionTest(dataSource, async () => {
+        // given
+
+        when(mockOperateService.retrieveMotimateOperation()).thenThrow(
+          new PolicyNotFoundException(),
+        );
+
+        // when
+        // then
+        return request(app.getHttpServer())
+          .get('/api/v1/operate/policy')
+          .expect(500)
+          .expect((res: request.Response) => {
+            expect(res.body.success).toEqual(false);
+            expect(res.body.message).toEqual('운영정책을 조회할 수 없습니다.');
+          });
+      });
+    });
+  });
+});

--- a/BE/src/operate/controller/operate.controller.ts
+++ b/BE/src/operate/controller/operate.controller.ts
@@ -1,18 +1,32 @@
-import { Body, Controller, Get, Patch, Post, Put } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Patch,
+  Post,
+  Put,
+  UseGuards,
+} from '@nestjs/common';
 import { OperateService } from '../application/operate.service';
 import { MotiPolicyResponse } from '../dto/moti-policy-response';
-import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
 import { MotiPolicyCreate } from '../dto/moti-policy-create';
 import { ApiData } from '../../common/api/api-data';
 import { MotiPolicyIdempotentUpdate } from '../dto/moti-policy-idempotent-update';
 import { MotiPolicyPartialUpdate } from '../dto/moti-policy-partitial-update';
+import { AdminTokenGuard } from '../../auth/guard/admin-token.guard';
 
 @Controller('/api/v1/operate')
 @ApiTags('운영 API')
 export class OperateController {
   constructor(private readonly operateService: OperateService) {}
 
-  @Post('policy')
+  @ApiBearerAuth('accessToken')
   @ApiOperation({
     summary: '모티메이트 운영정책 초기화 API',
     description: '운영 정책은 1개만 등록 가능',
@@ -21,6 +35,8 @@ export class OperateController {
     description: '운영 정책',
     type: MotiPolicyResponse,
   })
+  @Post('policy')
+  @UseGuards(AdminTokenGuard)
   async initPolicy(
     @Body() initPolicy: MotiPolicyCreate,
   ): Promise<ApiData<MotiPolicyResponse>> {
@@ -28,7 +44,6 @@ export class OperateController {
     return ApiData.success(MotiPolicyResponse.from(policy));
   }
 
-  @Get('policy')
   @ApiOperation({
     summary: '모티메이트 운영정책 조회 API',
     description: '모티메이트의 현재 버전, 최소 번전, 보안 정책을 조회',
@@ -37,12 +52,13 @@ export class OperateController {
     description: '운영 정책',
     type: MotiPolicyResponse,
   })
+  @Get('policy')
   async getPolicy(): Promise<ApiData<MotiPolicyResponse>> {
     const policy = await this.operateService.retrieveMotimateOperation();
     return ApiData.success(MotiPolicyResponse.from(policy));
   }
 
-  @Put('policy')
+  @ApiBearerAuth('accessToken')
   @ApiOperation({
     summary: '모티메이트 운영정책 업데이트 API',
     description: '모티메이트의 현재 버전, 최소 번전, 보안 정책을 업데이트',
@@ -51,6 +67,8 @@ export class OperateController {
     description: '운영 정책',
     type: MotiPolicyResponse,
   })
+  @Put('policy')
+  @UseGuards(AdminTokenGuard)
   async updateIdempotentPolicy(
     @Body() updatePolicyUpdate: MotiPolicyIdempotentUpdate,
   ): Promise<ApiData<MotiPolicyResponse>> {
@@ -59,7 +77,7 @@ export class OperateController {
     return ApiData.success(MotiPolicyResponse.from(policy));
   }
 
-  @Patch('policy')
+  @ApiBearerAuth('accessToken')
   @ApiOperation({
     summary: '모티메이트 운영정책 업데이트 API',
     description: '모티메이트의 현재 버전, 최소 번전, 보안 정책을 업데이트',
@@ -68,6 +86,8 @@ export class OperateController {
     description: '운영 정책',
     type: MotiPolicyResponse,
   })
+  @Patch('policy')
+  @UseGuards(AdminTokenGuard)
   async updatePartialPolicy(
     @Body() updatePolicyUpdate: MotiPolicyPartialUpdate,
   ): Promise<ApiData<MotiPolicyResponse>> {

--- a/BE/src/operate/operate.module.ts
+++ b/BE/src/operate/operate.module.ts
@@ -4,10 +4,18 @@ import { OperateService } from './application/operate.service';
 import { CustomTypeOrmModule } from '../config/typeorm/custom-typeorm.module';
 import { MotiPolicyRepository } from './entities/moti-policy.repository';
 import { OperateMvcController } from './controller/operate-mvc.controller';
+import { UserRepository } from '../users/entities/user.repository';
+import { AuthModule } from '../auth/auth.module';
 
 @Module({
   controllers: [OperateController, OperateMvcController],
   providers: [OperateService],
-  imports: [CustomTypeOrmModule.forCustomRepository([MotiPolicyRepository])],
+  imports: [
+    CustomTypeOrmModule.forCustomRepository([
+      MotiPolicyRepository,
+      UserRepository,
+    ]),
+    AuthModule,
+  ],
 })
 export class OperateModule {}

--- a/BE/test/admin/admin-fixture.ts
+++ b/BE/test/admin/admin-fixture.ts
@@ -23,6 +23,7 @@ export class AdminFixture {
   ): Promise<Admin> {
     const user = UsersFixture.user(id);
     user.roles.push(UserRole.ADMIN);
+    user.assignUserCode(`admin${id}${AdminFixture.id++}`);
     const adminRoleUser = await this.userRepository.saveUser(user);
 
     const admin = AdminFixture.admin(adminRoleUser, email, password);

--- a/BE/test/auth/auth-fixture.ts
+++ b/BE/test/auth/auth-fixture.ts
@@ -34,7 +34,6 @@ export class AuthFixture {
       userCode: user.userCode,
       roles: user.roles,
     };
-
     const accessToken = this.jwtUtils.createToken(claim, new Date());
     return {
       user,


### PR DESCRIPTION
## PR 요약
운영정책 변경은 관리 계정만 가능하도록 제한한다.

#### 변경 사항
- 운영정책 초기화 API에 어드민 토큰 가드
- 운영정책 수정 API에 어드민 토큰 가드

##### 스크린샷

<img width="429" alt="image" src="https://github.com/boostcampwm2023/iOS02-moti/assets/75921696/55bb63c3-616f-40a7-b890-ed41590a5224">

<img width="428" alt="image" src="https://github.com/boostcampwm2023/iOS02-moti/assets/75921696/65f11b47-c3d7-4d03-8381-6a1178af6f02">

#### Linked Issue
close #592
