### PR TITLE
차단했던 그룹원을 차단 해제한다.

### DIFF
--- a/iOS/moti/moti/Data/Sources/Data/Network/Endpoint/MotiAPI.swift
+++ b/iOS/moti/moti/Data/Sources/Data/Network/Endpoint/MotiAPI.swift
@@ -45,6 +45,7 @@ enum MotiAPI: EndpointProtocol {
     case blockingUser(userCode: String)
     case blockingAchievement(achievementId: Int, groupId: Int)
     case fetchBlockedUserList
+    case unblockUser(userCode: String)
     // 이모지
     case fetchEmojis(achievementId: Int, groupId: Int)
     case toggleEmoji(achievementId: Int, groupId: Int, emojiId: String)
@@ -117,6 +118,8 @@ extension MotiAPI {
             return "/groups/participation"
         case .fetchBlockedUserList:
             return "/users/reject"
+        case .unblockUser(let userCode):
+            return "/users/\(userCode)/reject"
         }
     }
     
@@ -156,6 +159,7 @@ extension MotiAPI {
         case .dropGroup: return .delete
         case .joinGroup: return .post
         case .fetchBlockedUserList: return .get
+        case .unblockUser: return .delete
         }
     }
     

--- a/iOS/moti/moti/Data/Sources/Repository/BlockingRepository.swift
+++ b/iOS/moti/moti/Data/Sources/Repository/BlockingRepository.swift
@@ -36,4 +36,10 @@ public struct BlockingRepository: BlockingRepositoryProtocol {
         guard let blockedUserListDTO = responseDTO.data?.data else { throw NetworkError.decode }
         return blockedUserListDTO.map { User(dto: $0) }
     }
+    
+    public func unblockUser(userCode: String) async throws -> Bool {
+        let endpoint = MotiAPI.unblockUser(userCode: userCode)
+        let responseDTO = try await provider.request(with: endpoint, type: BlockingDTO.self)
+        return responseDTO.success ?? false
+    }
 }

--- a/iOS/moti/moti/Domain/Sources/Domain/RepositoryProtocol/BlockingRepositoryProtocol.swift
+++ b/iOS/moti/moti/Domain/Sources/Domain/RepositoryProtocol/BlockingRepositoryProtocol.swift
@@ -11,4 +11,5 @@ public protocol BlockingRepositoryProtocol {
     func blockingUser(userCode: String) async throws -> Bool
     func blockingAchievement(achievementId: Int) async throws -> Bool
     func fetchBlockedUserList() async throws -> [User]
+    func unblockUser(userCode: String) async throws -> Bool
 }

--- a/iOS/moti/moti/Domain/Sources/Domain/UseCase/UnblockUserUseCase.swift
+++ b/iOS/moti/moti/Domain/Sources/Domain/UseCase/UnblockUserUseCase.swift
@@ -1,0 +1,21 @@
+//
+//  UnblockUserUseCase.swift
+//
+//
+//  Created by Kihyun Lee on 1/3/24.
+//
+
+import Foundation
+import Core
+
+public struct UnblockUserUseCase {
+    private let blockingRepository: BlockingRepositoryProtocol
+    
+    public init(blockingRepository: BlockingRepositoryProtocol) {
+        self.blockingRepository = blockingRepository
+    }
+    
+    public func execute(userCode: String) async throws -> Bool {
+        return try await blockingRepository.unblockUser(userCode: userCode)
+    }
+}

--- a/iOS/moti/moti/Presentation/Sources/Presentation/BlockedUserList/BlockedUserListCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/BlockedUserList/BlockedUserListCoordinator.swift
@@ -28,7 +28,8 @@ final class BlockedUserListCoordinator: Coordinator {
     func start(group: Group) {
         let blockingRepository = BlockingRepository(groupId: group.id)
         let blockedUserListVM = BlockedUserListViewModel(
-            fetchBlockedUserListUseCase: .init(blockingRepository: blockingRepository)
+            fetchBlockedUserListUseCase: .init(blockingRepository: blockingRepository),
+            unblockUserUseCase: .init(blockingRepository: blockingRepository)
         )
         let blockedUserListVC = BlockedUserListViewController(viewModel: blockedUserListVM)
         blockedUserListVC.coordinator = self

--- a/iOS/moti/moti/Presentation/Sources/Presentation/BlockedUserList/BlockedUserListCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/BlockedUserList/BlockedUserListCoordinator.swift
@@ -11,7 +11,7 @@ import Domain
 import Data
 
 protocol BlockedUserListCoordinatorDelegate: AnyObject {
-    func unblockUserIsSuccess()
+    func unblockedUser()
 }
 
 final class BlockedUserListCoordinator: Coordinator {

--- a/iOS/moti/moti/Presentation/Sources/Presentation/BlockedUserList/BlockedUserListCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/BlockedUserList/BlockedUserListCoordinator.swift
@@ -18,7 +18,7 @@ final class BlockedUserListCoordinator: Coordinator {
     var parentCoordinator: Coordinator?
     var childCoordinators: [Coordinator] = []
     var navigationController: UINavigationController
-    var delegate: BlockedUserListCoordinatorDelegate?
+    weak var delegate: BlockedUserListCoordinatorDelegate?
     
     init(
         _ navigationController: UINavigationController,

--- a/iOS/moti/moti/Presentation/Sources/Presentation/BlockedUserList/BlockedUserListCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/BlockedUserList/BlockedUserListCoordinator.swift
@@ -10,10 +10,15 @@ import Core
 import Domain
 import Data
 
+protocol BlockedUserListCoordinatorDelegate: AnyObject {
+    func unblockUserIsSuccess()
+}
+
 final class BlockedUserListCoordinator: Coordinator {
     var parentCoordinator: Coordinator?
     var childCoordinators: [Coordinator] = []
     var navigationController: UINavigationController
+    var delegate: BlockedUserListCoordinatorDelegate?
     
     init(
         _ navigationController: UINavigationController,

--- a/iOS/moti/moti/Presentation/Sources/Presentation/BlockedUserList/BlockedUserListViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/BlockedUserList/BlockedUserListViewController.swift
@@ -62,6 +62,7 @@ final class BlockedUserListViewController: BaseViewController<BlockedUserListVie
                     showLoadingIndicator()
                 case .success:
                     hideLoadingIndicator()
+                    coordinator?.delegate?.unblockUserIsSuccess()
                 case .failed:
                     hideLoadingIndicator()
                     showErrorAlert(message: "사용자 차단 해제에 실패했습니다.")

--- a/iOS/moti/moti/Presentation/Sources/Presentation/BlockedUserList/BlockedUserListViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/BlockedUserList/BlockedUserListViewController.swift
@@ -52,6 +52,22 @@ final class BlockedUserListViewController: BaseViewController<BlockedUserListVie
                 }
             }
             .store(in: &cancellables)
+        
+        viewModel.unblockUserState
+            .receive(on: RunLoop.main)
+            .sink { [weak self] state in
+                guard let self else { return }
+                switch state {
+                case .loading:
+                    showLoadingIndicator()
+                case .success:
+                    hideLoadingIndicator()
+                case .failed:
+                    hideLoadingIndicator()
+                    showErrorAlert(message: "사용자 차단 해제에 실패했습니다.")
+                }
+            }
+            .store(in: &cancellables)
     }
     
     private func setupBlockedUserListDataSource() {
@@ -80,8 +96,9 @@ extension BlockedUserListViewController: UICollectionViewDelegate {
 }
 
 extension BlockedUserListViewController: BlockedUserListCollectionViewCellDelegate {
-    func unblockButtonDidClicked() {
-        Logger.debug("차단 해제 버튼 눌림!")
-        // viewModel.action(.unblock)
+    func unblockButtonDidClicked(userCode: String) {
+        showTwoButtonAlert(title: "정말 차단 해제하시겠습니까?", okTitle: "차단 해제", okAction: {
+            self.viewModel.action(.unblockUser(userCode: userCode))
+        })
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/BlockedUserList/BlockedUserListViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/BlockedUserList/BlockedUserListViewController.swift
@@ -97,9 +97,10 @@ extension BlockedUserListViewController: UICollectionViewDelegate {
 }
 
 extension BlockedUserListViewController: BlockedUserListCollectionViewCellDelegate {
-    func unblockButtonDidClicked(userCode: String) {
+    func unblockButtonDidClicked(cell: UICollectionViewCell) {
+        guard let indexPathOfClickedCell = layoutView.blockedUserListCollectionView.indexPath(for: cell) else { return }
         showTwoButtonAlert(title: "정말 차단 해제하시겠습니까?", okTitle: "차단 해제", okAction: {
-            self.viewModel.action(.unblockUser(userCode: userCode))
+            self.viewModel.action(.unblockUser(indexPath: indexPathOfClickedCell))
         })
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/BlockedUserList/BlockedUserListViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/BlockedUserList/BlockedUserListViewController.swift
@@ -62,7 +62,7 @@ final class BlockedUserListViewController: BaseViewController<BlockedUserListVie
                     showLoadingIndicator()
                 case .success:
                     hideLoadingIndicator()
-                    coordinator?.delegate?.unblockUserIsSuccess()
+                    coordinator?.delegate?.unblockedUser()
                 case .failed:
                     hideLoadingIndicator()
                     showErrorAlert(message: "사용자 차단 해제에 실패했습니다.")

--- a/iOS/moti/moti/Presentation/Sources/Presentation/BlockedUserList/BlockedUserListViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/BlockedUserList/BlockedUserListViewModel.swift
@@ -71,7 +71,7 @@ final class BlockedUserListViewModel {
             do {
                 fetchBlockedUserListState.send(.loading)
                 let blockedUsers = try await fetchBlockedUserListUseCase.execute()
-                self.blockedUsers = blockedUsers
+                self.blockedUsers = blockedUsers.sorted { $0.blockedDate ?? .now > $1.blockedDate ?? .now }
                 fetchBlockedUserListState.send(.success)
             } catch {
                 Logger.debug("blocked users fetch error: \(error)")

--- a/iOS/moti/moti/Presentation/Sources/Presentation/BlockedUserList/BlockedUserListViewModel.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/BlockedUserList/BlockedUserListViewModel.swift
@@ -13,7 +13,7 @@ import Combine
 final class BlockedUserListViewModel {
     enum BlockedUserListViewModelAction {
         case fetchBlockedUserList
-        case unblockUser(userCode: String)
+        case unblockUser(indexPath: IndexPath)
     }
     
     enum FetchBlockedUserListState {
@@ -61,8 +61,8 @@ final class BlockedUserListViewModel {
         switch action {
         case .fetchBlockedUserList:
             fetchBlockedUserList()
-        case .unblockUser(let userCode):
-            unblockUser(userCode: userCode)
+        case .unblockUser(let indexPath):
+            unblockUser(indexPath: indexPath)
         }
     }
     
@@ -80,14 +80,15 @@ final class BlockedUserListViewModel {
         }
     }
     
-    private func unblockUser(userCode: String) {
+    private func unblockUser(indexPath: IndexPath) {
+        let willUnblockedUser = blockedUsers[indexPath.row]
         Task {
             do {
                 unblockUserState.send(.loading)
-                let isSuccess = try await unblockUserUseCase.execute(userCode: userCode)
+                let isSuccess = try await unblockUserUseCase.execute(userCode: willUnblockedUser.code)
                 if isSuccess {
                     unblockUserState.send(.success)
-                    deleteOfDataSource(userCode: userCode)
+                    deleteOfDataSource(user: willUnblockedUser)
                 } else {
                     unblockUserState.send(.failed(message: "사용자 차단 해제에 실패했습니다."))
                 }
@@ -98,7 +99,7 @@ final class BlockedUserListViewModel {
         }
     }
     
-    func deleteOfDataSource(userCode: String) {
-        blockedUsers = blockedUsers.filter { $0.code != userCode }
+    func deleteOfDataSource(user: User) {
+        blockedUsers = blockedUsers.filter { $0 != user }
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/BlockedUserList/Cell/BlockedUserListCollectionViewCell.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/BlockedUserList/Cell/BlockedUserListCollectionViewCell.swift
@@ -11,7 +11,7 @@ import Jeongfisher
 import Design
 
 protocol BlockedUserListCollectionViewCellDelegate: AnyObject {
-    func unblockButtonDidClicked()
+    func unblockButtonDidClicked(userCode: String)
 }
 
 final class BlockedUserListCollectionViewCell: UICollectionViewCell {
@@ -19,6 +19,7 @@ final class BlockedUserListCollectionViewCell: UICollectionViewCell {
     // MARK: - Properties
     private let iconSize: CGFloat = 60
     weak var delegate: BlockedUserListCollectionViewCellDelegate?
+    private var user: User?
     
     // MARK: - Views
     private lazy var iconImageView = {
@@ -73,12 +74,19 @@ final class BlockedUserListCollectionViewCell: UICollectionViewCell {
     
     // MARK: - Methods
     func configure(with user: User) {
+        self.user = user
         if let url = user.avatarURL {
             iconImageView.jk.setImage(with: url, downsamplingScale: 1.5)
         }
         userCodeLabel.text = "@" + user.code
         guard let blockedDate = user.blockedDate else { return }
         blockedDateLabel.text = blockedDate.convertStringYYYY년_MM월_dd일() + " 차단"
+        unblockButton.addTarget(self, action: #selector(unblockButtonDidClicked), for: .touchUpInside)
+    }
+    
+    @objc private func unblockButtonDidClicked() {
+        guard let user else { return }
+        delegate?.unblockButtonDidClicked(userCode: user.code)
     }
     
     func cancelDownloadImage() {

--- a/iOS/moti/moti/Presentation/Sources/Presentation/BlockedUserList/Cell/BlockedUserListCollectionViewCell.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/BlockedUserList/Cell/BlockedUserListCollectionViewCell.swift
@@ -11,7 +11,7 @@ import Jeongfisher
 import Design
 
 protocol BlockedUserListCollectionViewCellDelegate: AnyObject {
-    func unblockButtonDidClicked(userCode: String)
+    func unblockButtonDidClicked(cell: UICollectionViewCell)
 }
 
 final class BlockedUserListCollectionViewCell: UICollectionViewCell {
@@ -19,7 +19,6 @@ final class BlockedUserListCollectionViewCell: UICollectionViewCell {
     // MARK: - Properties
     private let iconSize: CGFloat = 60
     weak var delegate: BlockedUserListCollectionViewCellDelegate?
-    private var user: User?
     
     // MARK: - Views
     private lazy var iconImageView = {
@@ -75,7 +74,6 @@ final class BlockedUserListCollectionViewCell: UICollectionViewCell {
     
     // MARK: - Methods
     func configure(with user: User) {
-        self.user = user
         if let url = user.avatarURL {
             iconImageView.jk.setImage(with: url, downsamplingScale: 1.5)
         }
@@ -85,8 +83,7 @@ final class BlockedUserListCollectionViewCell: UICollectionViewCell {
     }
     
     @objc private func unblockButtonDidClicked() {
-        guard let user else { return }
-        delegate?.unblockButtonDidClicked(userCode: user.code)
+        delegate?.unblockButtonDidClicked(cell: self)
     }
     
     func cancelDownloadImage() {

--- a/iOS/moti/moti/Presentation/Sources/Presentation/BlockedUserList/Cell/BlockedUserListCollectionViewCell.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/BlockedUserList/Cell/BlockedUserListCollectionViewCell.swift
@@ -54,10 +54,11 @@ final class BlockedUserListCollectionViewCell: UICollectionViewCell {
         return label
     }()
     
-    private var unblockButton = {
+    private lazy var unblockButton = {
         let button = UIButton(type: .system)
         button.setTitle("차단 해제", for: .normal)
         button.setTitleColor(.red, for: .normal)
+        button.addTarget(self, action: #selector(unblockButtonDidClicked), for: .touchUpInside)
         return button
     }()
     
@@ -81,7 +82,6 @@ final class BlockedUserListCollectionViewCell: UICollectionViewCell {
         userCodeLabel.text = "@" + user.code
         guard let blockedDate = user.blockedDate else { return }
         blockedDateLabel.text = blockedDate.convertStringYYYY년_MM월_dd일() + " 차단"
-        unblockButton.addTarget(self, action: #selector(unblockButtonDidClicked), for: .touchUpInside)
     }
     
     @objc private func unblockButtonDidClicked() {

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeCoordinator.swift
@@ -57,6 +57,7 @@ final class GroupHomeCoordinator: Coordinator {
     
     func moveToGroupInfoViewController(group: Group) {
         let groupInfoCoordinator = GroupInfoCoordinator(navigationController, self)
+        groupInfoCoordinator.delegate = self
         groupInfoCoordinator.start(group: group)
         childCoordinators.append(groupInfoCoordinator)
     }
@@ -125,5 +126,12 @@ extension GroupHomeCoordinator: CaptureCoordinatorDelegate { }
 extension GroupHomeCoordinator: ManageCategoryCoordinatorDelegate {
     func doneButtonDidClicked() {
         currentViewController?.fetchCategoryList()
+    }
+}
+
+// MARK: - GroupInfoCoordinatorDelegate
+extension GroupHomeCoordinator: GroupInfoCoordinatorDelegate {
+    func unblockUserIsSuccess() {
+        currentViewController?.refreshAchievementList()
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeViewController.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupHome/GroupHomeViewController.swift
@@ -84,7 +84,7 @@ final class GroupHomeViewController: BaseViewController<HomeView>, LoadingIndica
         present(textFieldAlertVC, animated: true)
     }
     
-    @objc private func refreshAchievementList() {
+    @objc func refreshAchievementList() {
         viewModel.action(.fetchCurrentCategoryInfo)
         viewModel.action(.refreshAchievementList)
     }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupInfo/GroupInfoCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupInfo/GroupInfoCoordinator.swift
@@ -10,10 +10,15 @@ import Core
 import Domain
 import Data
 
+protocol GroupInfoCoordinatorDelegate: AnyObject {
+    func unblockUserIsSuccess()
+}
+
 final class GroupInfoCoordinator: Coordinator {
     var parentCoordinator: Coordinator?
     var childCoordinators: [Coordinator] = []
     var navigationController: UINavigationController
+    var delegate: GroupInfoCoordinatorDelegate?
     
     init(
         _ navigationController: UINavigationController,
@@ -42,7 +47,14 @@ final class GroupInfoCoordinator: Coordinator {
     
     func moveToBlockedUserListViewController(group: Group) {
         let blockedUserListCoordinator = BlockedUserListCoordinator(navigationController, self)
+        blockedUserListCoordinator.delegate = self
         blockedUserListCoordinator.start(group: group)
         childCoordinators.append(blockedUserListCoordinator)
+    }
+}
+
+extension GroupInfoCoordinator: BlockedUserListCoordinatorDelegate {
+    func unblockUserIsSuccess() {
+        delegate?.unblockUserIsSuccess()
     }
 }

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupInfo/GroupInfoCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupInfo/GroupInfoCoordinator.swift
@@ -18,7 +18,7 @@ final class GroupInfoCoordinator: Coordinator {
     var parentCoordinator: Coordinator?
     var childCoordinators: [Coordinator] = []
     var navigationController: UINavigationController
-    var delegate: GroupInfoCoordinatorDelegate?
+    weak var delegate: GroupInfoCoordinatorDelegate?
     
     init(
         _ navigationController: UINavigationController,

--- a/iOS/moti/moti/Presentation/Sources/Presentation/GroupInfo/GroupInfoCoordinator.swift
+++ b/iOS/moti/moti/Presentation/Sources/Presentation/GroupInfo/GroupInfoCoordinator.swift
@@ -54,7 +54,7 @@ final class GroupInfoCoordinator: Coordinator {
 }
 
 extension GroupInfoCoordinator: BlockedUserListCoordinatorDelegate {
-    func unblockUserIsSuccess() {
+    func unblockedUser() {
         delegate?.unblockUserIsSuccess()
     }
 }


### PR DESCRIPTION
## PR 요약
- 차단했던 그룹원을 차단 해제한다.
- 차단 유저 목록에서 사용자가 제거되고
- 차단이 풀린 사용자의 게시물들을 다시 보여주기 위해 그룹 홈에서 refresh를 한다.

##### 스크린샷
<img width="33%" src="https://github.com/boostcampwm2023/iOS02-moti/assets/60506170/4aaafd0c-2546-418e-b06b-0911d789f769">

#### Linked Issue
close #609
