### PR TITLE
회원 탈퇴 및 그룹 탈퇴 로직 세부 추가 구현

### DIFF
--- a/BE/src/auth/application/auth.service.spec.ts
+++ b/BE/src/auth/application/auth.service.spec.ts
@@ -28,6 +28,7 @@ import { InvalidIdentifierException } from '../exception/invalid-identifier.exce
 import { RevokeRequestFailException } from '../exception/revoke-request-fail.exception';
 import { transactionTest } from '../../../test/common/transaction-test';
 import { DataSource } from 'typeorm';
+import { GroupModule } from '../../group/group/group.module';
 
 describe('AuthService', () => {
   let authService: AuthService;
@@ -44,6 +45,7 @@ describe('AuthService', () => {
       imports: [
         HttpModule,
         CacheModule.register(),
+        GroupModule,
         AuthTestModule,
         UsersTestModule,
         JwtModule.register({}),

--- a/BE/src/auth/application/auth.service.ts
+++ b/BE/src/auth/application/auth.service.ts
@@ -19,6 +19,7 @@ import { RevokeAppleAuthRequest } from '../dto/revoke-apple-auth-request.dto';
 import { RevokeAppleAuthResponse } from '../dto/revoke-apple-auth-response.dto';
 import { RevokeRequestFailException } from '../exception/revoke-request-fail.exception';
 import { InvalidIdentifierException } from '../exception/invalid-identifier.exception';
+import { GroupService } from '../../group/group/application/group.service';
 
 @Injectable()
 export class AuthService {
@@ -29,6 +30,7 @@ export class AuthService {
     private readonly userCodeGenerator: UserCodeGenerator,
     private readonly jwtUtils: JwtUtils,
     private readonly avatarHolder: AvatarHolder,
+    private readonly groupService: GroupService,
   ) {}
 
   @Transactional()
@@ -78,12 +80,16 @@ export class AuthService {
     return new RefreshAuthResponseDto(UserDto.from(user), accessToken);
   }
 
+  @Transactional()
   async revoke(user: User, revokeAuthRequest: RevokeAppleAuthRequest) {
     const requestUserIdentifier = await this.oauthHandler.getUserIdentifier(
       revokeAuthRequest.identityToken,
     );
     if (user.userIdentifier !== requestUserIdentifier)
       throw new InvalidIdentifierException();
+
+    // TODO : 그룹 탈퇴 로직을 서비스 하위 레이어로 분리해서 AuthService, GroupService 에서 해당 레이어를 참조하는 방식으로 추후에 개선 필요
+    await this.groupService.removeUserFromAllGroup(user);
 
     const authorizationCode = revokeAuthRequest.authorizationCode;
 

--- a/BE/src/auth/auth.module.ts
+++ b/BE/src/auth/auth.module.ts
@@ -17,6 +17,7 @@ import type { RedisClientOptions } from 'redis';
 import { AvatarHolder } from './application/avatar.holder';
 import { AdminTokenGuard } from './guard/admin-token.guard';
 import { AdminPageTokenGuard } from './guard/admin-page-token.guard';
+import { GroupModule } from '../group/group/group.module';
 
 @Global()
 @Module({
@@ -25,6 +26,7 @@ import { AdminPageTokenGuard } from './guard/admin-page-token.guard';
     JwtModule.register({}),
     CacheModule.registerAsync<RedisClientOptions>(redisModuleOptions),
     CustomTypeOrmModule.forCustomRepository([UserRepository]),
+    GroupModule,
     forwardRef(() => UsersModule),
   ],
   controllers: [AuthController],

--- a/BE/src/group/achievement/entities/group-achievement.entity.ts
+++ b/BE/src/group/achievement/entities/group-achievement.entity.ts
@@ -30,7 +30,7 @@ export class GroupAchievementEntity extends BaseTimeEntity {
   @JoinColumn({ name: 'group_id', referencedColumnName: 'id' })
   group: GroupEntity;
 
-  @ManyToOne(() => GroupCategoryEntity)
+  @ManyToOne(() => GroupCategoryEntity, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'group_category_id', referencedColumnName: 'id' })
   groupCategory: GroupCategoryEntity;
 

--- a/BE/src/group/category/entities/group-category.entity.ts
+++ b/BE/src/group/category/entities/group-category.entity.ts
@@ -22,7 +22,7 @@ export class GroupCategoryEntity extends BaseTimeEntity {
   @JoinColumn({ name: 'user_id', referencedColumnName: 'id' })
   user: UserEntity;
 
-  @ManyToOne(() => GroupEntity)
+  @ManyToOne(() => GroupEntity, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'group_id', referencedColumnName: 'id' })
   group: GroupEntity;
 

--- a/BE/src/group/group/application/group.service.spec.ts
+++ b/BE/src/group/group/application/group.service.spec.ts
@@ -204,22 +204,7 @@ describe('GroupSerivce Test', () => {
       expect(groupLeaveResponse.userId).toEqual(user2.id);
     });
   });
-  test('리더가 탈퇴 시도를 하는 경우에는 LeaderNotAllowedToLeaveException를 던진다.', async () => {
-    // given
-    await transactionTest(dataSource, async () => {
-      // given
-      const user1 = await usersFixture.getUser('ABC');
-      const user2 = await usersFixture.getUser('DEF');
-      const group = await groupFixture.createGroup('Test Group', user1);
-      await groupFixture.addMember(group, user2, UserGroupGrade.PARTICIPANT);
 
-      // when
-      // then
-      await expect(groupService.removeUser(user1, group.id)).rejects.toThrow(
-        LeaderNotAllowedToLeaveException,
-      );
-    });
-  });
   test('내가 속한 그룹이 아닌 그룹에 대한 탈퇴 시도에 대해서는 NoSuchUserGroupException 예외를 던진다.', async () => {
     // given
     await transactionTest(dataSource, async () => {

--- a/BE/src/group/group/application/group.service.spec.ts
+++ b/BE/src/group/group/application/group.service.spec.ts
@@ -618,4 +618,19 @@ describe('GroupSerivce Test', () => {
       expect(newLeader.grade).toEqual(UserGroupGrade.LEADER);
     });
   });
+
+  test('마지막 멤버가 탈퇴하면 그룹은 삭제된다.', async () => {
+    await transactionTest(dataSource, async () => {
+      // given
+      const user = await usersFixture.getUser('ABC');
+      const group = await groupFixture.createGroup('Test Group', user);
+
+      // when
+      await groupService.removeUser(user, group.id);
+
+      // then
+      const expected = await groupRepository.findById(group.id);
+      expect(expected).toBeUndefined();
+    });
+  });
 });

--- a/BE/src/group/group/application/group.service.spec.ts
+++ b/BE/src/group/group/application/group.service.spec.ts
@@ -596,4 +596,41 @@ describe('GroupSerivce Test', () => {
       });
     });
   });
+
+  test('리더가 탈퇴하면 남아있는 멤버중 가입일이 가장 오래된 멤버가 리더가 된다.', async () => {
+    await transactionTest(dataSource, async () => {
+      // given
+      const leader = await usersFixture.getUser('ABC');
+      const group = await groupFixture.createGroup('Test Group', leader);
+      const firstMember = await usersFixture.getUser('DEF');
+      const secondMember = await usersFixture.getUser('EFG');
+      const thirdMember = await usersFixture.getUser('FGH');
+      await groupFixture.addMember(
+        group,
+        firstMember,
+        UserGroupGrade.PARTICIPANT,
+      );
+      await groupFixture.addMember(
+        group,
+        secondMember,
+        UserGroupGrade.PARTICIPANT,
+      );
+      await groupFixture.addMember(
+        group,
+        thirdMember,
+        UserGroupGrade.PARTICIPANT,
+      );
+
+      // when
+      await groupService.removeUser(leader, group.id);
+
+      // then
+      const newLeader = await userGroupRepository.findOneByUserIdAndGroupId(
+        firstMember.id,
+        group.id,
+      );
+
+      expect(newLeader.grade).toEqual(UserGroupGrade.LEADER);
+    });
+  });
 });

--- a/BE/src/group/group/application/group.service.ts
+++ b/BE/src/group/group/application/group.service.ts
@@ -9,7 +9,6 @@ import { GroupListResponse } from '../dto/group-list-response';
 import { GroupAvatarHolder } from './group-avatar.holder';
 import { UserGroupRepository } from '../entities/user-group.repository';
 import { GroupLeaveResponse } from '../dto/group-leave-response.dto';
-import { LeaderNotAllowedToLeaveException } from '../exception/leader-not-allowed-to-leave.exception';
 import { NoSuchUserGroupException } from '../exception/no-such-user-group.exception';
 import { InviteGroupRequest } from '../dto/invite-group-request.dto';
 import { UserRepository } from '../../../users/entities/user.repository';
@@ -61,8 +60,9 @@ export class GroupService {
   @Transactional()
   async removeUser(user: User, groupId: number) {
     const userGroup = await this.getUserGroup(user.id, groupId);
-    if (userGroup.grade === UserGroupGrade.LEADER)
-      throw new LeaderNotAllowedToLeaveException();
+    if (userGroup.grade === UserGroupGrade.LEADER) {
+      await this.assignNextLeader(groupId, user.id);
+    }
     user.leaveGroup();
 
     await this.userRepository.updateUser(user);
@@ -189,5 +189,21 @@ export class GroupService {
       userGroup.grade !== UserGroupGrade.MANAGER
     )
       throw new InvitePermissionDeniedException();
+  }
+
+  private async assignNextLeader(groupId: number, userId: number) {
+    const members =
+      await this.userGroupRepository.findAllByGroupIdAndUserIdNotOrderByCreatedAtAsc(
+        groupId,
+        userId,
+      );
+    if (members) {
+      const nextLeader = members[0];
+      nextLeader.grade = UserGroupGrade.LEADER;
+      await this.userGroupRepository.repository.update(
+        nextLeader.id,
+        nextLeader,
+      );
+    }
   }
 }

--- a/BE/src/group/group/application/group.service.ts
+++ b/BE/src/group/group/application/group.service.ts
@@ -77,6 +77,14 @@ export class GroupService {
   }
 
   @Transactional()
+  async removeUserFromAllGroup(user: User) {
+    const userGroups = await this.userGroupRepository.findAllByUserId(user.id);
+    for (const userGroup of userGroups) {
+      await this.removeUser(user, userGroup.group.id);
+    }
+  }
+
+  @Transactional()
   async invite(
     user: User,
     groupId: number,

--- a/BE/src/group/group/entities/group.entity.ts
+++ b/BE/src/group/group/entities/group.entity.ts
@@ -33,6 +33,7 @@ export class GroupEntity extends BaseTimeEntity {
   @OneToMany(
     () => GroupAchievementEntity,
     (groupAchievement) => groupAchievement.group,
+    { cascade: true },
   )
   achievements: GroupAchievementEntity[];
 

--- a/BE/src/group/group/entities/user-group.entity.ts
+++ b/BE/src/group/group/entities/user-group.entity.ts
@@ -21,7 +21,7 @@ export class UserGroupEntity extends BaseTimeEntity {
   @JoinColumn({ name: 'user_id', referencedColumnName: 'id' })
   user: UserEntity;
 
-  @ManyToOne(() => GroupEntity)
+  @ManyToOne(() => GroupEntity, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'group_id', referencedColumnName: 'id' })
   group: GroupEntity;
 

--- a/BE/src/group/group/entities/user-group.repository.spec.ts
+++ b/BE/src/group/group/entities/user-group.repository.spec.ts
@@ -186,4 +186,21 @@ describe('UserGroupRepository Test', () => {
       expect(rest).toEqual(3);
     });
   });
+
+  test('유저가 속한 모든 그룹에 대해 조회할 수 있다.', async () => {
+    await transactionTest(dataSource, async () => {
+      // given
+      const user = await usersFixture.getUser('ABC');
+      await groupFixture.createGroup('Test Group1', user);
+      await groupFixture.createGroup('Test Group2', user);
+      await groupFixture.createGroup('Test Group3', user);
+      await groupFixture.createGroup('Test Group4', user);
+
+      // when
+      const userGroups = await userGroupRepository.findAllByUserId(user.id);
+
+      // then
+      expect(userGroups.length).toEqual(4);
+    });
+  });
 });

--- a/BE/src/group/group/entities/user-group.repository.spec.ts
+++ b/BE/src/group/group/entities/user-group.repository.spec.ts
@@ -163,4 +163,27 @@ describe('UserGroupRepository Test', () => {
       expect(userGroups[2].user.id).toEqual(user3.id);
     });
   });
+
+  test('특정 유저를 제외한 멤버수를 조회할 수 있다.', async () => {
+    await transactionTest(dataSource, async () => {
+      // given
+      const leader = await usersFixture.getUser('ABC');
+      const group = await groupFixture.createGroup('Test Group', leader);
+      const user1 = await usersFixture.getUser('DEF');
+      const user2 = await usersFixture.getUser('EFG');
+      const user3 = await usersFixture.getUser('FGH');
+      await groupFixture.addMember(group, user1, UserGroupGrade.PARTICIPANT);
+      await groupFixture.addMember(group, user2, UserGroupGrade.PARTICIPANT);
+      await groupFixture.addMember(group, user3, UserGroupGrade.PARTICIPANT);
+
+      // when
+      const rest = await userGroupRepository.findCountByGroupIdAndUserIdNot(
+        group.id,
+        leader.id,
+      );
+
+      // then
+      expect(rest).toEqual(3);
+    });
+  });
 });

--- a/BE/src/group/group/entities/user-group.repository.spec.ts
+++ b/BE/src/group/group/entities/user-group.repository.spec.ts
@@ -136,4 +136,31 @@ describe('UserGroupRepository Test', () => {
       expect(userGroup.group.id).toEqual(group.id);
     });
   });
+
+  test('특정 유저를 제외하고 가입일이 가장 오래된 유저를 조회할 수 있다.', async () => {
+    await transactionTest(dataSource, async () => {
+      // given
+      const leader = await usersFixture.getUser('ABC');
+      const group = await groupFixture.createGroup('Test Group', leader);
+      const user1 = await usersFixture.getUser('DEF');
+      const user2 = await usersFixture.getUser('EFG');
+      const user3 = await usersFixture.getUser('FGH');
+      await groupFixture.addMember(group, user1, UserGroupGrade.PARTICIPANT);
+      await groupFixture.addMember(group, user2, UserGroupGrade.PARTICIPANT);
+      await groupFixture.addMember(group, user3, UserGroupGrade.PARTICIPANT);
+
+      // when
+      const userGroups =
+        await userGroupRepository.findAllByGroupIdAndUserIdNotOrderByCreatedAtAsc(
+          group.id,
+          leader.id,
+        );
+
+      // then
+      expect(userGroups.length).toEqual(3);
+      expect(userGroups[0].user.id).toEqual(user1.id);
+      expect(userGroups[1].user.id).toEqual(user2.id);
+      expect(userGroups[2].user.id).toEqual(user3.id);
+    });
+  });
 });

--- a/BE/src/group/group/entities/user-group.repository.ts
+++ b/BE/src/group/group/entities/user-group.repository.ts
@@ -2,6 +2,7 @@ import { TransactionalRepository } from '../../../config/transaction-manager/tra
 import { CustomRepository } from '../../../config/typeorm/custom-repository.decorator';
 import { UserGroupEntity } from './user-group.entity';
 import { UserGroup } from '../domain/user-group.doamin';
+import { Not } from 'typeorm';
 
 @CustomRepository(UserGroupEntity)
 export class UserGroupRepository extends TransactionalRepository<UserGroupEntity> {
@@ -61,5 +62,21 @@ export class UserGroupRepository extends TransactionalRepository<UserGroupEntity
       .getMany();
 
     return userGroups.map((g) => g.toModel());
+  }
+
+  async findAllByGroupIdAndUserIdNotOrderByCreatedAtAsc(
+    groupId: number,
+    userId: number,
+  ) {
+    const userGroupEntities = await this.repository
+      .createQueryBuilder('ug')
+      .leftJoin('ug.user', 'user')
+      .addSelect('user.id')
+      .where('ug.group_id = :groupId', { groupId })
+      .andWhere('ug.user_id != :userId', { userId })
+      .orderBy('ug.createdAt', 'ASC')
+      .getMany();
+
+    return userGroupEntities.map((ug) => ug.toModel());
   }
 }

--- a/BE/src/group/group/entities/user-group.repository.ts
+++ b/BE/src/group/group/entities/user-group.repository.ts
@@ -79,4 +79,11 @@ export class UserGroupRepository extends TransactionalRepository<UserGroupEntity
 
     return userGroupEntities.map((ug) => ug.toModel());
   }
+  async findCountByGroupIdAndUserIdNot(groupId: number, userId: number) {
+    return await this.repository
+      .createQueryBuilder('ug')
+      .where('ug.group_id = :groupId', { groupId })
+      .andWhere('ug.user_id != :userId', { userId })
+      .getCount();
+  }
 }

--- a/BE/src/group/group/entities/user-group.repository.ts
+++ b/BE/src/group/group/entities/user-group.repository.ts
@@ -86,4 +86,17 @@ export class UserGroupRepository extends TransactionalRepository<UserGroupEntity
       .andWhere('ug.user_id != :userId', { userId })
       .getCount();
   }
+
+  async findAllByUserId(userId: number): Promise<UserGroup[]> {
+    const userGroups = await this.repository
+      .createQueryBuilder('ug')
+      .leftJoin('ug.user', 'user')
+      .leftJoin('ug.group', 'group')
+      .addSelect(['user.id', 'group.id'])
+      .where('ug.user_id = :userId', { userId })
+      .andWhere('ug.group_id IS NOT NULL')
+      .orderBy('ug.createdAt', 'ASC')
+      .getMany();
+    return userGroups.map((ug) => ug.toModel());
+  }
 }

--- a/BE/src/group/group/group.module.ts
+++ b/BE/src/group/group/group.module.ts
@@ -18,5 +18,6 @@ import { GroupCodeGenerator } from './application/group-code-generator';
   ],
   controllers: [GroupController],
   providers: [GroupService, GroupAvatarHolder, GroupCodeGenerator],
+  exports: [GroupService],
 })
 export class GroupModule {}


### PR DESCRIPTION
## PR 요약
- 리더가 그룹을 탈퇴하면, 그룹 내에서 가장 가입일이 오래된 유저가 리더가 된다.
- 마지막 멤버가 그룹을 탈퇴하면, 그룹은 삭제된다.
- 회원 탈퇴 시, 회원이 속한 모든 그룹에 대해 위의 그룹 탈퇴 로직을 실행한다.
#### 변경 사항
- 리더가 그룹 탈퇴 시 발생했던 오류 제거
 
#### Linked Issue
close #585 
