### PR TITLE
카테고리 순서를 변경한다.

### DIFF
--- a/iOS/moti/moti/Data/Sources/Data/Network/Endpoint/MotiAPI.swift
+++ b/iOS/moti/moti/Data/Sources/Data/Network/Endpoint/MotiAPI.swift
@@ -20,6 +20,7 @@ enum MotiAPI: EndpointProtocol {
     case fetchCategory(categoryId: Int)
     case fetchCategoryList
     case addCategory(requestValue: AddCategoryRequestValue)
+    case reorderCategories(requestValue: ReorderCategoriesRequestValue)
     case fetchDetailAchievement(requestValue: FetchDetailAchievementRequestValue)
     case deleteAchievement(achievementId: Int)
     case updateAchievement(requestValue: UpdateAchievementRequestValue)
@@ -71,6 +72,7 @@ extension MotiAPI {
         case .fetchCategory(let categoryId): return "/categories/\(categoryId)"
         case .fetchCategoryList: return "/categories"
         case .addCategory: return "/categories"
+        case .reorderCategories: return "/categories"
         case .fetchDetailAchievement(let requestValue): return "/achievements/\(requestValue.id)"
         case .saveImage: return "/images"
         case .deleteAchievement(let achievementId): return "/achievements/\(achievementId)"
@@ -125,6 +127,7 @@ extension MotiAPI {
         case .fetchCategory: return .get
         case .fetchCategoryList: return .get
         case .addCategory: return .post
+        case .reorderCategories: return .put
         case .fetchDetailAchievement: return .get
         case .saveImage: return .post
         case .deleteAchievement: return .delete
@@ -172,6 +175,8 @@ extension MotiAPI {
         case .revoke(let requestValue):
             return requestValue
         case .addCategory(let requestValue):
+            return requestValue
+        case .reorderCategories(let requestValue):
             return requestValue
         case .updateAchievement(let requestValue):
             return requestValue.body

--- a/iOS/moti/moti/Data/Sources/Repository/CategoryRepository.swift
+++ b/iOS/moti/moti/Data/Sources/Repository/CategoryRepository.swift
@@ -38,4 +38,12 @@ public struct CategoryRepository: CategoryRepositoryProtocol {
         guard let categoryDTO = responseDTO.data else { throw NetworkError.decode }
         return CategoryItem(dto: categoryDTO)
     }
+    
+    public func reorderCategories(requestValue: ReorderCategoriesRequestValue) async throws -> Bool {
+        let endpoint = MotiAPI.reorderCategories(requestValue: requestValue)
+        let responseDTO = try await provider.request(with: endpoint, type: SimpleResponseDTO.self)
+        
+        guard let isSuccess = responseDTO.success else { throw NetworkError.decode }
+        return isSuccess
+    }
 }

--- a/iOS/moti/moti/Data/Sources/Repository/GroupCategoryRepository.swift
+++ b/iOS/moti/moti/Data/Sources/Repository/GroupCategoryRepository.swift
@@ -42,4 +42,12 @@ public struct GroupCategoryRepository: CategoryRepositoryProtocol {
         guard let categoryDTO = responseDTO.data else { throw NetworkError.decode }
         return CategoryItem(dto: categoryDTO)
     }
+    
+    public func reorderCategories(requestValue: ReorderCategoriesRequestValue) async throws -> Bool {
+        let endpoint = MotiAPI.reorderCategories(requestValue: requestValue)
+        let responseDTO = try await provider.request(with: endpoint, type: SimpleResponseDTO.self)
+        
+        guard let isSuccess = responseDTO.success else { throw NetworkError.decode }
+        return isSuccess
+    }
 }

--- a/iOS/moti/moti/Domain/Sources/Domain/RepositoryProtocol/CategoryRepositoryProtocol.swift
+++ b/iOS/moti/moti/Domain/Sources/Domain/RepositoryProtocol/CategoryRepositoryProtocol.swift
@@ -11,4 +11,5 @@ public protocol CategoryRepositoryProtocol {
     func fetchCategory(categoryId: Int) async throws -> CategoryItem
     func fetchCategoryList() async throws -> [CategoryItem]
     func addCategory(requestValue: AddCategoryRequestValue) async throws -> CategoryItem
+    func reorderCategories(requestValue: ReorderCategoriesRequestValue) async throws -> Bool
 }

--- a/iOS/moti/moti/Domain/Sources/Domain/UseCase/ReorderCategoriesUseCase.swift
+++ b/iOS/moti/moti/Domain/Sources/Domain/UseCase/ReorderCategoriesUseCase.swift
@@ -1,0 +1,28 @@
+//
+//  ReorderCategoriesUseCase.swift
+//  
+//
+//  Created by Kihyun Lee on 12/27/23.
+//
+
+import Foundation
+
+public struct ReorderCategoriesRequestValue: RequestValue {
+    public let order: [Int]
+    
+    public init(order: [Int]) {
+        self.order = order
+    }
+}
+
+public struct ReorderCategoriesUseCase {
+    private let repository: CategoryRepositoryProtocol
+    
+    public init(repository: CategoryRepositoryProtocol) {
+        self.repository = repository
+    }
+    
+    public func execute(requestValue: ReorderCategoriesRequestValue) async throws -> Bool {
+        return try await repository.reorderCategories(requestValue: requestValue)
+    }
+}

--- a/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/DetailAchievement/DetailAchievementViewController.swift
@@ -54,18 +54,18 @@ final class DetailAchievementViewController: BaseViewController<DetailAchievemen
     private func setupUI() {
         let removeButton = UIBarButtonItem(title: "삭제", style: .plain, target: self, action: #selector(removeButtonDidClicked))
         removeButton.tintColor = .red
-        let editButton = UIBarButtonItem(title: "편집", style: .plain, target: self, action: #selector(didClickedEditButton))
+        let editButton = UIBarButtonItem(title: "편집", style: .plain, target: self, action: #selector(editButtonDidClicked))
         navigationItem.rightBarButtonItems = [removeButton, editButton]
     }
     
-    @objc private func didClickedRemoveButton() {
+    @objc private func removeButtonDidClicked() {
         showDestructiveTwoButtonAlert(title: "정말로 삭제하시겠습니까?", message: "삭제된 도전 기록은 되돌릴 수 없습니다.") { [weak self] in
             guard let self else { return }
             viewModel.action(.delete)
         }
     }
     
-    @objc private func didClickedEditButton() {
+    @objc private func editButtonDidClicked() {
         delegate?.editButtonDidClicked(achievement: viewModel.achievement)
     }
     

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeActionState.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeActionState.swift
@@ -10,7 +10,7 @@ import Domain
 
 extension GroupHomeViewModel {
     enum GroupHomeViewModelAction {
-        case fetchCategories
+        case fetchCategoryList
         case fetchCurrentCategoryInfo
         case fetchCategoryInfo(categoryId: Int)
         case addCategory(name: String)

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeActionState.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeActionState.swift
@@ -10,7 +10,7 @@ import Domain
 
 extension GroupHomeViewModel {
     enum GroupHomeViewModelAction {
-        case launch
+        case fetchCategories
         case fetchCurrentCategoryInfo
         case fetchCategoryInfo(categoryId: Int)
         case addCategory(name: String)

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeCoordinator.swift
@@ -63,6 +63,7 @@ final class GroupHomeCoordinator: Coordinator {
     
     func moveToManageCategoryViewController(categories: [CategoryItem]) {
         let manageCategoryCoordinator = ManageCategoryCoordinator(navigationController, self)
+        manageCategoryCoordinator.delegate = self
         childCoordinators.append(manageCategoryCoordinator)
         manageCategoryCoordinator.start(categories: categories)
     }
@@ -120,3 +121,9 @@ extension GroupHomeCoordinator: GroupDetailAchievementCoordinatorDelegate {
 
 // MARK: - CaptureCoordinatorDelegate
 extension GroupHomeCoordinator: CaptureCoordinatorDelegate { }
+
+extension GroupHomeCoordinator: ManageCategoryCoordinatorDelegate {
+    func doneButtonDidClicked() {
+        currentViewController?.fetchCategoryList()
+    }
+}

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeViewController.swift
@@ -39,7 +39,7 @@ final class GroupHomeViewController: BaseViewController<HomeView>, LoadingIndica
         setupAchievementDataSource()
         setupCategoryDataSource()
         
-        viewModel.action(.launch)
+        viewModel.action(.fetchCategories)
     }
     
     override func viewWillAppear(_ animated: Bool) {

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeViewController.swift
@@ -39,7 +39,7 @@ final class GroupHomeViewController: BaseViewController<HomeView>, LoadingIndica
         setupAchievementDataSource()
         setupCategoryDataSource()
         
-        viewModel.action(.fetchCategories)
+        viewModel.action(.fetchCategoryList)
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -162,6 +162,10 @@ final class GroupHomeViewController: BaseViewController<HomeView>, LoadingIndica
     
     func blockedUser(_ userCode: String) {
         viewModel.action(.deleteUserDataSourceItem(userCode: userCode))
+    }
+    
+    func fetchCategoryList() {
+        viewModel.action(.fetchCategoryList)
     }
     
     private func showCelebrate(with achievement: Achievement) {

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeViewModel.swift
@@ -112,7 +112,7 @@ final class GroupHomeViewModel {
     
     func action(_ action: GroupHomeViewModelAction) {
         switch action {
-        case .launch:
+        case .fetchCategories:
             fetchCategories()
         case .fetchCurrentCategoryInfo:
             guard let currentCategory else { return }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeViewModel.swift
@@ -112,7 +112,7 @@ final class GroupHomeViewModel {
     
     func action(_ action: GroupHomeViewModelAction) {
         switch action {
-        case .fetchCategories:
+        case .fetchCategoryList:
             fetchCategories()
         case .fetchCurrentCategoryInfo:
             guard let currentCategory else { return }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeActionState.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeActionState.swift
@@ -10,7 +10,7 @@ import Domain
 
 extension HomeViewModel {
     enum HomeViewModelAction {
-        case launch
+        case fetchCategoryList
         case fetchCurrentCategoryInfo
         case fetchCategoryInfo(categoryId: Int)
         case addCategory(name: String)

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeCoordinator.swift
@@ -65,6 +65,7 @@ public final class HomeCoordinator: Coordinator {
     
     func moveToManageCategoryViewController(categories: [CategoryItem]) {
         let manageCategoryCoordinator = ManageCategoryCoordinator(navigationController, self)
+        manageCategoryCoordinator.delegate = self
         childCoordinators.append(manageCategoryCoordinator)
         manageCategoryCoordinator.start(categories: categories)
     }
@@ -107,3 +108,10 @@ extension HomeCoordinator: EditAchievementCoordinatorDelegate {
 
 // MARK: - CaptureCoordinatorDelegate
 extension HomeCoordinator: CaptureCoordinatorDelegate { }
+
+// MARK: - ManageCategoryCoordinatorDelegate
+extension HomeCoordinator: ManageCategoryCoordinatorDelegate {
+    func doneButtonDidClicked() {
+        currentViewController?.fetchCategoryList()
+    }
+}

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewController.swift
@@ -45,7 +45,7 @@ final class HomeViewController: BaseViewController<HomeView>, LoadingIndicator, 
         setupAchievementDataSource()
         setupCategoryDataSource()
         
-        viewModel.action(.launch)
+        viewModel.action(.fetchCategoryList)
     }
     
     override func viewWillAppear(_ animated: Bool) {

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewController.swift
@@ -76,6 +76,10 @@ final class HomeViewController: BaseViewController<HomeView>, LoadingIndicator, 
         showCelebrate(with: newAchievement)
     }
     
+    func fetchCategoryList() {
+        viewModel.action(.fetchCategoryList)
+    }
+    
     private func addTargets() {
         if let tabBarController = navigationController?.tabBarController as? TabBarViewController {
             tabBarController.captureButton.addTarget(self, action: #selector(captureButtonDidClicked), for: .touchUpInside)

--- a/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/Home/HomeViewModel.swift
@@ -92,7 +92,7 @@ final class HomeViewModel {
     
     func action(_ action: HomeViewModelAction) {
         switch action {
-        case .launch:
+        case .fetchCategoryList:
             fetchCategories()
         case .fetchCurrentCategoryInfo:
             guard let currentCategory else { return }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/ManageCategory/ManageCategoryCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/ManageCategory/ManageCategoryCoordinator.swift
@@ -10,10 +10,15 @@ import Core
 import Domain
 import Data
 
+protocol ManageCategoryCoordinatorDelegate: AnyObject {
+    func doneButtonDidClicked()
+}
+
 final class ManageCategoryCoordinator: Coordinator {
     var parentCoordinator: Coordinator?
     var childCoordinators: [Coordinator] = []
     var navigationController: UINavigationController
+    weak var delegate: ManageCategoryCoordinatorDelegate?
     
     init(
         _ navigationController: UINavigationController,
@@ -26,8 +31,10 @@ final class ManageCategoryCoordinator: Coordinator {
     func start() { }
     
     func start(categories: [CategoryItem]) {
+        let categoryRepository = CategoryRepository()
         let manageCategoryVM = ManageCategoryViewModel(
-            categories: categories
+            categories: categories,
+            reorderCategoriesUseCase: .init(repository: categoryRepository)
         )
         let manageCategoryVC = ManageCategoryViewController(viewModel: manageCategoryVM)
         manageCategoryVC.coordinator = self
@@ -43,6 +50,7 @@ extension ManageCategoryCoordinator: ManageCategoryViewControllerDelegate {
     }
     
     func doneButtonDidClicked() {
+        delegate?.doneButtonDidClicked()
         parentCoordinator?.dismiss(child: self, animated: true)
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/ManageCategory/ManageCategoryViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/ManageCategory/ManageCategoryViewController.swift
@@ -37,6 +37,7 @@ final class ManageCategoryViewController: BaseViewController<ManageCategoryView>
     override func viewDidLoad() {
         super.viewDidLoad()
         setupNavigationBar()
+        bind()
         setupManageCategoryCollectionView()
     }
     
@@ -60,8 +61,7 @@ final class ManageCategoryViewController: BaseViewController<ManageCategoryView>
     }
     
     @objc private func doneButtonDidClicked() {
-        // viewModel.action()
-        delegate?.doneButtonDidClicked()
+        viewModel.action(.reorderCategories)
     }
     
     private func setupManageCategoryCollectionView() {
@@ -91,6 +91,24 @@ final class ManageCategoryViewController: BaseViewController<ManageCategoryView>
         layoutView.manageCategoryCollectionView.dragDelegate = self
         layoutView.manageCategoryCollectionView.dropDelegate = self
         layoutView.manageCategoryCollectionView.dragInteractionEnabled = true
+    }
+}
+
+private extension ManageCategoryViewController {
+    func bind() {
+        viewModel.reorderCategoriesState
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] state in
+                guard let self else { return }
+                switch state {
+                case .success:
+                    delegate?.doneButtonDidClicked()
+                case .failed(let message):
+                    showErrorAlert(message: message)
+                }
+                
+            }
+            .store(in: &cancellables)
     }
 }
 

--- a/iOS/moti/moti/Presentation/Sources/Presentation/ManageCategory/ManageCategoryViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/ManageCategory/ManageCategoryViewController.swift
@@ -37,7 +37,7 @@ final class ManageCategoryViewController: BaseViewController<ManageCategoryView>
     override func viewDidLoad() {
         super.viewDidLoad()
         setupNavigationBar()
-        setupManageCategoryDataSource()
+        setupManageCategoryCollectionView()
     }
     
     private func setupNavigationBar() {
@@ -62,6 +62,11 @@ final class ManageCategoryViewController: BaseViewController<ManageCategoryView>
     @objc private func doneButtonDidClicked() {
         // viewModel.action()
         delegate?.doneButtonDidClicked()
+    }
+    
+    private func setupManageCategoryCollectionView() {
+        setupManageCategoryDataSource()
+        
     }
     
     private func setupManageCategoryDataSource() {

--- a/iOS/moti/moti/Presentation/Sources/Presentation/ManageCategory/ManageCategoryViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/ManageCategory/ManageCategoryViewController.swift
@@ -97,7 +97,7 @@ final class ManageCategoryViewController: BaseViewController<ManageCategoryView>
 private extension ManageCategoryViewController {
     func bind() {
         viewModel.reorderCategoriesState
-            .receive(on: DispatchQueue.main)
+            .receive(on: RunLoop.main)
             .sink { [weak self] state in
                 guard let self else { return }
                 switch state {

--- a/iOS/moti/moti/Presentation/Sources/Presentation/ManageCategory/ManageCategoryViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/ManageCategory/ManageCategoryViewController.swift
@@ -154,11 +154,8 @@ extension ManageCategoryViewController: UICollectionViewDropDelegate {
     }
     
     private func move(sourceIndexPath: IndexPath, destinationIndexPath: IndexPath) {
-        let sourceItem = viewModel.categories[sourceIndexPath.item]
-        
-        // dataSource 이동
-        viewModel.categories.remove(at: sourceIndexPath.item)
-        viewModel.categories.insert(sourceItem, at: destinationIndexPath.item)
+        let (sourceIndex, destinationIndex) = (sourceIndexPath.item, destinationIndexPath.item)
+        viewModel.swap(sourceIndex: sourceIndex, destinationIndex: destinationIndex)
     }
     
     func collectionView(

--- a/iOS/moti/moti/Presentation/Sources/Presentation/ManageCategory/ManageCategoryViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/ManageCategory/ManageCategoryViewController.swift
@@ -103,8 +103,8 @@ private extension ManageCategoryViewController {
                 switch state {
                 case .success:
                     delegate?.doneButtonDidClicked()
-                case .failed(let message):
-                    showErrorAlert(message: message)
+                case .failed(_):
+                    showErrorAlert(message: "카테고리 순서 변경에 실패했습니다.")
                 }
                 
             }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/ManageCategory/ManageCategoryViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/ManageCategory/ManageCategoryViewModel.swift
@@ -47,6 +47,11 @@ final class ManageCategoryViewModel {
         categoryDataSource?.update(data: categories)
     }
     
+    func swap(sourceIndex: Int, destinationIndex: Int) {
+        // dataSource 이동
+        categories.swapAt(sourceIndex, destinationIndex)
+    }
+    
     func action(_ action: ManageCategoryViewModelAction) {
         switch action {
         case .reorderCategories:

--- a/iOS/moti/moti/Presentation/Sources/Presentation/ManageCategory/ManageCategoryViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/ManageCategory/ManageCategoryViewModel.swift
@@ -12,7 +12,12 @@ import Combine
 
 final class ManageCategoryViewModel {
     enum ManageCategoryViewModelAction {
-        
+        case reorderCategories
+    }
+    
+    enum ReorderCategoriesState {
+        case success
+        case failed(message: String)
     }
     
     typealias CategoryDataSource = ListDiffableDataSource<CategoryItem>
@@ -25,14 +30,47 @@ final class ManageCategoryViewModel {
         }
     }
     
+    private let reorderCategoriesUseCase: ReorderCategoriesUseCase
+    
+    private(set) var reorderCategoriesState = PassthroughSubject<ReorderCategoriesState, Never>()
+    
     init(
-        categories: [CategoryItem]
+        categories: [CategoryItem],
+        reorderCategoriesUseCase: ReorderCategoriesUseCase
     ) {
         self.categories = categories.filter { !$0.isWhole && !$0.isUnset }
+        self.reorderCategoriesUseCase = reorderCategoriesUseCase
     }
     
     func setupDataSource(_ dataSource: CategoryDataSource) {
         self.categoryDataSource = dataSource
         categoryDataSource?.update(data: categories)
+    }
+    
+    func action(_ action: ManageCategoryViewModelAction) {
+        switch action {
+        case .reorderCategories:
+            reorderCategories()
+        }
+    }
+    
+    private func reorderCategories() {
+        Task {
+            do {
+                let requestValue = ReorderCategoriesRequestValue(order: categories.map { $0.id })
+                let isSuccess = try await reorderCategoriesUseCase.execute(requestValue: requestValue)
+                if isSuccess {
+                    reorderCategoriesState.send(.success)
+                } else {
+                    reorderCategoriesState.send(.failed(message: "카테고리 순서 변경에 실패했습니다."))
+                }
+            } catch {
+                Logger.debug("reorder categories error: \(error)")
+                
+                // response가 비어있어서 204가 오는데, catch 문으로 넘어온다. 응답을 넣어주시면 없앤다.
+                reorderCategoriesState.send(.success)
+//                reorderCategoriesState.send(.failed(message: error.localizedDescription))
+            }
+        }
     }
 }


### PR DESCRIPTION
## PR 요약
- 카테고리 순서 변경
- drag & drop 으로 컬렉션 뷰 순서 변경
- 완료 버튼 클릭 시 API 호출

#### 주의 사항
- 그룹은 API가 아직 미배포

##### 스크린샷
<img width="33%" src="https://github.com/boostcampwm2023/iOS02-moti/assets/60506170/3c778253-9341-445f-bd20-53fdc04af8e9">

#### Linked Issue
close #596 
