### PR TITLE
카테고리를 삭제할 수 있다.

### DIFF
--- a/BE/src/category/application/category.service.spec.ts
+++ b/BE/src/category/application/category.service.spec.ts
@@ -18,6 +18,9 @@ import { transactionTest } from '../../../test/common/transaction-test';
 import { NotFoundCategoryException } from '../exception/not-found-category.exception';
 import { CategoryRelocateRequest } from '../dto/category-relocate.request';
 import { InvalidCategoryRelocateException } from '../exception/Invalid-Category-Relocate.exception';
+import { CategoryMetaData } from '../dto/category-metadata';
+import { CategoryNotFoundException } from '../exception/category-not-found.exception';
+import { UserRepository } from '../../users/entities/user.repository';
 
 describe('CategoryService', () => {
   let categoryService: CategoryService;
@@ -25,6 +28,7 @@ describe('CategoryService', () => {
   let usersFixture: UsersFixture;
   let categoryFixture: CategoryFixture;
   let achievementFixture: AchievementFixture;
+  let userRepository: UserRepository;
 
   beforeAll(async () => {
     const app: TestingModule = await Test.createTestingModule({
@@ -40,6 +44,7 @@ describe('CategoryService', () => {
       providers: [],
     }).compile();
 
+    userRepository = app.get<UserRepository>(UserRepository);
     categoryFixture = app.get<CategoryFixture>(CategoryFixture);
     achievementFixture = app.get<AchievementFixture>(AchievementFixture);
     usersFixture = app.get<UsersFixture>(UsersFixture);
@@ -107,52 +112,56 @@ describe('CategoryService', () => {
 
   describe('getCategoriesByUsers는 카테고리를 조회할 수 있다', () => {
     it('user에 대한 카테고리가 없을 때 빈 배열을 반환한다.', async () => {
-      // given
-      const user = await usersFixture.getUser(1);
+      await transactionTest(dataSource, async () => {
+        // given
+        const user = await usersFixture.getUser(1);
 
-      // when
-      const retrievedCategories =
-        await categoryService.getCategoriesByUser(user);
+        // when
+        const retrievedCategories =
+          await categoryService.getCategoriesByUser(user);
 
-      // then
-      expect(retrievedCategories).toBeDefined();
-      expect(retrievedCategories.length).toBe(1);
-      expect(retrievedCategories[0].categoryId).toEqual(-1);
+        // then
+        expect(retrievedCategories).toBeDefined();
+        expect(retrievedCategories.length).toBe(1);
+        expect(retrievedCategories[0].categoryId).toEqual(-1);
+      });
     });
 
     it('user에 대한 카테고리가 있을 때 카테고리를 반환한다.', async () => {
-      // given
-      const user = await usersFixture.getUser(1);
-      const categories: Category[] = await categoryFixture.getCategories(
-        4,
-        user,
-      );
-      await achievementFixture.getAchievements(4, user, categories[0]);
-      await achievementFixture.getAchievements(5, user, categories[1]);
-      await achievementFixture.getAchievements(7, user, categories[2]);
-      await achievementFixture.getAchievements(10, user, categories[3]);
+      await transactionTest(dataSource, async () => {
+        // given
+        const user = await usersFixture.getUser(1);
+        const categories: Category[] = await categoryFixture.getCategories(
+          4,
+          user,
+        );
+        await achievementFixture.getAchievements(4, user, categories[0]);
+        await achievementFixture.getAchievements(5, user, categories[1]);
+        await achievementFixture.getAchievements(7, user, categories[2]);
+        await achievementFixture.getAchievements(10, user, categories[3]);
 
-      // when
-      const retrievedCategories =
-        await categoryService.getCategoriesByUser(user);
+        // when
+        const retrievedCategories =
+          await categoryService.getCategoriesByUser(user);
 
-      // then
-      expect(retrievedCategories.length).toBe(5);
-      expect(retrievedCategories[0].categoryId).toEqual(-1);
-      expect(retrievedCategories[0].insertedAt).toBeNull();
-      expect(retrievedCategories[0].achievementCount).toBe(0);
-      expect(retrievedCategories[1].categoryId).toEqual(categories[0].id);
-      expect(retrievedCategories[1].insertedAt).toBeInstanceOf(Date);
-      expect(retrievedCategories[1].achievementCount).toBe(4);
-      expect(retrievedCategories[2].categoryId).toEqual(categories[1].id);
-      expect(retrievedCategories[2].insertedAt).toBeInstanceOf(Date);
-      expect(retrievedCategories[2].achievementCount).toBe(5);
-      expect(retrievedCategories[3].categoryId).toEqual(categories[2].id);
-      expect(retrievedCategories[3].insertedAt).toBeInstanceOf(Date);
-      expect(retrievedCategories[3].achievementCount).toBe(7);
-      expect(retrievedCategories[4].categoryId).toEqual(categories[3].id);
-      expect(retrievedCategories[4].insertedAt).toBeInstanceOf(Date);
-      expect(retrievedCategories[4].achievementCount).toBe(10);
+        // then
+        expect(retrievedCategories.length).toBe(5);
+        expect(retrievedCategories[0].categoryId).toEqual(-1);
+        expect(retrievedCategories[0].insertedAt).toBeNull();
+        expect(retrievedCategories[0].achievementCount).toBe(0);
+        expect(retrievedCategories[1].categoryId).toEqual(categories[0].id);
+        expect(retrievedCategories[1].insertedAt).toBeInstanceOf(Date);
+        expect(retrievedCategories[1].achievementCount).toBe(4);
+        expect(retrievedCategories[2].categoryId).toEqual(categories[1].id);
+        expect(retrievedCategories[2].insertedAt).toBeInstanceOf(Date);
+        expect(retrievedCategories[2].achievementCount).toBe(5);
+        expect(retrievedCategories[3].categoryId).toEqual(categories[2].id);
+        expect(retrievedCategories[3].insertedAt).toBeInstanceOf(Date);
+        expect(retrievedCategories[3].achievementCount).toBe(7);
+        expect(retrievedCategories[4].categoryId).toEqual(categories[3].id);
+        expect(retrievedCategories[4].insertedAt).toBeInstanceOf(Date);
+        expect(retrievedCategories[4].achievementCount).toBe(10);
+      });
     });
   });
 
@@ -370,6 +379,86 @@ describe('CategoryService', () => {
         await expect(
           categoryService.relocateCategory(user, categoryRelocateRequest),
         ).rejects.toThrow(InvalidCategoryRelocateException);
+      });
+    });
+  });
+
+  describe('deleteCategory는 카테고리를 삭제할 수 있다.', () => {
+    it('본인의 카테고리를 삭제할 수 있다.', async () => {
+      await transactionTest(dataSource, async () => {
+        // given
+        const user = await usersFixture.getUser('ABCD');
+        const category = await categoryFixture.getCategory(user, '카테고리1');
+
+        // when
+        await categoryService.deleteCategory(user, category.id);
+        const categoryMetaData: CategoryMetaData[] =
+          await categoryService.getCategoriesByUser(user);
+
+        // then
+        expect(categoryMetaData.length).toBe(1);
+        expect(categoryMetaData[0].categoryId).toBe(-1);
+      });
+    });
+
+    it('본인의 카테고리가 아닌 카테고리는 삭제할 수 없다.', async () => {
+      await transactionTest(dataSource, async () => {
+        // given
+        const otherUser = await usersFixture.getUser('ABC');
+        const category = await categoryFixture.getCategory(
+          otherUser,
+          '카테고리1',
+        );
+
+        const user = await usersFixture.getUser('ABCD');
+
+        // when
+        await expect(
+          categoryService.deleteCategory(user, category.id),
+        ).rejects.toThrow(new CategoryNotFoundException());
+      });
+    });
+
+    it('카테고리를 삭제해도 기존 순서가 유지된다.', async () => {
+      await transactionTest(dataSource, async () => {
+        // given
+        const user = await usersFixture.getUser('ABCD');
+        const category1 = await categoryFixture.getCategory(user, '카테고리1');
+        const category2 = await categoryFixture.getCategory(user, '카테고리2');
+        const category3 = await categoryFixture.getCategory(user, '카테고리3');
+
+        // when
+        await categoryService.deleteCategory(user, category2.id);
+        const categoryMetaData: CategoryMetaData[] =
+          await categoryService.getCategoriesByUser(user);
+
+        // then
+        expect(categoryMetaData.length).toBe(3);
+        expect(categoryMetaData[0].categoryId).toBe(-1);
+        expect(categoryMetaData[1].categoryId).toBe(category1.id);
+        expect(categoryMetaData[2].categoryId).toBe(category3.id);
+      });
+    });
+
+    it('카테고리를 삭제하면 유저의 카테고리 카운트가 반영된다.', async () => {
+      await transactionTest(dataSource, async () => {
+        // given
+        const user = await usersFixture.getUser('ABCD');
+        await categoryFixture.getCategory(user, '카테고리1');
+        const category2 = await categoryFixture.getCategory(user, '카테고리2');
+        await categoryFixture.getCategory(user, '카테고리3');
+
+        // when
+        await categoryService.deleteCategory(user, category2.id);
+        const userEntity = await userRepository.repository.findOne({
+          where: {
+            id: user.id,
+          },
+        });
+
+        // then
+        expect(userEntity.categoryCount).toBe(2);
+        expect(userEntity.categorySequence).toBe(3);
       });
     });
   });

--- a/BE/src/category/application/category.service.ts
+++ b/BE/src/category/application/category.service.ts
@@ -9,6 +9,7 @@ import { NotFoundCategoryException } from '../exception/not-found-category.excep
 import { CategoryRelocateRequest } from '../dto/category-relocate.request';
 import { UserRepository } from '../../users/entities/user.repository';
 import { InvalidCategoryRelocateException } from '../exception/Invalid-Category-Relocate.exception';
+import { CategoryNotFoundException } from '../exception/category-not-found.exception';
 
 @Injectable()
 export class CategoryService {
@@ -60,5 +61,17 @@ export class CategoryService {
       category.seq = index + 1;
       await this.categoryRepository.saveCategory(category);
     }
+  }
+
+  @Transactional()
+  async deleteCategory(user: User, categoryId: number){
+    const category = await this.categoryRepository.findByIdAndUser(
+      user.id,
+      categoryId,
+    );
+    if (!category) throw new CategoryNotFoundException();
+    user.deleteCategory();
+    await this.userRepository.updateUser(user);
+    await this.categoryRepository.deleteCategory(category);
   }
 }

--- a/BE/src/category/application/category.service.ts
+++ b/BE/src/category/application/category.service.ts
@@ -64,7 +64,7 @@ export class CategoryService {
   }
 
   @Transactional()
-  async deleteCategory(user: User, categoryId: number){
+  async deleteCategory(user: User, categoryId: number) {
     const category = await this.categoryRepository.findByIdAndUser(
       user.id,
       categoryId,

--- a/BE/src/category/controller/category.controller.ts
+++ b/BE/src/category/controller/category.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
   HttpCode,
   HttpStatus,
@@ -108,5 +109,21 @@ export class CategoryController {
     @AuthenticatedUser() user: User,
   ) {
     return this.categoryService.relocateCategory(user, categoryRelocateRequest);
+  }
+
+  @ApiBearerAuth('accessToken')
+  @ApiOperation({
+    summary: '카테고리 순서 변경 API',
+    description:
+      '변경될 카테고리 순서로 카테고리 아이디를 배열의 형태로 요청한다.',
+  })
+  @Delete('/:categoryId')
+  @UseGuards(AccessTokenGuard)
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async deleteCategory(
+    @Param('categoryId', ParseIntPipe) categoryId: number,
+    @AuthenticatedUser() user: User,
+  ) {
+    return this.categoryService.deleteCategory(user, categoryId);
   }
 }

--- a/BE/src/category/entities/category.repository.ts
+++ b/BE/src/category/entities/category.repository.ts
@@ -46,6 +46,7 @@ export class CategoryRepository extends TransactionalRepository<CategoryEntity> 
       .addSelect('COUNT(achievement.id)', 'achievementCount')
       .leftJoin('category.achievements', 'achievement')
       .where('category.user_id = :user', { user: user.id })
+      .andWhere('category.deletedAt is NULL')
       .orderBy('category.seq', 'ASC')
       .groupBy('category.id')
       .getRawMany<ICategoryMetaData>();
@@ -126,5 +127,9 @@ export class CategoryRepository extends TransactionalRepository<CategoryEntity> 
       .getMany();
 
     return categories.map((c) => c.toModel());
+  }
+
+  async deleteCategory(category: Category) {
+    await this.repository.softDelete(category.id);
   }
 }

--- a/BE/src/category/exception/category-not-found.exception.ts
+++ b/BE/src/category/exception/category-not-found.exception.ts
@@ -1,0 +1,8 @@
+import { MotimateException } from '../../common/exception/motimate.excpetion';
+import { ERROR_INFO } from '../../common/exception/error-code';
+
+export class CategoryNotFoundException extends MotimateException {
+  constructor() {
+    super(ERROR_INFO.CATEGORY_NOT_FOUND);
+  }
+}

--- a/BE/src/common/exception/error-code.ts
+++ b/BE/src/common/exception/error-code.ts
@@ -147,4 +147,8 @@ export const ERROR_INFO = {
     statusCode: 400,
     message: '잘못된 카테고리 순서 변경 요청입니다.',
   },
+  CATEGORY_NOT_FOUND: {
+    statusCode: 404,
+    message: '카테고리를 찾을 수 없습니다.',
+  },
 } as const;

--- a/BE/src/users/domain/user.domain.ts
+++ b/BE/src/users/domain/user.domain.ts
@@ -38,4 +38,8 @@ export class User {
     ++this.categoryCount;
     return new Category(this, categoryName, ++this.categorySequence);
   }
+
+  deleteCategory() {
+    this.categoryCount--;
+  }
 }

--- a/BE/test/category/category-fixture.ts
+++ b/BE/test/category/category-fixture.ts
@@ -2,12 +2,16 @@ import { User } from '../../src/users/domain/user.domain';
 import { Injectable } from '@nestjs/common';
 import { Category } from '../../src/category/domain/category.domain';
 import { CategoryRepository } from '../../src/category/entities/category.repository';
+import { UserRepository } from '../../src/users/entities/user.repository';
 
 @Injectable()
 export class CategoryFixture {
   private static id = 0;
 
-  constructor(private readonly categoryRepository: CategoryRepository) {}
+  constructor(
+    private readonly categoryRepository: CategoryRepository,
+    private readonly userRepository: UserRepository,
+  ) {}
 
   async getCategory(user: User, name?: string): Promise<Category> {
     user.categoryCount++;
@@ -16,7 +20,8 @@ export class CategoryFixture {
       user,
       name || CategoryFixture.getDummyCategoryName(),
     );
-
+    await this.userRepository.updateUser(user);
+    category.seq = user.categorySequence;
     return await this.categoryRepository.saveCategory(category);
   }
 

--- a/BE/test/category/category-test.module.ts
+++ b/BE/test/category/category-test.module.ts
@@ -3,10 +3,14 @@ import { Module } from '@nestjs/common';
 import { CategoryRepository } from '../../src/category/entities/category.repository';
 import { CategoryModule } from '../../src/category/category.module';
 import { CategoryFixture } from './category-fixture';
+import { UserRepository } from '../../src/users/entities/user.repository';
 
 @Module({
   imports: [
-    CustomTypeOrmModule.forCustomRepository([CategoryRepository]),
+    CustomTypeOrmModule.forCustomRepository([
+      CategoryRepository,
+      UserRepository,
+    ]),
     CategoryModule,
   ],
   providers: [CategoryFixture],


### PR DESCRIPTION
## PR 요약
카테고리를 삭제할 수 있다.

#### 변경 사항
- 카테고리 삭제 API
- 카테고리 삭제를 위한 테스트 코드
- 카테고리 fixture 데이터에도 적절한 seq값 처리
- 카테고리가 삭제되더라도 카테고리 순서 변경 로직에 문제가 없도록 처리

##### 스크린샷

<img width="428" alt="image" src="https://github.com/boostcampwm2023/iOS02-moti/assets/75921696/807c00a7-0339-4800-8cb1-dc4f59075300">

#### Linked Issue
close #594
