### PR TITLE
유저 차단 해제 버그 픽스

### DIFF
--- a/BE/src/users/application/users.service.ts
+++ b/BE/src/users/application/users.service.ts
@@ -51,7 +51,10 @@ export class UsersService {
         userCode,
       );
     if (!userBlockedUser) throw new InvalidAllowRequestException();
-    await this.userBlockedUserRepository.repository.delete(userBlockedUser);
+    await this.userBlockedUserRepository.deleteByUserIdAndBlockedUserId(
+      user.id,
+      blockedUser.id,
+    );
     return AllowUserResponse.from(userBlockedUser);
   }
 

--- a/BE/src/users/entities/user-blocked-user.repository.spec.ts
+++ b/BE/src/users/entities/user-blocked-user.repository.spec.ts
@@ -99,4 +99,28 @@ describe('UserBlockedUserRepository Test', () => {
       expect(userBlockedUser.blockedUser.id).toEqual(user2.id);
     });
   });
+
+  test('유저차단을 해제한다.', async () => {
+    // await transactionTest(dataSource, async () => {
+    // given
+    const user1 = await usersFixture.getUser('ABC');
+    const user2 = await usersFixture.getUser('DEF');
+    await userBlockedUserRepository.saveUserBlockedUser(
+      new UserBlockedUser(user1, user2),
+    );
+
+    // when
+    await userBlockedUserRepository.deleteByUserIdAndBlockedUserId(
+      user1.id,
+      user2.id,
+    );
+
+    // then
+    const expected =
+      await userBlockedUserRepository.findByUserIdAndBlockedUserCode(
+        user1.id,
+        user2.userCode,
+      );
+    expect(expected).toBeUndefined();
+  });
 });

--- a/BE/src/users/entities/user-blocked-user.repository.ts
+++ b/BE/src/users/entities/user-blocked-user.repository.ts
@@ -33,4 +33,15 @@ export class UserBlockedUserRepository extends TransactionalRepository<UserBlock
 
     return userBlockedUserEntity?.toModel();
   }
+
+  async deleteByUserIdAndBlockedUserId(userId: number, blockedUserId: number) {
+    await this.repository
+      .createQueryBuilder()
+      .delete()
+      .where('userId = :userId AND blockedUserId = :blockedUserId', {
+        userId: userId,
+        blockedUserId: blockedUserId,
+      })
+      .execute();
+  }
 }


### PR DESCRIPTION
## PR 요약
- 유저 차단 해제 버그 픽스 

#### 변경 사항
- typeorm이 제공하는 delete 함수 사용시 createdAt javascript Date 형태값이 쿼리문에 포함되어 쿼리가 나가서 특정 row를 식별하지 못하여 삭제가 안되는 이슈를 발견
- 그에 따라 복합 pk 만을 쿼리문의 조건으로 사용하는 delete 함수 추가

#### Linked Issue
close #612 
